### PR TITLE
feat: add CreateOrder RPC to TradingService (#186)

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -60,7 +60,7 @@ func main() {
 	stopScheduler := bankService.StartScheduler()
 	defer stopScheduler()
 
-	tradingService := internalTrading.NewServer(gorm_db)
+	tradingService := internalTrading.NewServer(gorm_db, bankService)
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -381,6 +381,185 @@ func (x *ListListingsResponse) GetListings() []*Listing {
 	return nil
 }
 
+// Exactly one of listing_id / option_id / forex_pair_id must be set — that's
+// the instrument being traded. limit_price / stop_price are required only
+// for LIMIT / STOP / STOP_LIMIT; senders must leave them 0 otherwise.
+type CreateOrderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ListingId     int64                  `protobuf:"varint,1,opt,name=listing_id,json=listingId,proto3" json:"listing_id,omitempty"`
+	OptionId      int64                  `protobuf:"varint,2,opt,name=option_id,json=optionId,proto3" json:"option_id,omitempty"`
+	ForexPairId   int64                  `protobuf:"varint,3,opt,name=forex_pair_id,json=forexPairId,proto3" json:"forex_pair_id,omitempty"`
+	AccountNumber string                 `protobuf:"bytes,4,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
+	OrderType     string                 `protobuf:"bytes,5,opt,name=order_type,json=orderType,proto3" json:"order_type,omitempty"`
+	Direction     string                 `protobuf:"bytes,6,opt,name=direction,proto3" json:"direction,omitempty"`
+	Quantity      int64                  `protobuf:"varint,7,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	LimitPrice    int64                  `protobuf:"varint,8,opt,name=limit_price,json=limitPrice,proto3" json:"limit_price,omitempty"`
+	StopPrice     int64                  `protobuf:"varint,9,opt,name=stop_price,json=stopPrice,proto3" json:"stop_price,omitempty"`
+	AllOrNone     bool                   `protobuf:"varint,10,opt,name=all_or_none,json=allOrNone,proto3" json:"all_or_none,omitempty"`
+	Margin        bool                   `protobuf:"varint,11,opt,name=margin,proto3" json:"margin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateOrderRequest) Reset() {
+	*x = CreateOrderRequest{}
+	mi := &file_trading_trading_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateOrderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateOrderRequest) ProtoMessage() {}
+
+func (x *CreateOrderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateOrderRequest.ProtoReflect.Descriptor instead.
+func (*CreateOrderRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *CreateOrderRequest) GetListingId() int64 {
+	if x != nil {
+		return x.ListingId
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetOptionId() int64 {
+	if x != nil {
+		return x.OptionId
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetForexPairId() int64 {
+	if x != nil {
+		return x.ForexPairId
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetAccountNumber() string {
+	if x != nil {
+		return x.AccountNumber
+	}
+	return ""
+}
+
+func (x *CreateOrderRequest) GetOrderType() string {
+	if x != nil {
+		return x.OrderType
+	}
+	return ""
+}
+
+func (x *CreateOrderRequest) GetDirection() string {
+	if x != nil {
+		return x.Direction
+	}
+	return ""
+}
+
+func (x *CreateOrderRequest) GetQuantity() int64 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetLimitPrice() int64 {
+	if x != nil {
+		return x.LimitPrice
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetStopPrice() int64 {
+	if x != nil {
+		return x.StopPrice
+	}
+	return 0
+}
+
+func (x *CreateOrderRequest) GetAllOrNone() bool {
+	if x != nil {
+		return x.AllOrNone
+	}
+	return false
+}
+
+func (x *CreateOrderRequest) GetMargin() bool {
+	if x != nil {
+		return x.Margin
+	}
+	return false
+}
+
+type CreateOrderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrderId       int64                  `protobuf:"varint,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateOrderResponse) Reset() {
+	*x = CreateOrderResponse{}
+	mi := &file_trading_trading_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateOrderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateOrderResponse) ProtoMessage() {}
+
+func (x *CreateOrderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateOrderResponse.ProtoReflect.Descriptor instead.
+func (*CreateOrderResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CreateOrderResponse) GetOrderId() int64 {
+	if x != nil {
+		return x.OrderId
+	}
+	return 0
+}
+
+func (x *CreateOrderResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
@@ -410,10 +589,31 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x11last_refresh_unix\x18\b \x01(\x03R\x0flastRefreshUnix\"\x15\n" +
 	"\x13ListListingsRequest\"D\n" +
 	"\x14ListListingsResponse\x12,\n" +
-	"\blistings\x18\x01 \x03(\v2\x10.trading.ListingR\blistings2\xad\x01\n" +
+	"\blistings\x18\x01 \x03(\v2\x10.trading.ListingR\blistings\"\xec\x02\n" +
+	"\x12CreateOrderRequest\x12\x1d\n" +
+	"\n" +
+	"listing_id\x18\x01 \x01(\x03R\tlistingId\x12\x1b\n" +
+	"\toption_id\x18\x02 \x01(\x03R\boptionId\x12\"\n" +
+	"\rforex_pair_id\x18\x03 \x01(\x03R\vforexPairId\x12%\n" +
+	"\x0eaccount_number\x18\x04 \x01(\tR\raccountNumber\x12\x1d\n" +
+	"\n" +
+	"order_type\x18\x05 \x01(\tR\torderType\x12\x1c\n" +
+	"\tdirection\x18\x06 \x01(\tR\tdirection\x12\x1a\n" +
+	"\bquantity\x18\a \x01(\x03R\bquantity\x12\x1f\n" +
+	"\vlimit_price\x18\b \x01(\x03R\n" +
+	"limitPrice\x12\x1d\n" +
+	"\n" +
+	"stop_price\x18\t \x01(\x03R\tstopPrice\x12\x1e\n" +
+	"\vall_or_none\x18\n" +
+	" \x01(\bR\tallOrNone\x12\x16\n" +
+	"\x06margin\x18\v \x01(\bR\x06margin\"H\n" +
+	"\x13CreateOrderResponse\x12\x19\n" +
+	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status2\xf7\x01\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
-	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
+	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12H\n" +
+	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
 	file_trading_trading_proto_rawDescOnce sync.Once
@@ -427,7 +627,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),              // 0: trading.Exchange
 	(*ListExchangesRequest)(nil),  // 1: trading.ListExchangesRequest
@@ -435,16 +635,20 @@ var file_trading_trading_proto_goTypes = []any{
 	(*Listing)(nil),               // 3: trading.Listing
 	(*ListListingsRequest)(nil),   // 4: trading.ListListingsRequest
 	(*ListListingsResponse)(nil),  // 5: trading.ListListingsResponse
+	(*CreateOrderRequest)(nil),    // 6: trading.CreateOrderRequest
+	(*CreateOrderResponse)(nil),   // 7: trading.CreateOrderResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0, // 0: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
 	3, // 1: trading.ListListingsResponse.listings:type_name -> trading.Listing
 	1, // 2: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
 	4, // 3: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	2, // 4: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	5, // 5: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
+	6, // 4: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	2, // 5: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	5, // 6: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	7, // 7: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	5, // [5:8] is the sub-list for method output_type
+	2, // [2:5] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -461,7 +665,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -21,19 +21,16 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	TradingService_ListExchanges_FullMethodName = "/trading.TradingService/ListExchanges"
 	TradingService_ListListings_FullMethodName  = "/trading.TradingService/ListListings"
+	TradingService_CreateOrder_FullMethodName   = "/trading.TradingService/CreateOrder"
 )
 
 // TradingServiceClient is the client API for TradingService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
-//
-// Minimal surface for #183 — this service only exposes health-style RPCs
-// and a handful of reads so callers can verify the service is wired up.
-// Order placement, listing refresh from external APIs, and stock-price
-// queries are owned by follow-up issues (#184, #186, #189).
 type TradingServiceClient interface {
 	ListExchanges(ctx context.Context, in *ListExchangesRequest, opts ...grpc.CallOption) (*ListExchangesResponse, error)
 	ListListings(ctx context.Context, in *ListListingsRequest, opts ...grpc.CallOption) (*ListListingsResponse, error)
+	CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error)
 }
 
 type tradingServiceClient struct {
@@ -64,17 +61,23 @@ func (c *tradingServiceClient) ListListings(ctx context.Context, in *ListListing
 	return out, nil
 }
 
+func (c *tradingServiceClient) CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateOrderResponse)
+	err := c.cc.Invoke(ctx, TradingService_CreateOrder_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TradingServiceServer is the server API for TradingService service.
 // All implementations must embed UnimplementedTradingServiceServer
 // for forward compatibility.
-//
-// Minimal surface for #183 — this service only exposes health-style RPCs
-// and a handful of reads so callers can verify the service is wired up.
-// Order placement, listing refresh from external APIs, and stock-price
-// queries are owned by follow-up issues (#184, #186, #189).
 type TradingServiceServer interface {
 	ListExchanges(context.Context, *ListExchangesRequest) (*ListExchangesResponse, error)
 	ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error)
+	CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
 
@@ -90,6 +93,9 @@ func (UnimplementedTradingServiceServer) ListExchanges(context.Context, *ListExc
 }
 func (UnimplementedTradingServiceServer) ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListListings not implemented")
+}
+func (UnimplementedTradingServiceServer) CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateOrder not implemented")
 }
 func (UnimplementedTradingServiceServer) mustEmbedUnimplementedTradingServiceServer() {}
 func (UnimplementedTradingServiceServer) testEmbeddedByValue()                        {}
@@ -148,6 +154,24 @@ func _TradingService_ListListings_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_CreateOrder_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateOrderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).CreateOrder(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_CreateOrder_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).CreateOrder(ctx, req.(*CreateOrderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TradingService_ServiceDesc is the grpc.ServiceDesc for TradingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -162,6 +186,10 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListListings",
 			Handler:    _TradingService_ListListings_Handler,
+		},
+		{
+			MethodName: "CreateOrder",
+			Handler:    _TradingService_CreateOrder_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/bank/account.go
+++ b/internal/bank/account.go
@@ -26,6 +26,22 @@ type callerIdentity struct {
 	IsEmployee bool
 }
 
+// CallerIdentity is the exported form of callerIdentity, exposed for other
+// services running in the bank process (e.g. trading) that reuse the same
+// metadata-based auth scheme.
+type CallerIdentity = callerIdentity
+
+// ResolveCaller is exported for in-process callers that share bank's auth
+// scheme. See authorizeAccountAccess for the ownership-check counterpart.
+func (s *Server) ResolveCaller(ctx context.Context) (*CallerIdentity, error) {
+	return s.resolveCaller(ctx)
+}
+
+// AuthorizeAccountAccess is exported for in-process callers.
+func (s *Server) AuthorizeAccountAccess(ctx context.Context, acc *Account) error {
+	return s.authorizeAccountAccess(ctx, acc)
+}
+
 func (s *Server) ListAccounts(ctx context.Context, req *bankpb.ListAccountsRequest) (*bankpb.ListAccountsResponse, error) {
 	caller, err := s.resolveCaller(ctx)
 	if err != nil {

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -129,6 +129,11 @@ func SetupApi(router *gin.Engine, server *Server) {
 	{
 		exchange.POST("/convert", auth, secured("role:client"), server.ConvertMoney)
 	}
+
+	orders := api.Group("/orders", auth, secured("role:client|employee"))
+	{
+		orders.POST("", server.CreateOrder)
+	}
 }
 
 func (s *Server) Healthz(c *gin.Context) {

--- a/internal/gateway/orders.go
+++ b/internal/gateway/orders.go
@@ -1,0 +1,62 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/metadata"
+)
+
+type createOrderBody struct {
+	ListingID     int64  `json:"listing_id"`
+	OptionID      int64  `json:"option_id"`
+	ForexPairID   int64  `json:"forex_pair_id"`
+	AccountNumber string `json:"account_number" binding:"required"`
+	OrderType     string `json:"order_type" binding:"required"`
+	Direction     string `json:"direction" binding:"required"`
+	Quantity      int64  `json:"quantity" binding:"required"`
+	LimitPrice    int64  `json:"limit_price"`
+	StopPrice     int64  `json:"stop_price"`
+	AllOrNone     bool   `json:"all_or_none"`
+	Margin        bool   `json:"margin"`
+}
+
+func (s *Server) CreateOrder(c *gin.Context) {
+	var body createOrderBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.CreateOrder(ctx, &tradingpb.CreateOrderRequest{
+		ListingId:     body.ListingID,
+		OptionId:      body.OptionID,
+		ForexPairId:   body.ForexPairID,
+		AccountNumber: body.AccountNumber,
+		OrderType:     body.OrderType,
+		Direction:     body.Direction,
+		Quantity:      body.Quantity,
+		LimitPrice:    body.LimitPrice,
+		StopPrice:     body.StopPrice,
+		AllOrNone:     body.AllOrNone,
+		Margin:        body.Margin,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"order_id": resp.OrderId,
+		"status":   resp.Status,
+	})
+}

--- a/internal/trading/orders.go
+++ b/internal/trading/orders.go
@@ -1,0 +1,164 @@
+package trading
+
+import (
+	"errors"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+func parseOrderType(s string) (OrderType, error) {
+	switch s {
+	case "market":
+		return OrderMarket, nil
+	case "limit":
+		return OrderLimit, nil
+	case "stop":
+		return OrderStop, nil
+	case "stop_limit":
+		return OrderStopLimit, nil
+	}
+	return "", status.Errorf(codes.InvalidArgument, "invalid order_type %q", s)
+}
+
+func parseDirection(s string) (OrderDirection, error) {
+	switch s {
+	case "buy":
+		return DirectionBuy, nil
+	case "sell":
+		return DirectionSell, nil
+	}
+	return "", status.Errorf(codes.InvalidArgument, "invalid direction %q", s)
+}
+
+// validatePriceFields enforces that limit/stop prices are provided exactly
+// when the order type needs them. Market orders derive price from the book
+// at execution time (issue #189).
+func validatePriceFields(ot OrderType, limit, stop int64) error {
+	switch ot {
+	case OrderMarket:
+		if limit != 0 || stop != 0 {
+			return status.Error(codes.InvalidArgument, "market orders must not set limit_price or stop_price")
+		}
+	case OrderLimit:
+		if limit <= 0 {
+			return status.Error(codes.InvalidArgument, "limit orders require limit_price > 0")
+		}
+		if stop != 0 {
+			return status.Error(codes.InvalidArgument, "limit orders must not set stop_price")
+		}
+	case OrderStop:
+		if stop <= 0 {
+			return status.Error(codes.InvalidArgument, "stop orders require stop_price > 0")
+		}
+		if limit != 0 {
+			return status.Error(codes.InvalidArgument, "stop orders must not set limit_price")
+		}
+	case OrderStopLimit:
+		if limit <= 0 || stop <= 0 {
+			return status.Error(codes.InvalidArgument, "stop_limit orders require both limit_price and stop_price > 0")
+		}
+	}
+	return nil
+}
+
+// marketReferencePrice stores the user-provided price on the row so that
+// execution later (#189+) has a stable quote to compare against. Market
+// orders land with 0 — execution reads from the listing at fill time.
+func marketReferencePrice(ot OrderType, req *tradingpb.CreateOrderRequest) int64 {
+	switch ot {
+	case OrderLimit, OrderStopLimit:
+		return req.LimitPrice
+	case OrderStop:
+		return req.StopPrice
+	}
+	return 0
+}
+
+// resolveInstrumentCurrency returns the currency in which the instrument
+// trades, so it can be compared to the debit account's currency. Listings
+// inherit currency from their exchange; options inherit from their underlying
+// stock's exchange; forex pairs use the quote currency (that's what the user
+// pays out of).
+func (s *Server) resolveInstrumentCurrency(req *tradingpb.CreateOrderRequest) (string, error) {
+	set := 0
+	if req.ListingId != 0 {
+		set++
+	}
+	if req.OptionId != 0 {
+		set++
+	}
+	if req.ForexPairId != 0 {
+		set++
+	}
+	if set != 1 {
+		return "", status.Error(codes.InvalidArgument, "exactly one of listing_id, option_id, forex_pair_id must be set")
+	}
+
+	switch {
+	case req.ListingId != 0:
+		var listing Listing
+		if err := s.db.First(&listing, req.ListingId).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", status.Error(codes.NotFound, "listing not found")
+			}
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		var exch Exchange
+		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		return exch.Currency, nil
+
+	case req.OptionId != 0:
+		var opt Option
+		if err := s.db.First(&opt, req.OptionId).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", status.Error(codes.NotFound, "option not found")
+			}
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		var listing Listing
+		if err := s.db.Where("stock_id = ?", opt.StockID).First(&listing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", status.Error(codes.FailedPrecondition, "underlying stock has no listing")
+			}
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		var exch Exchange
+		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		return exch.Currency, nil
+
+	default: // forex pair
+		var fx ForexPair
+		if err := s.db.First(&fx, req.ForexPairId).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", status.Error(codes.NotFound, "forex pair not found")
+			}
+			return "", status.Errorf(codes.Internal, "%v", err)
+		}
+		return fx.QuoteCurrency, nil
+	}
+}
+
+// lookupEmployeeID resolves an employee email to its bank-side id. We query
+// the employees table directly since we already have a DB handle; going
+// through the user gRPC service would add a hop for data that lives here.
+func lookupEmployeeID(tx *gorm.DB, email string) (int64, error) {
+	var row struct{ ID int64 }
+	err := tx.Table("employees").
+		Select("id").
+		Where("email = ?", email).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, status.Error(codes.NotFound, "employee not found")
+		}
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return row.ID, nil
+}

--- a/internal/trading/orders_test.go
+++ b/internal/trading/orders_test.go
@@ -1,0 +1,141 @@
+package trading
+
+import (
+	"testing"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestParseOrderType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want OrderType
+		ok   bool
+	}{
+		{"market", OrderMarket, true},
+		{"limit", OrderLimit, true},
+		{"stop", OrderStop, true},
+		{"stop_limit", OrderStopLimit, true},
+		{"MARKET", "", false},
+		{"", "", false},
+		{"bogus", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseOrderType(c.in)
+			if c.ok {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != c.want {
+					t.Errorf("got %q, want %q", got, c.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error for %q", c.in)
+			}
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("code = %s, want InvalidArgument", status.Code(err))
+			}
+		})
+	}
+}
+
+func TestParseDirection(t *testing.T) {
+	cases := []struct {
+		in   string
+		want OrderDirection
+		ok   bool
+	}{
+		{"buy", DirectionBuy, true},
+		{"sell", DirectionSell, true},
+		{"BUY", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseDirection(c.in)
+			if c.ok {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != c.want {
+					t.Errorf("got %q, want %q", got, c.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error for %q", c.in)
+			}
+		})
+	}
+}
+
+func TestValidatePriceFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		ot      OrderType
+		limit   int64
+		stop    int64
+		wantErr bool
+	}{
+		{"market/empty", OrderMarket, 0, 0, false},
+		{"market/limit-set", OrderMarket, 100, 0, true},
+		{"market/stop-set", OrderMarket, 0, 100, true},
+
+		{"limit/limit-set", OrderLimit, 100, 0, false},
+		{"limit/missing", OrderLimit, 0, 0, true},
+		{"limit/negative", OrderLimit, -1, 0, true},
+		{"limit/stop-also-set", OrderLimit, 100, 50, true},
+
+		{"stop/stop-set", OrderStop, 0, 100, false},
+		{"stop/missing", OrderStop, 0, 0, true},
+		{"stop/limit-also-set", OrderStop, 50, 100, true},
+
+		{"stop_limit/both-set", OrderStopLimit, 100, 50, false},
+		{"stop_limit/only-limit", OrderStopLimit, 100, 0, true},
+		{"stop_limit/only-stop", OrderStopLimit, 0, 100, true},
+		{"stop_limit/neither", OrderStopLimit, 0, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validatePriceFields(c.ot, c.limit, c.stop)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Errorf("code = %s, want InvalidArgument", status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMarketReferencePrice(t *testing.T) {
+	cases := []struct {
+		name string
+		ot   OrderType
+		req  *tradingpb.CreateOrderRequest
+		want int64
+	}{
+		{"market", OrderMarket, &tradingpb.CreateOrderRequest{}, 0},
+		{"limit", OrderLimit, &tradingpb.CreateOrderRequest{LimitPrice: 150}, 150},
+		{"stop", OrderStop, &tradingpb.CreateOrderRequest{StopPrice: 120}, 120},
+		{"stop_limit", OrderStopLimit, &tradingpb.CreateOrderRequest{LimitPrice: 150, StopPrice: 120}, 150},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := marketReferencePrice(c.ot, c.req); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -2,8 +2,10 @@ package trading
 
 import (
 	"context"
+	"errors"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
@@ -11,11 +13,15 @@ import (
 
 type Server struct {
 	tradingpb.UnimplementedTradingServiceServer
-	db *gorm.DB
+	db   *gorm.DB
+	bank *bank.Server
 }
 
-func NewServer(db *gorm.DB) *Server {
-	return &Server{db: db}
+// NewServer wires trading to the bank server running in the same process —
+// trading reuses bank's auth (ResolveCaller) and account lookups since orders
+// always debit a bank account.
+func NewServer(db *gorm.DB, bankSrv *bank.Server) *Server {
+	return &Server{db: db, bank: bankSrv}
 }
 
 func (s *Server) ListExchanges(_ context.Context, _ *tradingpb.ListExchangesRequest) (*tradingpb.ListExchangesResponse, error) {
@@ -67,4 +73,107 @@ func (s *Server) ListListings(_ context.Context, _ *tradingpb.ListListingsReques
 		})
 	}
 	return &tradingpb.ListListingsResponse{Listings: out}, nil
+}
+
+func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequest) (*tradingpb.CreateOrderResponse, error) {
+	if req.Quantity <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "quantity must be positive")
+	}
+	if req.AccountNumber == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_number required")
+	}
+
+	orderType, err := parseOrderType(req.OrderType)
+	if err != nil {
+		return nil, err
+	}
+	direction, err := parseDirection(req.Direction)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePriceFields(orderType, req.LimitPrice, req.StopPrice); err != nil {
+		return nil, err
+	}
+
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	acc, err := s.bank.GetAccountByNumber(req.AccountNumber)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if err := s.bank.AuthorizeAccountAccess(ctx, acc); err != nil {
+		return nil, err
+	}
+
+	instrumentCurrency, err := s.resolveInstrumentCurrency(req)
+	if err != nil {
+		return nil, err
+	}
+	if acc.Currency != instrumentCurrency {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"account currency %s does not match instrument currency %s",
+			acc.Currency, instrumentCurrency)
+	}
+
+	pricePerUnit := marketReferencePrice(orderType, req)
+	order := Order{
+		OrderType:         orderType,
+		Direction:         direction,
+		Status:            StatusPending,
+		Quantity:          req.Quantity,
+		ContractSize:      1,
+		PricePerUnit:      pricePerUnit,
+		RemainingPortions: req.Quantity,
+		AllOrNone:         req.AllOrNone,
+		Margin:            req.Margin,
+	}
+	if req.ListingId != 0 {
+		v := req.ListingId
+		order.ListingID = &v
+	}
+	if req.OptionId != 0 {
+		v := req.OptionId
+		order.OptionID = &v
+	}
+	if req.ForexPairId != 0 {
+		v := req.ForexPairId
+		order.ForexPairID = &v
+	}
+
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		placer := OrderPlacer{}
+		if caller.IsClient {
+			id := caller.ClientID
+			placer.ClientID = &id
+		} else if caller.IsEmployee {
+			if caller.Email == "" {
+				return status.Error(codes.Internal, "employee email missing from caller")
+			}
+			empID, lookupErr := lookupEmployeeID(tx, caller.Email)
+			if lookupErr != nil {
+				return lookupErr
+			}
+			placer.EmployeeID = &empID
+		} else {
+			return status.Error(codes.PermissionDenied, "caller is neither client nor employee")
+		}
+		if err := tx.Create(&placer).Error; err != nil {
+			return err
+		}
+		order.PlacerID = placer.ID
+		return tx.Create(&order).Error
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	return &tradingpb.CreateOrderResponse{
+		OrderId: order.ID,
+		Status:  string(order.Status),
+	}, nil
 }

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -4,13 +4,10 @@ package trading;
 
 option go_package = "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading";
 
-// Minimal surface for #183 — this service only exposes health-style RPCs
-// and a handful of reads so callers can verify the service is wired up.
-// Order placement, listing refresh from external APIs, and stock-price
-// queries are owned by follow-up issues (#184, #186, #189).
 service TradingService {
   rpc ListExchanges(ListExchangesRequest) returns (ListExchangesResponse);
   rpc ListListings(ListListingsRequest) returns (ListListingsResponse);
+  rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);
 }
 
 message Exchange {
@@ -45,4 +42,26 @@ message ListListingsRequest {}
 
 message ListListingsResponse {
   repeated Listing listings = 1;
+}
+
+// Exactly one of listing_id / option_id / forex_pair_id must be set — that's
+// the instrument being traded. limit_price / stop_price are required only
+// for LIMIT / STOP / STOP_LIMIT; senders must leave them 0 otherwise.
+message CreateOrderRequest {
+  int64 listing_id = 1;
+  int64 option_id = 2;
+  int64 forex_pair_id = 3;
+  string account_number = 4;
+  string order_type = 5;
+  string direction = 6;
+  int64 quantity = 7;
+  int64 limit_price = 8;
+  int64 stop_price = 9;
+  bool all_or_none = 10;
+  bool margin = 11;
+}
+
+message CreateOrderResponse {
+  int64 order_id = 1;
+  string status = 2;
 }


### PR DESCRIPTION
## Summary
- Adds `TradingService.CreateOrder` RPC letting clients and employees place orders. The service is hosted inside the bank process per #185.
- `OrderPlacer` is written with `client_id` set for client callers and `employee_id` set for employee callers, honoring the nullable-FK relation from #183.

Unit tests added.