### PR TITLE
dodat permission middleware

### DIFF
--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -22,6 +22,9 @@ func SetupApi(router *gin.Engine, server *Server) {
 	router.GET("/healthz", server.Healthz)
 	router.Use(CORSMiddleware())
 	api := router.Group("/api")
+
+	secured := PermissionMiddleware(server.UserClient)
+
 	{
 		api.POST("/login", server.Login)
 		api.POST("/logout", AuthenticatedMiddleware(server.UserClient), server.Logout)
@@ -97,7 +100,7 @@ func SetupApi(router *gin.Engine, server *Server) {
 	{
 		loanRequests.POST("", server.CreateLoanRequest)
 		loanRequests.GET("", server.GetLoanRequests)
-		loanRequests.PATCH("/:id/approve", server.ApproveLoanRequest)
+		loanRequests.PATCH("/:id/approve", AuthenticatedMiddleware(server.UserClient), secured("manage_contracts"), server.ApproveLoanRequest)
 		loanRequests.PATCH("/:id/reject", server.RejectLoanRequest)
 	}
 

--- a/internal/gateway/middleware.go
+++ b/internal/gateway/middleware.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,5 +90,30 @@ func TOTPMiddleware(totp userpb.TOTPServiceClient) gin.HandlerFunc {
 			return
 		}
 		c.Next()
+	}
+}
+
+func PermissionMiddleware(user userpb.UserServiceClient) func(...string) gin.HandlerFunc {
+	return func(permissions ...string) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			email, exists := c.Get("email")
+			if !exists {
+				c.AbortWithStatus(401)
+				return
+			}
+
+			emp, err := user.GetEmployeeByEmail(c, &userpb.GetEmployeeByEmailRequest{
+				Email: email.(string),
+			})
+			if err != nil {
+				c.AbortWithStatus(403)
+			}
+			for _, perm := range permissions {
+				if !slices.Contains(emp.Permissions, perm) {
+					c.AbortWithStatus(403)
+				}
+			}
+			c.Next()
+		}
 	}
 }


### PR DESCRIPTION
closes #116 

Dodat middleware za permisije. Potreban je auth middleware pre njega. Vraca 403 ako korisnik nema sve permisije koje mu se proslede. Secured instanca je dodata u handlers i ona ima curryed userService u sebi. Proslediti sve permisije kao zasebne stringove u secured jer je variadicna funckija.

Primer
```
loanRequests.PATCH("/:id/approve", AuthenticatedMiddleware(server.UserClient), secured("manage_contracts", "manage_insurance"), server.ApproveLoanRequest)
```