### PR TITLE
Bug transfer status

### DIFF
--- a/internal/bank/models.go
+++ b/internal/bank/models.go
@@ -17,6 +17,7 @@ type (
 	installment_status  string
 	employment_status   string
 	card_brand          string
+	Transfer_status     string
 
 	// Note, unlike type aliease these are all destinct types, only
 	// their underlying type is string.
@@ -81,6 +82,10 @@ const (
 	mastercard card_brand = "mastercard"
 	amex       card_brand = "amex"
 	dinacard   card_brand = "dinacard"
+
+	pending  Transfer_status = "pending"
+	realized Transfer_status = "realized"
+	rejected Transfer_status = "rejected"
 )
 
 type (
@@ -191,16 +196,16 @@ type (
 	}
 
 	Transfer struct {
-		Transaction_id    int64     `gorm:"column:transaction_id;type:bigserial;not null;primaryKey"`
-		From_account      string    `gorm:"column:from_account;type:varchar(20);references accounts(number)"`
-		To_account        string    `gorm:"column:to_account;type:varchar(20);references accounts(number)"`
-		Start_amount      int64     `gorm:"column:start_amount;type:bigint;not null"`
-		End_amount        int64     `gorm:"column:end_amount;type:bigint;not null"`
-		Start_currency_id int64     `gorm:"column:start_currency_id;type:bigint;references currencies(id)"`
-		Exchange_rate     float64   `gorm:"column:exchange_rate;type:decimal(20,2)"`
-		Commission        int64     `gorm:"column:commission;type:bigint;not null"`
-		Timestamp         time.Time `gorm:"column:timestamp;not null;autoCreateTime"`
-		Status            string    `gorm:"column:status;type:varchar(20);not null"`
+		Transaction_id    int64           `gorm:"column:transaction_id;type:bigserial;not null;primaryKey"`
+		From_account      string          `gorm:"column:from_account;type:varchar(20);references accounts(number)"`
+		To_account        string          `gorm:"column:to_account;type:varchar(20);references accounts(number)"`
+		Start_amount      int64           `gorm:"column:start_amount;type:bigint;not null"`
+		End_amount        int64           `gorm:"column:end_amount;type:bigint;not null"`
+		Start_currency_id int64           `gorm:"column:start_currency_id;type:bigint;references currencies(id)"`
+		Exchange_rate     float64         `gorm:"column:exchange_rate;type:decimal(20,2)"`
+		Commission        int64           `gorm:"column:commission;type:bigint;not null"`
+		Timestamp         time.Time       `gorm:"column:timestamp;not null;autoCreateTime"`
+		Status            Transfer_status `gorm:"column:status;type:varchar(20);not null"`
 	}
 
 	PaymentCode struct {

--- a/internal/bank/repository.go
+++ b/internal/bank/repository.go
@@ -1162,12 +1162,12 @@ func (s *Server) CreateTransfer(fromAccount, toAccount string, amount int64) (*T
         from_account, to_account, start_amount, end_amount,
         start_currency_id, exchange_rate, commission, status
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
     RETURNING transaction_id, from_account, to_account,
               start_amount, end_amount,
               start_currency_id, exchange_rate,
               commission, status, timestamp
-`, fromAccount, toAccount, amount, finalAmount, currency.Id, exchangeRate, commission)
+`, fromAccount, toAccount, amount, finalAmount, currency.Id, exchangeRate, commission, pending)
 
 	transfer, err := scanTransfer(row)
 	if err != nil {
@@ -1251,7 +1251,7 @@ func (s *Server) ConfirmTransfer(transferID int64, verificationCode string) erro
 		}
 	}
 
-	_, err = tx.Exec(`UPDATE transfers SET status = 'realized' WHERE transaction_id = $1`, t.Transaction_id)
+	_, err = tx.Exec(`UPDATE transfers SET status = $1 WHERE transaction_id = $2`, realized, t.Transaction_id)
 	if err != nil {
 		return err
 	}
@@ -1303,7 +1303,7 @@ func (s *Server) GetTransferHistory(clientEmail string, page, pageSize int32) (*
 			PaymentCode:     "",
 			ReferenceNumber: "",
 			Purpose:         "",
-			Status:          t.Status,
+			Status:          string(t.Status),
 			Timestamp:       t.Timestamp.Format(time.RFC3339),
 		})
 	}

--- a/internal/bank/repository.go
+++ b/internal/bank/repository.go
@@ -1200,7 +1200,7 @@ func (s *Server) ConfirmTransfer(transferID int64, verificationCode string) erro
 		return err
 	}
 
-	if t.Status != "pending" {
+	if t.Status != pending {
 		return errors.New("transfer already processed")
 	}
 

--- a/internal/bank/server.go
+++ b/internal/bank/server.go
@@ -1530,7 +1530,7 @@ func (s *Server) TransferMoneyBetweenAccounts(
 		PaymentCode:     "",
 		ReferenceNumber: "",
 		Purpose:         req.Description,
-		Status:          "realized",
+		Status:          string(transfer.Status),
 		Timestamp:       fmt.Sprintf("%d", time.Now().Unix()),
 	}
 

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -182,6 +182,9 @@ CREATE TABLE IF NOT EXISTS payments (
     timestamp           TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 
+
+CREATE TYPE transfer_status AS ENUM ('pending', 'realized', 'rejected');
+
 CREATE TABLE IF NOT EXISTS transfers (
     transaction_id      BIGSERIAL       PRIMARY KEY,
     from_account        VARCHAR(20)     REFERENCES accounts(number),
@@ -191,7 +194,7 @@ CREATE TABLE IF NOT EXISTS transfers (
     start_currency_id   BIGINT          REFERENCES currencies(id) ON UPDATE CASCADE ON DELETE RESTRICT,
     exchange_rate       DECIMAL(20,2),
     commission          BIGINT          NOT NULL,
-    status              VARCHAR(20)     NOT NULL DEFAULT 'pending' CHECK  (status IN ('pending', 'completed', 'rejected')),
+    status              transfer_status  NOT NULL DEFAULT 'pending',
     timestamp           TIMESTAMP       NOT NULL DEFAULT NOW()
 );
 


### PR DESCRIPTION
Closes #155

Dodat enum za transfer_status u models.go i u schema.sql 

- Vrednosti: 'pending', 'realized', 'rejected'

**completed** je zamenjen sa **realized**, ovo je bio problem.