### PR TITLE
feat: employee trading limits + agent/supervisor perms (#187)

### DIFF
--- a/gen/user/user.pb.go
+++ b/gen/user/user.pb.go
@@ -1768,6 +1768,8 @@ type GetEmployeeResponse struct {
 	Department    string                 `protobuf:"bytes,11,opt,name=department,proto3" json:"department,omitempty"`
 	Active        bool                   `protobuf:"varint,12,opt,name=active,proto3" json:"active,omitempty"`
 	Permissions   []string               `protobuf:"bytes,13,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	Limit         int64                  `protobuf:"varint,14,opt,name=limit,proto3" json:"limit,omitempty"`
+	UsedLimit     int64                  `protobuf:"varint,15,opt,name=used_limit,json=usedLimit,proto3" json:"used_limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1893,6 +1895,20 @@ func (x *GetEmployeeResponse) GetPermissions() []string {
 	return nil
 }
 
+func (x *GetEmployeeResponse) GetLimit() int64 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *GetEmployeeResponse) GetUsedLimit() int64 {
+	if x != nil {
+		return x.UsedLimit
+	}
+	return 0
+}
+
 type GetClientResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1994,17 +2010,21 @@ func (x *GetClientResponse) GetAddress() string {
 }
 
 type UpdateEmployeeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	FirstName     string                 `protobuf:"bytes,2,opt,name=first_name,json=firstName,proto3" json:"first_name,omitempty"`
-	LastName      string                 `protobuf:"bytes,3,opt,name=last_name,json=lastName,proto3" json:"last_name,omitempty"`
-	Gender        string                 `protobuf:"bytes,4,opt,name=gender,proto3" json:"gender,omitempty"`
-	PhoneNumber   string                 `protobuf:"bytes,5,opt,name=phone_number,json=phoneNumber,proto3" json:"phone_number,omitempty"`
-	Address       string                 `protobuf:"bytes,6,opt,name=address,proto3" json:"address,omitempty"`
-	Position      string                 `protobuf:"bytes,7,opt,name=position,proto3" json:"position,omitempty"`
-	Department    string                 `protobuf:"bytes,8,opt,name=department,proto3" json:"department,omitempty"`
-	Active        bool                   `protobuf:"varint,9,opt,name=active,proto3" json:"active,omitempty"`
-	Permissions   []string               `protobuf:"bytes,10,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Id          int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	FirstName   string                 `protobuf:"bytes,2,opt,name=first_name,json=firstName,proto3" json:"first_name,omitempty"`
+	LastName    string                 `protobuf:"bytes,3,opt,name=last_name,json=lastName,proto3" json:"last_name,omitempty"`
+	Gender      string                 `protobuf:"bytes,4,opt,name=gender,proto3" json:"gender,omitempty"`
+	PhoneNumber string                 `protobuf:"bytes,5,opt,name=phone_number,json=phoneNumber,proto3" json:"phone_number,omitempty"`
+	Address     string                 `protobuf:"bytes,6,opt,name=address,proto3" json:"address,omitempty"`
+	Position    string                 `protobuf:"bytes,7,opt,name=position,proto3" json:"position,omitempty"`
+	Department  string                 `protobuf:"bytes,8,opt,name=department,proto3" json:"department,omitempty"`
+	Active      bool                   `protobuf:"varint,9,opt,name=active,proto3" json:"active,omitempty"`
+	Permissions []string               `protobuf:"bytes,10,rep,name=permissions,proto3" json:"permissions,omitempty"`
+	// email of the caller issuing the update, forwarded by the gateway.
+	// Required so the user service can enforce that only admins may grant
+	// or revoke the `agent` / `supervisor` permissions.
+	CallerEmail   string `protobuf:"bytes,11,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2109,6 +2129,84 @@ func (x *UpdateEmployeeRequest) GetPermissions() []string {
 	return nil
 }
 
+func (x *UpdateEmployeeRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type UpdateEmployeeTradingLimitRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// new daily limit (in RSD minor units); null/omitted means don't touch.
+	Limit *int64 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	// new used_limit value; null/omitted means don't touch. Pass 0 to reset.
+	UsedLimit *int64 `protobuf:"varint,3,opt,name=used_limit,json=usedLimit,proto3,oneof" json:"used_limit,omitempty"`
+	// email of the caller; required so the user service can verify the caller is admin/supervisor.
+	CallerEmail   string `protobuf:"bytes,4,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) Reset() {
+	*x = UpdateEmployeeTradingLimitRequest{}
+	mi := &file_user_user_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateEmployeeTradingLimitRequest) ProtoMessage() {}
+
+func (x *UpdateEmployeeTradingLimitRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_user_user_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateEmployeeTradingLimitRequest.ProtoReflect.Descriptor instead.
+func (*UpdateEmployeeTradingLimitRequest) Descriptor() ([]byte, []int) {
+	return file_user_user_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) GetLimit() int64 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) GetUsedLimit() int64 {
+	if x != nil && x.UsedLimit != nil {
+		return *x.UsedLimit
+	}
+	return 0
+}
+
+func (x *UpdateEmployeeTradingLimitRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
 type GetEmployeesResponse_Employee struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -2124,7 +2222,7 @@ type GetEmployeesResponse_Employee struct {
 
 func (x *GetEmployeesResponse_Employee) Reset() {
 	*x = GetEmployeesResponse_Employee{}
-	mi := &file_user_user_proto_msgTypes[32]
+	mi := &file_user_user_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2136,7 +2234,7 @@ func (x *GetEmployeesResponse_Employee) String() string {
 func (*GetEmployeesResponse_Employee) ProtoMessage() {}
 
 func (x *GetEmployeesResponse_Employee) ProtoReflect() protoreflect.Message {
-	mi := &file_user_user_proto_msgTypes[32]
+	mi := &file_user_user_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2340,7 +2438,7 @@ const file_user_user_proto_rawDesc = "" +
 	"\x12GetUserByIdRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"-\n" +
 	"\x15GetUserByEmailRequest\x12\x14\n" +
-	"\x05email\x18\x01 \x01(\tR\x05email\"\xfd\x02\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\"\xb2\x03\n" +
 	"\x13GetEmployeeResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2359,7 +2457,10 @@ const file_user_user_proto_rawDesc = "" +
 	"department\x18\v \x01(\tR\n" +
 	"department\x12\x16\n" +
 	"\x06active\x18\f \x01(\bR\x06active\x12 \n" +
-	"\vpermissions\x18\r \x03(\tR\vpermissions\"\xe9\x01\n" +
+	"\vpermissions\x18\r \x03(\tR\vpermissions\x12\x14\n" +
+	"\x05limit\x18\x0e \x01(\x03R\x05limit\x12\x1d\n" +
+	"\n" +
+	"used_limit\x18\x0f \x01(\x03R\tusedLimit\"\xe9\x01\n" +
 	"\x11GetClientResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2370,7 +2471,7 @@ const file_user_user_proto_rawDesc = "" +
 	"\x06gender\x18\x05 \x01(\tR\x06gender\x12\x14\n" +
 	"\x05email\x18\x06 \x01(\tR\x05email\x12!\n" +
 	"\fphone_number\x18\a \x01(\tR\vphoneNumber\x12\x18\n" +
-	"\aaddress\x18\b \x01(\tR\aaddress\"\xae\x02\n" +
+	"\aaddress\x18\b \x01(\tR\aaddress\"\xd1\x02\n" +
 	"\x15UpdateEmployeeRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2385,12 +2486,22 @@ const file_user_user_proto_rawDesc = "" +
 	"department\x12\x16\n" +
 	"\x06active\x18\t \x01(\bR\x06active\x12 \n" +
 	"\vpermissions\x18\n" +
-	" \x03(\tR\vpermissions2\xd9\v\n" +
+	" \x03(\tR\vpermissions\x12!\n" +
+	"\fcaller_email\x18\v \x01(\tR\vcallerEmail\"\xae\x01\n" +
+	"!UpdateEmployeeTradingLimitRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x19\n" +
+	"\x05limit\x18\x02 \x01(\x03H\x00R\x05limit\x88\x01\x01\x12\"\n" +
+	"\n" +
+	"used_limit\x18\x03 \x01(\x03H\x01R\tusedLimit\x88\x01\x01\x12!\n" +
+	"\fcaller_email\x18\x04 \x01(\tR\vcallerEmailB\b\n" +
+	"\x06_limitB\r\n" +
+	"\v_used_limit2\xbb\f\n" +
 	"\vUserService\x12F\n" +
 	"\x0fGetEmployeeById\x12\x18.user.GetUserByIdRequest\x1a\x19.user.GetEmployeeResponse\x12L\n" +
 	"\x12GetEmployeeByEmail\x12\x1b.user.GetUserByEmailRequest\x1a\x19.user.GetEmployeeResponse\x12E\n" +
 	"\fGetEmployees\x12\x19.user.GetEmployeesRequest\x1a\x1a.user.GetEmployeesResponse\x12H\n" +
-	"\x0eUpdateEmployee\x12\x1b.user.UpdateEmployeeRequest\x1a\x19.user.GetEmployeeResponse\x12K\n" +
+	"\x0eUpdateEmployee\x12\x1b.user.UpdateEmployeeRequest\x1a\x19.user.GetEmployeeResponse\x12`\n" +
+	"\x1aUpdateEmployeeTradingLimit\x12'.user.UpdateEmployeeTradingLimitRequest\x1a\x19.user.GetEmployeeResponse\x12K\n" +
 	"\x0eDeleteEmployee\x12\x1b.user.DeleteEmployeeRequest\x1a\x1c.user.DeleteEmployeeResponse\x120\n" +
 	"\x05Login\x12\x12.user.LoginRequest\x1a\x13.user.LoginResponse\x123\n" +
 	"\x06Logout\x12\x13.user.LogoutRequest\x1a\x14.user.LogoutResponse\x126\n" +
@@ -2421,87 +2532,90 @@ func file_user_user_proto_rawDescGZIP() []byte {
 	return file_user_user_proto_rawDescData
 }
 
-var file_user_user_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_user_user_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_user_user_proto_goTypes = []any{
-	(*GetUserPermissionsRequest)(nil),     // 0: user.GetUserPermissionsRequest
-	(*GetUserPermissionsResponse)(nil),    // 1: user.GetUserPermissionsResponse
-	(*DeleteEmployeeRequest)(nil),         // 2: user.DeleteEmployeeRequest
-	(*DeleteEmployeeResponse)(nil),        // 3: user.DeleteEmployeeResponse
-	(*ValidateTokenRequest)(nil),          // 4: user.ValidateTokenRequest
-	(*ValidateTokenResponse)(nil),         // 5: user.ValidateTokenResponse
-	(*RefreshRequest)(nil),                // 6: user.RefreshRequest
-	(*RefreshResponse)(nil),               // 7: user.RefreshResponse
-	(*EmployeeResponse)(nil),              // 8: user.EmployeeResponse
-	(*LogoutRequest)(nil),                 // 9: user.LogoutRequest
-	(*LogoutResponse)(nil),                // 10: user.LogoutResponse
-	(*LoginRequest)(nil),                  // 11: user.LoginRequest
-	(*LoginResponse)(nil),                 // 12: user.LoginResponse
-	(*PasswordActionRequest)(nil),         // 13: user.PasswordActionRequest
-	(*PasswordActionResponse)(nil),        // 14: user.PasswordActionResponse
-	(*SetPasswordWithTokenRequest)(nil),   // 15: user.SetPasswordWithTokenRequest
-	(*SetPasswordWithTokenResponse)(nil),  // 16: user.SetPasswordWithTokenResponse
-	(*CreateEmployeeRequest)(nil),         // 17: user.CreateEmployeeRequest
-	(*CreateClientRequest)(nil),           // 18: user.CreateClientRequest
-	(*CreateClientResponse)(nil),          // 19: user.CreateClientResponse
-	(*Client)(nil),                        // 20: user.Client
-	(*GetClientsRequest)(nil),             // 21: user.GetClientsRequest
-	(*GetClientsResponse)(nil),            // 22: user.GetClientsResponse
-	(*UpdateClientRequest)(nil),           // 23: user.UpdateClientRequest
-	(*UpdateClientResponse)(nil),          // 24: user.UpdateClientResponse
-	(*GetEmployeesRequest)(nil),           // 25: user.GetEmployeesRequest
-	(*GetEmployeesResponse)(nil),          // 26: user.GetEmployeesResponse
-	(*GetUserByIdRequest)(nil),            // 27: user.GetUserByIdRequest
-	(*GetUserByEmailRequest)(nil),         // 28: user.GetUserByEmailRequest
-	(*GetEmployeeResponse)(nil),           // 29: user.GetEmployeeResponse
-	(*GetClientResponse)(nil),             // 30: user.GetClientResponse
-	(*UpdateEmployeeRequest)(nil),         // 31: user.UpdateEmployeeRequest
-	(*GetEmployeesResponse_Employee)(nil), // 32: user.GetEmployeesResponse.Employee
+	(*GetUserPermissionsRequest)(nil),         // 0: user.GetUserPermissionsRequest
+	(*GetUserPermissionsResponse)(nil),        // 1: user.GetUserPermissionsResponse
+	(*DeleteEmployeeRequest)(nil),             // 2: user.DeleteEmployeeRequest
+	(*DeleteEmployeeResponse)(nil),            // 3: user.DeleteEmployeeResponse
+	(*ValidateTokenRequest)(nil),              // 4: user.ValidateTokenRequest
+	(*ValidateTokenResponse)(nil),             // 5: user.ValidateTokenResponse
+	(*RefreshRequest)(nil),                    // 6: user.RefreshRequest
+	(*RefreshResponse)(nil),                   // 7: user.RefreshResponse
+	(*EmployeeResponse)(nil),                  // 8: user.EmployeeResponse
+	(*LogoutRequest)(nil),                     // 9: user.LogoutRequest
+	(*LogoutResponse)(nil),                    // 10: user.LogoutResponse
+	(*LoginRequest)(nil),                      // 11: user.LoginRequest
+	(*LoginResponse)(nil),                     // 12: user.LoginResponse
+	(*PasswordActionRequest)(nil),             // 13: user.PasswordActionRequest
+	(*PasswordActionResponse)(nil),            // 14: user.PasswordActionResponse
+	(*SetPasswordWithTokenRequest)(nil),       // 15: user.SetPasswordWithTokenRequest
+	(*SetPasswordWithTokenResponse)(nil),      // 16: user.SetPasswordWithTokenResponse
+	(*CreateEmployeeRequest)(nil),             // 17: user.CreateEmployeeRequest
+	(*CreateClientRequest)(nil),               // 18: user.CreateClientRequest
+	(*CreateClientResponse)(nil),              // 19: user.CreateClientResponse
+	(*Client)(nil),                            // 20: user.Client
+	(*GetClientsRequest)(nil),                 // 21: user.GetClientsRequest
+	(*GetClientsResponse)(nil),                // 22: user.GetClientsResponse
+	(*UpdateClientRequest)(nil),               // 23: user.UpdateClientRequest
+	(*UpdateClientResponse)(nil),              // 24: user.UpdateClientResponse
+	(*GetEmployeesRequest)(nil),               // 25: user.GetEmployeesRequest
+	(*GetEmployeesResponse)(nil),              // 26: user.GetEmployeesResponse
+	(*GetUserByIdRequest)(nil),                // 27: user.GetUserByIdRequest
+	(*GetUserByEmailRequest)(nil),             // 28: user.GetUserByEmailRequest
+	(*GetEmployeeResponse)(nil),               // 29: user.GetEmployeeResponse
+	(*GetClientResponse)(nil),                 // 30: user.GetClientResponse
+	(*UpdateEmployeeRequest)(nil),             // 31: user.UpdateEmployeeRequest
+	(*UpdateEmployeeTradingLimitRequest)(nil), // 32: user.UpdateEmployeeTradingLimitRequest
+	(*GetEmployeesResponse_Employee)(nil),     // 33: user.GetEmployeesResponse.Employee
 }
 var file_user_user_proto_depIdxs = []int32{
 	20, // 0: user.GetClientsResponse.Clients:type_name -> user.Client
-	32, // 1: user.GetEmployeesResponse.employees:type_name -> user.GetEmployeesResponse.Employee
+	33, // 1: user.GetEmployeesResponse.employees:type_name -> user.GetEmployeesResponse.Employee
 	27, // 2: user.UserService.GetEmployeeById:input_type -> user.GetUserByIdRequest
 	28, // 3: user.UserService.GetEmployeeByEmail:input_type -> user.GetUserByEmailRequest
 	25, // 4: user.UserService.GetEmployees:input_type -> user.GetEmployeesRequest
 	31, // 5: user.UserService.UpdateEmployee:input_type -> user.UpdateEmployeeRequest
-	2,  // 6: user.UserService.DeleteEmployee:input_type -> user.DeleteEmployeeRequest
-	11, // 7: user.UserService.Login:input_type -> user.LoginRequest
-	9,  // 8: user.UserService.Logout:input_type -> user.LogoutRequest
-	6,  // 9: user.UserService.Refresh:input_type -> user.RefreshRequest
-	4,  // 10: user.UserService.ValidateAccessToken:input_type -> user.ValidateTokenRequest
-	4,  // 11: user.UserService.ValidateRefreshToken:input_type -> user.ValidateTokenRequest
-	13, // 12: user.UserService.RequestPasswordReset:input_type -> user.PasswordActionRequest
-	13, // 13: user.UserService.RequestInitialPasswordSet:input_type -> user.PasswordActionRequest
-	15, // 14: user.UserService.SetPasswordWithToken:input_type -> user.SetPasswordWithTokenRequest
-	18, // 15: user.UserService.CreateClientAccount:input_type -> user.CreateClientRequest
-	21, // 16: user.UserService.GetClients:input_type -> user.GetClientsRequest
-	23, // 17: user.UserService.UpdateClient:input_type -> user.UpdateClientRequest
-	17, // 18: user.UserService.CreateEmployeeAccount:input_type -> user.CreateEmployeeRequest
-	0,  // 19: user.UserService.GetUserPermissions:input_type -> user.GetUserPermissionsRequest
-	27, // 20: user.UserService.GetClientById:input_type -> user.GetUserByIdRequest
-	28, // 21: user.UserService.GetClientByEmail:input_type -> user.GetUserByEmailRequest
-	29, // 22: user.UserService.GetEmployeeById:output_type -> user.GetEmployeeResponse
-	29, // 23: user.UserService.GetEmployeeByEmail:output_type -> user.GetEmployeeResponse
-	26, // 24: user.UserService.GetEmployees:output_type -> user.GetEmployeesResponse
-	29, // 25: user.UserService.UpdateEmployee:output_type -> user.GetEmployeeResponse
-	3,  // 26: user.UserService.DeleteEmployee:output_type -> user.DeleteEmployeeResponse
-	12, // 27: user.UserService.Login:output_type -> user.LoginResponse
-	10, // 28: user.UserService.Logout:output_type -> user.LogoutResponse
-	7,  // 29: user.UserService.Refresh:output_type -> user.RefreshResponse
-	5,  // 30: user.UserService.ValidateAccessToken:output_type -> user.ValidateTokenResponse
-	5,  // 31: user.UserService.ValidateRefreshToken:output_type -> user.ValidateTokenResponse
-	14, // 32: user.UserService.RequestPasswordReset:output_type -> user.PasswordActionResponse
-	14, // 33: user.UserService.RequestInitialPasswordSet:output_type -> user.PasswordActionResponse
-	16, // 34: user.UserService.SetPasswordWithToken:output_type -> user.SetPasswordWithTokenResponse
-	19, // 35: user.UserService.CreateClientAccount:output_type -> user.CreateClientResponse
-	22, // 36: user.UserService.GetClients:output_type -> user.GetClientsResponse
-	24, // 37: user.UserService.UpdateClient:output_type -> user.UpdateClientResponse
-	29, // 38: user.UserService.CreateEmployeeAccount:output_type -> user.GetEmployeeResponse
-	1,  // 39: user.UserService.GetUserPermissions:output_type -> user.GetUserPermissionsResponse
-	30, // 40: user.UserService.GetClientById:output_type -> user.GetClientResponse
-	30, // 41: user.UserService.GetClientByEmail:output_type -> user.GetClientResponse
-	22, // [22:42] is the sub-list for method output_type
-	2,  // [2:22] is the sub-list for method input_type
+	32, // 6: user.UserService.UpdateEmployeeTradingLimit:input_type -> user.UpdateEmployeeTradingLimitRequest
+	2,  // 7: user.UserService.DeleteEmployee:input_type -> user.DeleteEmployeeRequest
+	11, // 8: user.UserService.Login:input_type -> user.LoginRequest
+	9,  // 9: user.UserService.Logout:input_type -> user.LogoutRequest
+	6,  // 10: user.UserService.Refresh:input_type -> user.RefreshRequest
+	4,  // 11: user.UserService.ValidateAccessToken:input_type -> user.ValidateTokenRequest
+	4,  // 12: user.UserService.ValidateRefreshToken:input_type -> user.ValidateTokenRequest
+	13, // 13: user.UserService.RequestPasswordReset:input_type -> user.PasswordActionRequest
+	13, // 14: user.UserService.RequestInitialPasswordSet:input_type -> user.PasswordActionRequest
+	15, // 15: user.UserService.SetPasswordWithToken:input_type -> user.SetPasswordWithTokenRequest
+	18, // 16: user.UserService.CreateClientAccount:input_type -> user.CreateClientRequest
+	21, // 17: user.UserService.GetClients:input_type -> user.GetClientsRequest
+	23, // 18: user.UserService.UpdateClient:input_type -> user.UpdateClientRequest
+	17, // 19: user.UserService.CreateEmployeeAccount:input_type -> user.CreateEmployeeRequest
+	0,  // 20: user.UserService.GetUserPermissions:input_type -> user.GetUserPermissionsRequest
+	27, // 21: user.UserService.GetClientById:input_type -> user.GetUserByIdRequest
+	28, // 22: user.UserService.GetClientByEmail:input_type -> user.GetUserByEmailRequest
+	29, // 23: user.UserService.GetEmployeeById:output_type -> user.GetEmployeeResponse
+	29, // 24: user.UserService.GetEmployeeByEmail:output_type -> user.GetEmployeeResponse
+	26, // 25: user.UserService.GetEmployees:output_type -> user.GetEmployeesResponse
+	29, // 26: user.UserService.UpdateEmployee:output_type -> user.GetEmployeeResponse
+	29, // 27: user.UserService.UpdateEmployeeTradingLimit:output_type -> user.GetEmployeeResponse
+	3,  // 28: user.UserService.DeleteEmployee:output_type -> user.DeleteEmployeeResponse
+	12, // 29: user.UserService.Login:output_type -> user.LoginResponse
+	10, // 30: user.UserService.Logout:output_type -> user.LogoutResponse
+	7,  // 31: user.UserService.Refresh:output_type -> user.RefreshResponse
+	5,  // 32: user.UserService.ValidateAccessToken:output_type -> user.ValidateTokenResponse
+	5,  // 33: user.UserService.ValidateRefreshToken:output_type -> user.ValidateTokenResponse
+	14, // 34: user.UserService.RequestPasswordReset:output_type -> user.PasswordActionResponse
+	14, // 35: user.UserService.RequestInitialPasswordSet:output_type -> user.PasswordActionResponse
+	16, // 36: user.UserService.SetPasswordWithToken:output_type -> user.SetPasswordWithTokenResponse
+	19, // 37: user.UserService.CreateClientAccount:output_type -> user.CreateClientResponse
+	22, // 38: user.UserService.GetClients:output_type -> user.GetClientsResponse
+	24, // 39: user.UserService.UpdateClient:output_type -> user.UpdateClientResponse
+	29, // 40: user.UserService.CreateEmployeeAccount:output_type -> user.GetEmployeeResponse
+	1,  // 41: user.UserService.GetUserPermissions:output_type -> user.GetUserPermissionsResponse
+	30, // 42: user.UserService.GetClientById:output_type -> user.GetClientResponse
+	30, // 43: user.UserService.GetClientByEmail:output_type -> user.GetClientResponse
+	23, // [23:44] is the sub-list for method output_type
+	2,  // [2:23] is the sub-list for method input_type
 	2,  // [2:2] is the sub-list for extension type_name
 	2,  // [2:2] is the sub-list for extension extendee
 	0,  // [0:2] is the sub-list for field type_name
@@ -2512,13 +2626,14 @@ func file_user_user_proto_init() {
 	if File_user_user_proto != nil {
 		return
 	}
+	file_user_user_proto_msgTypes[32].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_user_user_proto_rawDesc), len(file_user_user_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/user/user_grpc.pb.go
+++ b/gen/user/user_grpc.pb.go
@@ -19,26 +19,27 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	UserService_GetEmployeeById_FullMethodName           = "/user.UserService/GetEmployeeById"
-	UserService_GetEmployeeByEmail_FullMethodName        = "/user.UserService/GetEmployeeByEmail"
-	UserService_GetEmployees_FullMethodName              = "/user.UserService/GetEmployees"
-	UserService_UpdateEmployee_FullMethodName            = "/user.UserService/UpdateEmployee"
-	UserService_DeleteEmployee_FullMethodName            = "/user.UserService/DeleteEmployee"
-	UserService_Login_FullMethodName                     = "/user.UserService/Login"
-	UserService_Logout_FullMethodName                    = "/user.UserService/Logout"
-	UserService_Refresh_FullMethodName                   = "/user.UserService/Refresh"
-	UserService_ValidateAccessToken_FullMethodName       = "/user.UserService/ValidateAccessToken"
-	UserService_ValidateRefreshToken_FullMethodName      = "/user.UserService/ValidateRefreshToken"
-	UserService_RequestPasswordReset_FullMethodName      = "/user.UserService/RequestPasswordReset"
-	UserService_RequestInitialPasswordSet_FullMethodName = "/user.UserService/RequestInitialPasswordSet"
-	UserService_SetPasswordWithToken_FullMethodName      = "/user.UserService/SetPasswordWithToken"
-	UserService_CreateClientAccount_FullMethodName       = "/user.UserService/CreateClientAccount"
-	UserService_GetClients_FullMethodName                = "/user.UserService/GetClients"
-	UserService_UpdateClient_FullMethodName              = "/user.UserService/UpdateClient"
-	UserService_CreateEmployeeAccount_FullMethodName     = "/user.UserService/CreateEmployeeAccount"
-	UserService_GetUserPermissions_FullMethodName        = "/user.UserService/GetUserPermissions"
-	UserService_GetClientById_FullMethodName             = "/user.UserService/GetClientById"
-	UserService_GetClientByEmail_FullMethodName          = "/user.UserService/GetClientByEmail"
+	UserService_GetEmployeeById_FullMethodName            = "/user.UserService/GetEmployeeById"
+	UserService_GetEmployeeByEmail_FullMethodName         = "/user.UserService/GetEmployeeByEmail"
+	UserService_GetEmployees_FullMethodName               = "/user.UserService/GetEmployees"
+	UserService_UpdateEmployee_FullMethodName             = "/user.UserService/UpdateEmployee"
+	UserService_UpdateEmployeeTradingLimit_FullMethodName = "/user.UserService/UpdateEmployeeTradingLimit"
+	UserService_DeleteEmployee_FullMethodName             = "/user.UserService/DeleteEmployee"
+	UserService_Login_FullMethodName                      = "/user.UserService/Login"
+	UserService_Logout_FullMethodName                     = "/user.UserService/Logout"
+	UserService_Refresh_FullMethodName                    = "/user.UserService/Refresh"
+	UserService_ValidateAccessToken_FullMethodName        = "/user.UserService/ValidateAccessToken"
+	UserService_ValidateRefreshToken_FullMethodName       = "/user.UserService/ValidateRefreshToken"
+	UserService_RequestPasswordReset_FullMethodName       = "/user.UserService/RequestPasswordReset"
+	UserService_RequestInitialPasswordSet_FullMethodName  = "/user.UserService/RequestInitialPasswordSet"
+	UserService_SetPasswordWithToken_FullMethodName       = "/user.UserService/SetPasswordWithToken"
+	UserService_CreateClientAccount_FullMethodName        = "/user.UserService/CreateClientAccount"
+	UserService_GetClients_FullMethodName                 = "/user.UserService/GetClients"
+	UserService_UpdateClient_FullMethodName               = "/user.UserService/UpdateClient"
+	UserService_CreateEmployeeAccount_FullMethodName      = "/user.UserService/CreateEmployeeAccount"
+	UserService_GetUserPermissions_FullMethodName         = "/user.UserService/GetUserPermissions"
+	UserService_GetClientById_FullMethodName              = "/user.UserService/GetClientById"
+	UserService_GetClientByEmail_FullMethodName           = "/user.UserService/GetClientByEmail"
 )
 
 // UserServiceClient is the client API for UserService service.
@@ -49,6 +50,7 @@ type UserServiceClient interface {
 	GetEmployeeByEmail(ctx context.Context, in *GetUserByEmailRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
 	GetEmployees(ctx context.Context, in *GetEmployeesRequest, opts ...grpc.CallOption) (*GetEmployeesResponse, error)
 	UpdateEmployee(ctx context.Context, in *UpdateEmployeeRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
+	UpdateEmployeeTradingLimit(ctx context.Context, in *UpdateEmployeeTradingLimitRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
 	DeleteEmployee(ctx context.Context, in *DeleteEmployeeRequest, opts ...grpc.CallOption) (*DeleteEmployeeResponse, error)
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
 	Logout(ctx context.Context, in *LogoutRequest, opts ...grpc.CallOption) (*LogoutResponse, error)
@@ -109,6 +111,16 @@ func (c *userServiceClient) UpdateEmployee(ctx context.Context, in *UpdateEmploy
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetEmployeeResponse)
 	err := c.cc.Invoke(ctx, UserService_UpdateEmployee_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userServiceClient) UpdateEmployeeTradingLimit(ctx context.Context, in *UpdateEmployeeTradingLimitRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetEmployeeResponse)
+	err := c.cc.Invoke(ctx, UserService_UpdateEmployeeTradingLimit_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +295,7 @@ type UserServiceServer interface {
 	GetEmployeeByEmail(context.Context, *GetUserByEmailRequest) (*GetEmployeeResponse, error)
 	GetEmployees(context.Context, *GetEmployeesRequest) (*GetEmployeesResponse, error)
 	UpdateEmployee(context.Context, *UpdateEmployeeRequest) (*GetEmployeeResponse, error)
+	UpdateEmployeeTradingLimit(context.Context, *UpdateEmployeeTradingLimitRequest) (*GetEmployeeResponse, error)
 	DeleteEmployee(context.Context, *DeleteEmployeeRequest) (*DeleteEmployeeResponse, error)
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
 	Logout(context.Context, *LogoutRequest) (*LogoutResponse, error)
@@ -320,6 +333,9 @@ func (UnimplementedUserServiceServer) GetEmployees(context.Context, *GetEmployee
 }
 func (UnimplementedUserServiceServer) UpdateEmployee(context.Context, *UpdateEmployeeRequest) (*GetEmployeeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateEmployee not implemented")
+}
+func (UnimplementedUserServiceServer) UpdateEmployeeTradingLimit(context.Context, *UpdateEmployeeTradingLimitRequest) (*GetEmployeeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateEmployeeTradingLimit not implemented")
 }
 func (UnimplementedUserServiceServer) DeleteEmployee(context.Context, *DeleteEmployeeRequest) (*DeleteEmployeeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteEmployee not implemented")
@@ -458,6 +474,24 @@ func _UserService_UpdateEmployee_Handler(srv interface{}, ctx context.Context, d
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(UserServiceServer).UpdateEmployee(ctx, req.(*UpdateEmployeeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserService_UpdateEmployeeTradingLimit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateEmployeeTradingLimitRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).UpdateEmployeeTradingLimit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_UpdateEmployeeTradingLimit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).UpdateEmployeeTradingLimit(ctx, req.(*UpdateEmployeeTradingLimitRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -772,6 +806,10 @@ var UserService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateEmployee",
 			Handler:    _UserService_UpdateEmployee_Handler,
+		},
+		{
+			MethodName: "UpdateEmployeeTradingLimit",
+			Handler:    _UserService_UpdateEmployeeTradingLimit_Handler,
 		},
 		{
 			MethodName: "DeleteEmployee",

--- a/internal/gateway/employees.go
+++ b/internal/gateway/employees.go
@@ -69,6 +69,58 @@ func (s *Server) CreateEmployeeAccount(c *gin.Context) {
 		"username":    resp.Username,
 		"department":  resp.Department,
 		"permissions": perms,
+		"limit":       resp.Limit,
+		"used_limit":  resp.UsedLimit,
+	})
+}
+
+func (s *Server) UpdateEmployeeTradingLimit(c *gin.Context) {
+	var uri updateEmployeeURI
+	if err := c.ShouldBindUri(&uri); err != nil {
+		c.String(http.StatusBadRequest, "employee id is required and must be a valid integer")
+		return
+	}
+
+	var body updateEmployeeTradingLimitRequest
+	if err := c.BindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+	if body.Limit == nil && body.UsedLimit == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "limit or used_limit must be provided"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.UserClient.UpdateEmployeeTradingLimit(ctx, &userpb.UpdateEmployeeTradingLimitRequest{
+		Id:          uri.EmployeeID,
+		Limit:       body.Limit,
+		UsedLimit:   body.UsedLimit,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	perms := resp.Permissions
+	if perms == nil {
+		perms = []string{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":          resp.Id,
+		"first_name":  resp.FirstName,
+		"last_name":   resp.LastName,
+		"email":       resp.Email,
+		"position":    resp.Position,
+		"department":  resp.Department,
+		"active":      resp.Active,
+		"permissions": perms,
+		"limit":       resp.Limit,
+		"used_limit":  resp.UsedLimit,
 	})
 }
 
@@ -109,6 +161,8 @@ func (s *Server) GetEmployeeByID(c *gin.Context) {
 		"department":  resp.Department,
 		"active":      resp.Active,
 		"permissions": perms,
+		"limit":       resp.Limit,
+		"used_limit":  resp.UsedLimit,
 	})
 }
 
@@ -196,6 +250,7 @@ func (s *Server) UpdateEmployee(c *gin.Context) {
 		Department:  req.Department,
 		Active:      req.Active,
 		Permissions: req.Permissions,
+		CallerEmail: c.GetString("email"),
 	})
 	if err != nil {
 		writeGRPCError(c, err)
@@ -221,5 +276,7 @@ func (s *Server) UpdateEmployee(c *gin.Context) {
 		"department":  resp.Department,
 		"active":      resp.Active,
 		"permissions": perms,
+		"limit":       resp.Limit,
+		"used_limit":  resp.UsedLimit,
 	})
 }

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -84,6 +84,10 @@ func SetupApi(router *gin.Engine, server *Server) {
 		employees.PATCH("/:employeeId", server.UpdateEmployee)
 	}
 
+	// Supervisors (and admins via bypass) adjust an agent's daily trading limit
+	// and/or reset their used_limit. Gated by `supervisor`; admin bypass still applies.
+	api.PATCH("/employees/:employeeId/trading-limit", auth, secured("supervisor"), server.UpdateEmployeeTradingLimit)
+
 	companies := api.Group("/companies", auth, secured("manage_companies"))
 	{
 		companies.POST("", server.CreateCompany)

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -52,6 +52,11 @@ type updateEmployeeRequest struct {
 	Permissions []string `json:"permissions"`
 }
 
+type updateEmployeeTradingLimitRequest struct {
+	Limit     *int64 `json:"limit"`
+	UsedLimit *int64 `json:"used_limit"`
+}
+
 type createClientAccountRequest struct {
 	FirstName   string `json:"first_name" binding:"required"`
 	LastName    string `json:"last_name" binding:"required"`

--- a/internal/user/models.go
+++ b/internal/user/models.go
@@ -36,6 +36,8 @@ type (
 		Position      string       `gorm:"column:position;type:varchar(100);not null"`
 		Department    string       `gorm:"column:department;type:varchar(100);not null"`
 		Active        bool         `gorm:"column:active;type:bool; not null"`
+		Limit         int64        `gorm:"column:limit;type:bigint;not null;default:0"`
+		Used_limit    int64        `gorm:"column:used_limit;type:bigint;not null;default:0"`
 		Created_at    time.Time    `gorm:"column:created_at;not null;autoCreateTime"`
 		Updated_at    time.Time    `gorm:"column:updated_at;not null;autoUpdateTime"`
 		Permissions   []Permission `gorm:"many2many:employee_permissions;joinForeignKey:Employee_id;joinReferences:PermissionId"`

--- a/internal/user/server.go
+++ b/internal/user/server.go
@@ -113,6 +113,8 @@ func (emp Employee) toProtobuf() *userpb.GetEmployeeResponse {
 		Department:  emp.Department,
 		Active:      emp.Active,
 		Permissions: permissions,
+		Limit:       emp.Limit,
+		UsedLimit:   emp.Used_limit,
 	}
 }
 
@@ -208,13 +210,24 @@ func (s *Server) GetEmployees(_ context.Context, req *userpb.GetEmployeesRequest
 }
 
 func (s *Server) UpdateEmployee(ctx context.Context, req *userpb.UpdateEmployeeRequest) (*userpb.GetEmployeeResponse, error) {
+	existing, existingErr := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
 	if !req.Active {
-		existing, err := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
-		if err == nil && existing != nil {
+		if existingErr == nil && existing != nil {
 			for _, p := range existing.Permissions {
 				if p.Name == "admin" {
 					return nil, status.Error(codes.PermissionDenied, "cannot deactivate an admin")
 				}
+			}
+		}
+	}
+
+	// Only admins may grant or revoke the `agent` / `supervisor` permissions.
+	if req.Permissions != nil && existingErr == nil && existing != nil {
+		oldSet := permissionSet(existing.Permissions)
+		newSet := namesToSet(req.Permissions)
+		if togglesTradingRole(oldSet, newSet) {
+			if !callerIsAdmin(ctx, s, req.CallerEmail) {
+				return nil, status.Error(codes.PermissionDenied, "only admins may grant or revoke agent/supervisor permissions")
 			}
 		}
 	}
@@ -262,6 +275,116 @@ func (s *Server) UpdateEmployee(ctx context.Context, req *userpb.UpdateEmployeeR
 
 	return updated.toProtobuf(), nil
 
+}
+
+// UpdateEmployeeTradingLimit sets an agent's daily trading limit and/or used_limit.
+// Only admins and supervisors may call this. The caller is identified by CallerEmail
+// (forwarded from the gateway).
+func (s *Server) UpdateEmployeeTradingLimit(ctx context.Context, req *userpb.UpdateEmployeeTradingLimitRequest) (*userpb.GetEmployeeResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "id must be greater than zero")
+	}
+	if req.Limit == nil && req.UsedLimit == nil {
+		return nil, status.Error(codes.InvalidArgument, "limit or used_limit must be provided")
+	}
+	if req.Limit != nil && *req.Limit < 0 {
+		return nil, status.Error(codes.InvalidArgument, "limit must be non-negative")
+	}
+	if req.UsedLimit != nil && *req.UsedLimit < 0 {
+		return nil, status.Error(codes.InvalidArgument, "used_limit must be non-negative")
+	}
+
+	if !callerCanManageLimits(ctx, s, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "only admins and supervisors may change an agent's limit")
+	}
+
+	target, err := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "employee not found")
+		}
+		return nil, status.Error(codes.Internal, "failed to load employee")
+	}
+
+	updates := map[string]any{"updated_at": time.Now()}
+	if req.Limit != nil {
+		updates["limit"] = *req.Limit
+	}
+	if req.UsedLimit != nil {
+		updates["used_limit"] = *req.UsedLimit
+	}
+
+	if err := s.db_gorm.Model(&Employee{}).Where("id = ?", target.Id).Updates(updates).Error; err != nil {
+		return nil, status.Error(codes.Internal, "failed to update trading limit")
+	}
+
+	reloaded, err := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to reload employee")
+	}
+	return reloaded.toProtobuf(), nil
+}
+
+// permissionSet converts a list of Permission rows to a string set for easy membership tests.
+func permissionSet(perms []Permission) map[string]struct{} {
+	out := make(map[string]struct{}, len(perms))
+	for _, p := range perms {
+		out[p.Name] = struct{}{}
+	}
+	return out
+}
+
+func namesToSet(names []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
+// togglesTradingRole reports whether the `agent` or `supervisor` membership differs
+// between the old and new permission sets.
+func togglesTradingRole(oldSet, newSet map[string]struct{}) bool {
+	for _, perm := range []string{"agent", "supervisor"} {
+		_, inOld := oldSet[perm]
+		_, inNew := newSet[perm]
+		if inOld != inNew {
+			return true
+		}
+	}
+	return false
+}
+
+func callerIsAdmin(_ context.Context, s *Server, callerEmail string) bool {
+	if strings.TrimSpace(callerEmail) == "" {
+		return false
+	}
+	caller, err := getUserByAttribute(Employee{}, s.db_gorm, "email", callerEmail)
+	if err != nil || caller == nil {
+		return false
+	}
+	for _, p := range caller.Permissions {
+		if p.Name == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
+func callerCanManageLimits(_ context.Context, s *Server, callerEmail string) bool {
+	if strings.TrimSpace(callerEmail) == "" {
+		return false
+	}
+	caller, err := getUserByAttribute(Employee{}, s.db_gorm, "email", callerEmail)
+	if err != nil || caller == nil {
+		return false
+	}
+	for _, p := range caller.Permissions {
+		if p.Name == "admin" || p.Name == "supervisor" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) GetClients(_ context.Context, req *userpb.GetClientsRequest) (*userpb.GetClientsResponse, error) {

--- a/internal/user/trading_limits_test.go
+++ b/internal/user/trading_limits_test.go
@@ -1,0 +1,88 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/user"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestTogglesTradingRoleDetectsGrantRevoke(t *testing.T) {
+	tests := []struct {
+		name string
+		old  []string
+		new  []string
+		want bool
+	}{
+		{"no change, no trading role", []string{"manage_loans"}, []string{"manage_loans", "manage_cards"}, false},
+		{"grants agent", []string{"manage_loans"}, []string{"manage_loans", "agent"}, true},
+		{"revokes agent", []string{"agent", "trade_stocks"}, []string{"trade_stocks"}, true},
+		{"grants supervisor", []string{}, []string{"supervisor"}, true},
+		{"revokes supervisor", []string{"supervisor"}, []string{}, true},
+		{"agent stays set", []string{"agent"}, []string{"agent", "view_stocks"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := togglesTradingRole(namesToSet(tc.old), namesToSet(tc.new))
+			if got != tc.want {
+				t.Fatalf("togglesTradingRole(%v -> %v) = %v, want %v", tc.old, tc.new, got, tc.want)
+			}
+		})
+	}
+}
+
+// UpdateEmployeeTradingLimit validates its arguments before touching the DB, so
+// we can exercise those branches without plumbing gorm/sqlmock expectations.
+func TestUpdateEmployeeTradingLimitArgValidation(t *testing.T) {
+	server, _, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	cases := []struct {
+		name string
+		req  *userpb.UpdateEmployeeTradingLimitRequest
+		code codes.Code
+	}{
+		{
+			name: "zero id",
+			req:  &userpb.UpdateEmployeeTradingLimitRequest{Id: 0},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nothing to update",
+			req:  &userpb.UpdateEmployeeTradingLimitRequest{Id: 1},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "negative limit",
+			req:  &userpb.UpdateEmployeeTradingLimitRequest{Id: 1, Limit: ptr64(-1)},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "negative used_limit",
+			req:  &userpb.UpdateEmployeeTradingLimitRequest{Id: 1, UsedLimit: ptr64(-5)},
+			code: codes.InvalidArgument,
+		},
+		{
+			// permission check runs after validation; empty CallerEmail means no admin/supervisor
+			// caller found → PermissionDenied without any DB round-trips.
+			name: "caller not supervisor or admin",
+			req:  &userpb.UpdateEmployeeTradingLimitRequest{Id: 1, Limit: ptr64(500)},
+			code: codes.PermissionDenied,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := server.UpdateEmployeeTradingLimit(context.Background(), tc.req)
+			if err == nil {
+				t.Fatalf("expected error with code %s, got nil", tc.code)
+			}
+			if status.Code(err) != tc.code {
+				t.Fatalf("got code %s, want %s (err=%v)", status.Code(err), tc.code, err)
+			}
+		})
+	}
+}
+
+func ptr64(v int64) *int64 { return &v }

--- a/proto/user/user.proto
+++ b/proto/user/user.proto
@@ -9,6 +9,7 @@ service UserService {
   rpc GetEmployeeByEmail(GetUserByEmailRequest) returns (GetEmployeeResponse);
   rpc GetEmployees(GetEmployeesRequest) returns (GetEmployeesResponse);
   rpc UpdateEmployee(UpdateEmployeeRequest) returns (GetEmployeeResponse);
+  rpc UpdateEmployeeTradingLimit(UpdateEmployeeTradingLimitRequest) returns (GetEmployeeResponse);
   rpc DeleteEmployee(DeleteEmployeeRequest) returns (DeleteEmployeeResponse);
   rpc Login(LoginRequest) returns (LoginResponse);
   rpc Logout(LogoutRequest) returns (LogoutResponse);
@@ -228,6 +229,8 @@ message GetEmployeeResponse {
   string department = 11;
   bool active = 12;
   repeated string permissions = 13;
+  int64 limit = 14;
+  int64 used_limit = 15;
 }
 
 message GetClientResponse {
@@ -252,4 +255,18 @@ message UpdateEmployeeRequest {
   string department = 8;
   bool active = 9;
   repeated string permissions = 10;
+  // email of the caller issuing the update, forwarded by the gateway.
+  // Required so the user service can enforce that only admins may grant
+  // or revoke the `agent` / `supervisor` permissions.
+  string caller_email = 11;
+}
+
+message UpdateEmployeeTradingLimitRequest {
+  int64 id = 1;
+  // new daily limit (in RSD minor units); null/omitted means don't touch.
+  optional int64 limit = 2;
+  // new used_limit value; null/omitted means don't touch. Pass 0 to reset.
+  optional int64 used_limit = 3;
+  // email of the caller; required so the user service can verify the caller is admin/supervisor.
+  string caller_email = 4;
 }

--- a/scripts/bruno/13-employees/10-agent-update-limit-forbidden.bru
+++ b/scripts/bruno/13-employees/10-agent-update-limit-forbidden.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Agent Update Limit Forbidden
+  type: http
+  seq: 10
+}
+
+patch {
+  url: {{baseUrl}}/api/employees/{{agentId}}/trading-limit
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{agentToken}}
+}
+
+body:json {
+  {
+    "limit": 999999999
+  }
+}
+
+tests {
+  test("forbidden", function() {
+    expect(res.status).to.equal(403);
+  });
+}

--- a/scripts/bruno/13-employees/6-login-supervisor.bru
+++ b/scripts/bruno/13-employees/6-login-supervisor.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Login Supervisor
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "supervisor@banka.raf",
+    "password": "Test1234!"
+  }
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("has supervisor permission", function() {
+    expect(res.body.permissions).to.be.an("array");
+    expect(res.body.permissions).to.include("supervisor");
+  });
+}
+
+script:post-response {
+  if (res.body && res.body.accessToken) {
+    bru.setEnvVar("supervisorToken", res.body.accessToken);
+  }
+}

--- a/scripts/bruno/13-employees/7-get-agent-id.bru
+++ b/scripts/bruno/13-employees/7-get-agent-id.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get Agent ID
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/api/employees?email=agent@banka.raf
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{accessToken}}
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("one agent returned", function() {
+    expect(res.body).to.be.an("array");
+    expect(res.body.length).to.equal(1);
+  });
+}
+
+script:post-response {
+  if (res.body && res.body.length > 0) {
+    bru.setEnvVar("agentId", res.body[0].id);
+  }
+}

--- a/scripts/bruno/13-employees/8-supervisor-updates-agent-limit.bru
+++ b/scripts/bruno/13-employees/8-supervisor-updates-agent-limit.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Supervisor Updates Agent Limit
+  type: http
+  seq: 8
+}
+
+patch {
+  url: {{baseUrl}}/api/employees/{{agentId}}/trading-limit
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{supervisorToken}}
+}
+
+body:json {
+  {
+    "limit": 25000000,
+    "used_limit": 0
+  }
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  test("limit updated", function() {
+    expect(res.body.limit).to.equal(25000000);
+  });
+  test("used_limit reset to 0", function() {
+    expect(res.body.used_limit).to.equal(0);
+  });
+}

--- a/scripts/bruno/13-employees/9-agent-cannot-update-limits.bru
+++ b/scripts/bruno/13-employees/9-agent-cannot-update-limits.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Agent Cannot Update Limits
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/api/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "agent@banka.raf",
+    "password": "Test1234!"
+  }
+}
+
+tests {
+  test("login status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}
+
+script:post-response {
+  if (res.body && res.body.accessToken) {
+    bru.setEnvVar("agentToken", res.body.accessToken);
+  }
+}

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -18,6 +18,10 @@ CREATE TABLE IF NOT EXISTS employees (
     position      VARCHAR(100) NOT NULL,
     department    VARCHAR(100) NOT NULL,
     active        BOOLEAN      NOT NULL DEFAULT true,
+    -- Daily trading limit (in RSD minor units) for employees with the `agent` permission.
+    -- Supervisors and admins ignore the limit.
+    "limit"       BIGINT       NOT NULL DEFAULT 0 CHECK ("limit" >= 0),
+    used_limit    BIGINT       NOT NULL DEFAULT 0 CHECK (used_limit >= 0),
     created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMP    NOT NULL DEFAULT NOW()
 );

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -9,7 +9,9 @@ VALUES
     ('manage_clients'),
     ('manage_accounts'),
     ('manage_companies'),
-    ('manage_cards')
+    ('manage_cards'),
+    ('agent'),
+    ('supervisor')
 ON CONFLICT (name) DO NOTHING;
 
 -- default admin (password: "Admin123!")
@@ -78,6 +80,48 @@ INSERT INTO employee_permissions (employee_id, permission_id)
 SELECT e.id, p.id
 FROM employees e, permissions p
 WHERE e.email = 'limited_emp@banka.raf' AND p.name = 'view_stocks'
+ON CONFLICT DO NOTHING;
+
+-- trading agent (password: "Test1234!") — has `agent` perm with a 100,000 RSD daily limit
+INSERT INTO employees (
+    first_name, last_name, date_of_birth, gender, email,
+    phone_number, address, username, password, salt_password,
+    position, department, active, "limit", used_limit
+)
+VALUES (
+    'Agent', 'Trgovac', '1990-01-01', 'M', 'agent@banka.raf',
+    '+381649990003', 'Test Adresa 3', 'agent',
+    '\xa514f71947f5447cdfc2845f40d020cea4146ba28e84cb1a82662a6286f8228d'::BYTEA,
+    '\x11223344556677889900aabbccddeeff'::BYTEA,
+    'Trader', 'Brokersko', true, 10000000, 0
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO employee_permissions (employee_id, permission_id)
+SELECT e.id, p.id
+FROM employees e, permissions p
+WHERE e.email = 'agent@banka.raf' AND p.name IN ('agent', 'trade_stocks', 'view_stocks')
+ON CONFLICT DO NOTHING;
+
+-- trading supervisor (password: "Test1234!") — has `supervisor` perm, no trading limit
+INSERT INTO employees (
+    first_name, last_name, date_of_birth, gender, email,
+    phone_number, address, username, password, salt_password,
+    position, department, active
+)
+VALUES (
+    'Supervizor', 'Trgovac', '1990-01-01', 'F', 'supervisor@banka.raf',
+    '+381649990004', 'Test Adresa 4', 'supervisor',
+    '\xa514f71947f5447cdfc2845f40d020cea4146ba28e84cb1a82662a6286f8228d'::BYTEA,
+    '\x11223344556677889900aabbccddeeff'::BYTEA,
+    'Head Trader', 'Brokersko', true
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO employee_permissions (employee_id, permission_id)
+SELECT e.id, p.id
+FROM employees e, permissions p
+WHERE e.email = 'supervisor@banka.raf' AND p.name IN ('supervisor', 'trade_stocks', 'view_stocks')
 ON CONFLICT DO NOTHING;
 
 -- test client (password: "Test1234!")


### PR DESCRIPTION
Closes #187.

## Summary
- Extends the `employees` relation with `limit` and `used_limit` (BIGINT, RSD minor units) and seeds `agent` + `supervisor` permissions plus matching test fixtures.
- Adds `UpdateEmployeeTradingLimit` RPC + `PATCH /api/employees/:id/trading-limit` endpoint so supervisors (admins via bypass) can set an agent's daily limit and/or reset `used_limit`.
- Gates `agent` / `supervisor` perm toggles on `UpdateEmployee` to admins only (per spec §Aktuari, page ~47).

Leaves approval-request generation to #188 and market execution/fills to #189.

## Test plan
- [x] `go test ./...`
- [x] `make lint`
- [x] Schema + seed apply cleanly on postgres:18-alpine; new columns populated as expected
- [ ] Bruno `13-employees` folder runs green against a live stack (6–10 cover supervisor login, agent id lookup, supervisor-sets-limit, agent-cannot-set-limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)