### PR TITLE
feat: exchange working hours + open_override toggle (#194)

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -31,8 +31,12 @@ type Exchange struct {
 	Currency       string                 `protobuf:"bytes,6,opt,name=currency,proto3" json:"currency,omitempty"`
 	TimeZoneOffset string                 `protobuf:"bytes,7,opt,name=time_zone_offset,json=timeZoneOffset,proto3" json:"time_zone_offset,omitempty"`
 	OpenOverride   bool                   `protobuf:"varint,8,opt,name=open_override,json=openOverride,proto3" json:"open_override,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Local-time working hours as "HH:MM:SS" (Postgres TIME). Clients that only
+	// care about HH:MM can truncate.
+	OpenTime      string `protobuf:"bytes,9,opt,name=open_time,json=openTime,proto3" json:"open_time,omitempty"`
+	CloseTime     string `protobuf:"bytes,10,opt,name=close_time,json=closeTime,proto3" json:"close_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Exchange) Reset() {
@@ -121,6 +125,129 @@ func (x *Exchange) GetOpenOverride() bool {
 	return false
 }
 
+func (x *Exchange) GetOpenTime() string {
+	if x != nil {
+		return x.OpenTime
+	}
+	return ""
+}
+
+func (x *Exchange) GetCloseTime() string {
+	if x != nil {
+		return x.CloseTime
+	}
+	return ""
+}
+
+// Supervisor-only (gated at the gateway by `secured("supervisor")`; the
+// trading server re-checks against employee_permissions). Flips the
+// exchange's open_override flag — when true, IsOpen returns true regardless
+// of the clock, which lets us exercise the trading flow outside real market
+// hours.
+type SetExchangeOpenOverrideRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExchangeId    int64                  `protobuf:"varint,1,opt,name=exchange_id,json=exchangeId,proto3" json:"exchange_id,omitempty"`
+	OpenOverride  bool                   `protobuf:"varint,2,opt,name=open_override,json=openOverride,proto3" json:"open_override,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,3,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetExchangeOpenOverrideRequest) Reset() {
+	*x = SetExchangeOpenOverrideRequest{}
+	mi := &file_trading_trading_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetExchangeOpenOverrideRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetExchangeOpenOverrideRequest) ProtoMessage() {}
+
+func (x *SetExchangeOpenOverrideRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetExchangeOpenOverrideRequest.ProtoReflect.Descriptor instead.
+func (*SetExchangeOpenOverrideRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *SetExchangeOpenOverrideRequest) GetExchangeId() int64 {
+	if x != nil {
+		return x.ExchangeId
+	}
+	return 0
+}
+
+func (x *SetExchangeOpenOverrideRequest) GetOpenOverride() bool {
+	if x != nil {
+		return x.OpenOverride
+	}
+	return false
+}
+
+func (x *SetExchangeOpenOverrideRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type SetExchangeOpenOverrideResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Exchange      *Exchange              `protobuf:"bytes,1,opt,name=exchange,proto3" json:"exchange,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetExchangeOpenOverrideResponse) Reset() {
+	*x = SetExchangeOpenOverrideResponse{}
+	mi := &file_trading_trading_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetExchangeOpenOverrideResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetExchangeOpenOverrideResponse) ProtoMessage() {}
+
+func (x *SetExchangeOpenOverrideResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetExchangeOpenOverrideResponse.ProtoReflect.Descriptor instead.
+func (*SetExchangeOpenOverrideResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *SetExchangeOpenOverrideResponse) GetExchange() *Exchange {
+	if x != nil {
+		return x.Exchange
+	}
+	return nil
+}
+
 type ListExchangesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -129,7 +256,7 @@ type ListExchangesRequest struct {
 
 func (x *ListExchangesRequest) Reset() {
 	*x = ListExchangesRequest{}
-	mi := &file_trading_trading_proto_msgTypes[1]
+	mi := &file_trading_trading_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -141,7 +268,7 @@ func (x *ListExchangesRequest) String() string {
 func (*ListExchangesRequest) ProtoMessage() {}
 
 func (x *ListExchangesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[1]
+	mi := &file_trading_trading_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -154,7 +281,7 @@ func (x *ListExchangesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExchangesRequest.ProtoReflect.Descriptor instead.
 func (*ListExchangesRequest) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{1}
+	return file_trading_trading_proto_rawDescGZIP(), []int{3}
 }
 
 type ListExchangesResponse struct {
@@ -166,7 +293,7 @@ type ListExchangesResponse struct {
 
 func (x *ListExchangesResponse) Reset() {
 	*x = ListExchangesResponse{}
-	mi := &file_trading_trading_proto_msgTypes[2]
+	mi := &file_trading_trading_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -178,7 +305,7 @@ func (x *ListExchangesResponse) String() string {
 func (*ListExchangesResponse) ProtoMessage() {}
 
 func (x *ListExchangesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[2]
+	mi := &file_trading_trading_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -191,7 +318,7 @@ func (x *ListExchangesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExchangesResponse.ProtoReflect.Descriptor instead.
 func (*ListExchangesResponse) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{2}
+	return file_trading_trading_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ListExchangesResponse) GetExchanges() []*Exchange {
@@ -217,7 +344,7 @@ type Listing struct {
 
 func (x *Listing) Reset() {
 	*x = Listing{}
-	mi := &file_trading_trading_proto_msgTypes[3]
+	mi := &file_trading_trading_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -229,7 +356,7 @@ func (x *Listing) String() string {
 func (*Listing) ProtoMessage() {}
 
 func (x *Listing) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[3]
+	mi := &file_trading_trading_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -242,7 +369,7 @@ func (x *Listing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Listing.ProtoReflect.Descriptor instead.
 func (*Listing) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{3}
+	return file_trading_trading_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Listing) GetId() int64 {
@@ -309,7 +436,7 @@ type ListListingsRequest struct {
 
 func (x *ListListingsRequest) Reset() {
 	*x = ListListingsRequest{}
-	mi := &file_trading_trading_proto_msgTypes[4]
+	mi := &file_trading_trading_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -321,7 +448,7 @@ func (x *ListListingsRequest) String() string {
 func (*ListListingsRequest) ProtoMessage() {}
 
 func (x *ListListingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[4]
+	mi := &file_trading_trading_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -334,7 +461,7 @@ func (x *ListListingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListListingsRequest.ProtoReflect.Descriptor instead.
 func (*ListListingsRequest) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{4}
+	return file_trading_trading_proto_rawDescGZIP(), []int{6}
 }
 
 type ListListingsResponse struct {
@@ -346,7 +473,7 @@ type ListListingsResponse struct {
 
 func (x *ListListingsResponse) Reset() {
 	*x = ListListingsResponse{}
-	mi := &file_trading_trading_proto_msgTypes[5]
+	mi := &file_trading_trading_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -358,7 +485,7 @@ func (x *ListListingsResponse) String() string {
 func (*ListListingsResponse) ProtoMessage() {}
 
 func (x *ListListingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[5]
+	mi := &file_trading_trading_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -371,7 +498,7 @@ func (x *ListListingsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListListingsResponse.ProtoReflect.Descriptor instead.
 func (*ListListingsResponse) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{5}
+	return file_trading_trading_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListListingsResponse) GetListings() []*Listing {
@@ -403,7 +530,7 @@ type CreateOrderRequest struct {
 
 func (x *CreateOrderRequest) Reset() {
 	*x = CreateOrderRequest{}
-	mi := &file_trading_trading_proto_msgTypes[6]
+	mi := &file_trading_trading_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -415,7 +542,7 @@ func (x *CreateOrderRequest) String() string {
 func (*CreateOrderRequest) ProtoMessage() {}
 
 func (x *CreateOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[6]
+	mi := &file_trading_trading_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -428,7 +555,7 @@ func (x *CreateOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrderRequest.ProtoReflect.Descriptor instead.
 func (*CreateOrderRequest) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{6}
+	return file_trading_trading_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateOrderRequest) GetListingId() int64 {
@@ -518,7 +645,7 @@ type CreateOrderResponse struct {
 
 func (x *CreateOrderResponse) Reset() {
 	*x = CreateOrderResponse{}
-	mi := &file_trading_trading_proto_msgTypes[7]
+	mi := &file_trading_trading_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -530,7 +657,7 @@ func (x *CreateOrderResponse) String() string {
 func (*CreateOrderResponse) ProtoMessage() {}
 
 func (x *CreateOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[7]
+	mi := &file_trading_trading_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -543,7 +670,7 @@ func (x *CreateOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrderResponse.ProtoReflect.Descriptor instead.
 func (*CreateOrderResponse) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{7}
+	return file_trading_trading_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CreateOrderResponse) GetOrderId() int64 {
@@ -564,7 +691,7 @@ var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
 	"\n" +
-	"\x15trading/trading.proto\x12\atrading\"\xe6\x01\n" +
+	"\x15trading/trading.proto\x12\atrading\"\xa2\x02\n" +
 	"\bExchange\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -573,7 +700,18 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x06polity\x18\x05 \x01(\tR\x06polity\x12\x1a\n" +
 	"\bcurrency\x18\x06 \x01(\tR\bcurrency\x12(\n" +
 	"\x10time_zone_offset\x18\a \x01(\tR\x0etimeZoneOffset\x12#\n" +
-	"\ropen_override\x18\b \x01(\bR\fopenOverride\"\x16\n" +
+	"\ropen_override\x18\b \x01(\bR\fopenOverride\x12\x1b\n" +
+	"\topen_time\x18\t \x01(\tR\bopenTime\x12\x1d\n" +
+	"\n" +
+	"close_time\x18\n" +
+	" \x01(\tR\tcloseTime\"\x89\x01\n" +
+	"\x1eSetExchangeOpenOverrideRequest\x12\x1f\n" +
+	"\vexchange_id\x18\x01 \x01(\x03R\n" +
+	"exchangeId\x12#\n" +
+	"\ropen_override\x18\x02 \x01(\bR\fopenOverride\x12!\n" +
+	"\fcaller_email\x18\x03 \x01(\tR\vcallerEmail\"P\n" +
+	"\x1fSetExchangeOpenOverrideResponse\x12-\n" +
+	"\bexchange\x18\x01 \x01(\v2\x11.trading.ExchangeR\bexchange\"\x16\n" +
 	"\x14ListExchangesRequest\"H\n" +
 	"\x15ListExchangesResponse\x12/\n" +
 	"\texchanges\x18\x01 \x03(\v2\x11.trading.ExchangeR\texchanges\"\xee\x01\n" +
@@ -609,11 +747,12 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x06margin\x18\v \x01(\bR\x06margin\"H\n" +
 	"\x13CreateOrderResponse\x12\x19\n" +
 	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status2\xf7\x01\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status2\xe5\x02\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12H\n" +
-	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
+	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponse\x12l\n" +
+	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
 	file_trading_trading_proto_rawDescOnce sync.Once
@@ -627,31 +766,36 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_trading_trading_proto_goTypes = []any{
-	(*Exchange)(nil),              // 0: trading.Exchange
-	(*ListExchangesRequest)(nil),  // 1: trading.ListExchangesRequest
-	(*ListExchangesResponse)(nil), // 2: trading.ListExchangesResponse
-	(*Listing)(nil),               // 3: trading.Listing
-	(*ListListingsRequest)(nil),   // 4: trading.ListListingsRequest
-	(*ListListingsResponse)(nil),  // 5: trading.ListListingsResponse
-	(*CreateOrderRequest)(nil),    // 6: trading.CreateOrderRequest
-	(*CreateOrderResponse)(nil),   // 7: trading.CreateOrderResponse
+	(*Exchange)(nil),                        // 0: trading.Exchange
+	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
+	(*SetExchangeOpenOverrideResponse)(nil), // 2: trading.SetExchangeOpenOverrideResponse
+	(*ListExchangesRequest)(nil),            // 3: trading.ListExchangesRequest
+	(*ListExchangesResponse)(nil),           // 4: trading.ListExchangesResponse
+	(*Listing)(nil),                         // 5: trading.Listing
+	(*ListListingsRequest)(nil),             // 6: trading.ListListingsRequest
+	(*ListListingsResponse)(nil),            // 7: trading.ListListingsResponse
+	(*CreateOrderRequest)(nil),              // 8: trading.CreateOrderRequest
+	(*CreateOrderResponse)(nil),             // 9: trading.CreateOrderResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
-	0, // 0: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
-	3, // 1: trading.ListListingsResponse.listings:type_name -> trading.Listing
-	1, // 2: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
-	4, // 3: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	6, // 4: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	2, // 5: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	5, // 6: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	7, // 7: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	5, // [5:8] is the sub-list for method output_type
-	2, // [2:5] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	0, // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
+	0, // 1: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
+	5, // 2: trading.ListListingsResponse.listings:type_name -> trading.Listing
+	3, // 3: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
+	6, // 4: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	8, // 5: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	1, // 6: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
+	4, // 7: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7, // 8: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9, // 9: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	2, // 10: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	7, // [7:11] is the sub-list for method output_type
+	3, // [3:7] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_trading_trading_proto_init() }
@@ -665,7 +809,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -19,9 +19,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TradingService_ListExchanges_FullMethodName = "/trading.TradingService/ListExchanges"
-	TradingService_ListListings_FullMethodName  = "/trading.TradingService/ListListings"
-	TradingService_CreateOrder_FullMethodName   = "/trading.TradingService/CreateOrder"
+	TradingService_ListExchanges_FullMethodName           = "/trading.TradingService/ListExchanges"
+	TradingService_ListListings_FullMethodName            = "/trading.TradingService/ListListings"
+	TradingService_CreateOrder_FullMethodName             = "/trading.TradingService/CreateOrder"
+	TradingService_SetExchangeOpenOverride_FullMethodName = "/trading.TradingService/SetExchangeOpenOverride"
 )
 
 // TradingServiceClient is the client API for TradingService service.
@@ -31,6 +32,7 @@ type TradingServiceClient interface {
 	ListExchanges(ctx context.Context, in *ListExchangesRequest, opts ...grpc.CallOption) (*ListExchangesResponse, error)
 	ListListings(ctx context.Context, in *ListListingsRequest, opts ...grpc.CallOption) (*ListListingsResponse, error)
 	CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error)
+	SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error)
 }
 
 type tradingServiceClient struct {
@@ -71,6 +73,16 @@ func (c *tradingServiceClient) CreateOrder(ctx context.Context, in *CreateOrderR
 	return out, nil
 }
 
+func (c *tradingServiceClient) SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetExchangeOpenOverrideResponse)
+	err := c.cc.Invoke(ctx, TradingService_SetExchangeOpenOverride_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TradingServiceServer is the server API for TradingService service.
 // All implementations must embed UnimplementedTradingServiceServer
 // for forward compatibility.
@@ -78,6 +90,7 @@ type TradingServiceServer interface {
 	ListExchanges(context.Context, *ListExchangesRequest) (*ListExchangesResponse, error)
 	ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error)
 	CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error)
+	SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
 
@@ -96,6 +109,9 @@ func (UnimplementedTradingServiceServer) ListListings(context.Context, *ListList
 }
 func (UnimplementedTradingServiceServer) CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateOrder not implemented")
+}
+func (UnimplementedTradingServiceServer) SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetExchangeOpenOverride not implemented")
 }
 func (UnimplementedTradingServiceServer) mustEmbedUnimplementedTradingServiceServer() {}
 func (UnimplementedTradingServiceServer) testEmbeddedByValue()                        {}
@@ -172,6 +188,24 @@ func _TradingService_CreateOrder_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_SetExchangeOpenOverride_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetExchangeOpenOverrideRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).SetExchangeOpenOverride(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_SetExchangeOpenOverride_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).SetExchangeOpenOverride(ctx, req.(*SetExchangeOpenOverrideRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TradingService_ServiceDesc is the grpc.ServiceDesc for TradingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -190,6 +224,10 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateOrder",
 			Handler:    _TradingService_CreateOrder_Handler,
+		},
+		{
+			MethodName: "SetExchangeOpenOverride",
+			Handler:    _TradingService_SetExchangeOpenOverride_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/gateway/exchange.go
+++ b/internal/gateway/exchange.go
@@ -1,9 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
+	"strconv"
+	"time"
 
 	exchangepb "github.com/RAF-SI-2025/Banka-3-Backend/gen/exchange"
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/status"
 )
@@ -41,6 +45,55 @@ func (s *Server) GetExchangeRates(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, rates)
+}
+
+type setExchangeOpenOverrideBody struct {
+	OpenOverride *bool `json:"open_override" binding:"required"`
+}
+
+// SetExchangeOpenOverride flips the open_override flag on an exchange.
+// Supervisor-only — route is gated at `secured("supervisor")` and the trading
+// RPC re-checks the caller's permissions against employee_permissions.
+func (s *Server) SetExchangeOpenOverride(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "exchange id must be a positive integer"})
+		return
+	}
+
+	var body setExchangeOpenOverrideBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.SetExchangeOpenOverride(ctx, &tradingpb.SetExchangeOpenOverrideRequest{
+		ExchangeId:   id,
+		OpenOverride: *body.OpenOverride,
+		CallerEmail:  c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	ex := resp.Exchange
+	c.JSON(http.StatusOK, gin.H{
+		"id":               ex.Id,
+		"name":             ex.Name,
+		"acronym":          ex.Acronym,
+		"mic_code":         ex.MicCode,
+		"polity":           ex.Polity,
+		"currency":         ex.Currency,
+		"time_zone_offset": ex.TimeZoneOffset,
+		"open_time":        ex.OpenTime,
+		"close_time":       ex.CloseTime,
+		"open_override":    ex.OpenOverride,
+	})
 }
 
 func (s *Server) ConvertMoney(c *gin.Context) {

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -138,6 +138,11 @@ func SetupApi(router *gin.Engine, server *Server) {
 	{
 		orders.POST("", server.CreateOrder)
 	}
+
+	// Supervisor-only toggle used to exercise the trading flow outside real
+	// market hours (see spec p.40 and issue #194). Admin bypass still applies
+	// through `secured("supervisor")`.
+	api.PATCH("/exchanges/:id/open-override", auth, secured("supervisor"), server.SetExchangeOpenOverride)
 }
 
 func (s *Server) Healthz(c *gin.Context) {

--- a/internal/trading/hours.go
+++ b/internal/trading/hours.go
@@ -1,0 +1,142 @@
+package trading
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// polityHolidays lists fixed 2026 market holidays per polity. The spec (p.40)
+// lets us simplify by treating every exchange in the same polity as sharing a
+// calendar, so we key by polity rather than MIC. Hardcoded (not a table) — we
+// only need a handful of dates to exercise the open-check logic.
+var polityHolidays = map[string]map[string]struct{}{
+	"United States": {
+		"2026-01-01": {}, // New Year's Day
+		"2026-01-19": {}, // MLK Day
+		"2026-02-16": {}, // Presidents' Day
+		"2026-04-03": {}, // Good Friday
+		"2026-05-25": {}, // Memorial Day
+		"2026-06-19": {}, // Juneteenth
+		"2026-07-03": {}, // Independence Day (observed)
+		"2026-09-07": {}, // Labor Day
+		"2026-11-26": {}, // Thanksgiving
+		"2026-12-25": {}, // Christmas
+	},
+	"United Kingdom": {
+		"2026-01-01": {},
+		"2026-04-03": {}, // Good Friday
+		"2026-04-06": {}, // Easter Monday
+		"2026-05-04": {}, // Early May Bank Holiday
+		"2026-05-25": {}, // Spring Bank Holiday
+		"2026-08-31": {}, // Summer Bank Holiday
+		"2026-12-25": {},
+		"2026-12-28": {}, // Boxing Day (observed)
+	},
+	"Japan": {
+		"2026-01-01": {},
+		"2026-01-02": {},
+		"2026-01-03": {},
+		"2026-12-31": {},
+	},
+}
+
+// parseTZOffset turns "±HH:MM" into a fixed-offset *time.Location. Exchanges
+// store a static offset (no DST), so FixedZone is sufficient. On malformed
+// input we fall back to UTC so IsOpen stays a best-effort "closed" rather
+// than crashing the caller.
+func parseTZOffset(s string) *time.Location {
+	s = strings.TrimSpace(s)
+	if len(s) < 3 {
+		return time.UTC
+	}
+	sign := 1
+	switch s[0] {
+	case '+':
+		s = s[1:]
+	case '-':
+		sign = -1
+		s = s[1:]
+	}
+	parts := strings.SplitN(s, ":", 2)
+	h, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return time.UTC
+	}
+	m := 0
+	if len(parts) == 2 {
+		m, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return time.UTC
+		}
+	}
+	return time.FixedZone(s, sign*(h*3600+m*60))
+}
+
+// parseClockHM parses "HH:MM" or "HH:MM:SS" into minute-of-day.
+func parseClockHM(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("invalid time %q", s)
+	}
+	h, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, err
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, err
+	}
+	return h*60 + m, nil
+}
+
+// withinClockWindow returns (open, closes, stillTrading) where stillTrading
+// is true iff the local time is inside the [open, close) window, weekend and
+// holidays excluded. open_override is NOT consulted here — callers handle it.
+func withinClockWindow(ex Exchange, t time.Time) (openMin, closeMin, nowMin int, trading bool) {
+	loc := parseTZOffset(ex.TimeZoneOffset)
+	local := t.In(loc)
+	if local.Weekday() == time.Saturday || local.Weekday() == time.Sunday {
+		return 0, 0, 0, false
+	}
+	if _, hit := polityHolidays[ex.Polity][local.Format("2006-01-02")]; hit {
+		return 0, 0, 0, false
+	}
+	openMin, err := parseClockHM(ex.OpenTime)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	closeMin, err = parseClockHM(ex.CloseTime)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	nowMin = local.Hour()*60 + local.Minute()
+	trading = nowMin >= openMin && nowMin < closeMin
+	return openMin, closeMin, nowMin, trading
+}
+
+// IsOpen reports whether the exchange accepts orders at instant t. When
+// open_override is set (supervisor toggle for testing outside market hours)
+// the exchange is always open; otherwise we check TZ, weekends, holidays,
+// and working hours.
+func IsOpen(ex Exchange, t time.Time) bool {
+	if ex.OpenOverride {
+		return true
+	}
+	_, _, _, trading := withinClockWindow(ex, t)
+	return trading
+}
+
+// IsAfterHours reports whether an order placed at t should be flagged as
+// after-hours per spec p.50: it must land *during* the open window AND within
+// the last 4h before close. open_override does NOT count — after-hours is a
+// clock-based fact, and the override is only a testing convenience.
+func IsAfterHours(ex Exchange, t time.Time) bool {
+	_, closeMin, nowMin, trading := withinClockWindow(ex, t)
+	if !trading {
+		return false
+	}
+	return closeMin-nowMin < 4*60
+}

--- a/internal/trading/hours_test.go
+++ b/internal/trading/hours_test.go
@@ -1,0 +1,173 @@
+package trading
+
+import (
+	"testing"
+	"time"
+)
+
+// nyse mirrors the seeded NYSE row: 09:30–16:00 local, UTC-05:00, US calendar.
+func nyse() Exchange {
+	return Exchange{
+		MICCode:        "XNYS",
+		Polity:         "United States",
+		TimeZoneOffset: "-05:00",
+		OpenTime:       "09:30",
+		CloseTime:      "16:00",
+	}
+}
+
+// tse mirrors Tokyo: 09:00–15:00 local, UTC+09:00, JP calendar. Included so
+// we cover a positive offset too — easy to get signs wrong.
+func tse() Exchange {
+	return Exchange{
+		MICCode:        "XTKS",
+		Polity:         "Japan",
+		TimeZoneOffset: "+09:00",
+		OpenTime:       "09:00",
+		CloseTime:      "15:00",
+	}
+}
+
+func TestIsOpen_WithinHours(t *testing.T) {
+	ex := nyse()
+	// Wed 2026-04-22, 14:00 New York → 19:00 UTC
+	now := time.Date(2026, 4, 22, 19, 0, 0, 0, time.UTC)
+	if !IsOpen(ex, now) {
+		t.Fatalf("expected open at NY 14:00 Wed")
+	}
+}
+
+func TestIsOpen_BeforeOpen(t *testing.T) {
+	ex := nyse()
+	// Wed 2026-04-22, 09:29 New York → 13:29 UTC (one minute before open)
+	now := time.Date(2026, 4, 22, 13, 29, 0, 0, time.UTC)
+	if IsOpen(ex, now) {
+		t.Fatalf("expected closed at NY 09:29")
+	}
+}
+
+func TestIsOpen_AtCloseIsClosed(t *testing.T) {
+	ex := nyse()
+	// Window is [open, close), so 16:00 is already closed
+	now := time.Date(2026, 4, 22, 21, 0, 0, 0, time.UTC) // NY 16:00
+	if IsOpen(ex, now) {
+		t.Fatalf("expected closed at NY 16:00 (exclusive)")
+	}
+}
+
+func TestIsOpen_Weekend(t *testing.T) {
+	ex := nyse()
+	// Sat 2026-04-25, mid-day NY
+	now := time.Date(2026, 4, 25, 18, 0, 0, 0, time.UTC)
+	if IsOpen(ex, now) {
+		t.Fatalf("expected closed on Saturday")
+	}
+}
+
+func TestIsOpen_Holiday(t *testing.T) {
+	ex := nyse()
+	// Christmas 2026-12-25 is a Friday, 14:00 NY
+	now := time.Date(2026, 12, 25, 19, 0, 0, 0, time.UTC)
+	if IsOpen(ex, now) {
+		t.Fatalf("expected closed on Christmas")
+	}
+}
+
+func TestIsOpen_Override(t *testing.T) {
+	ex := nyse()
+	ex.OpenOverride = true
+	// Sat 3am NY — normally closed hard, but override wins
+	now := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+	if !IsOpen(ex, now) {
+		t.Fatalf("open_override must force open")
+	}
+}
+
+func TestIsOpen_TimezonePositiveOffset(t *testing.T) {
+	ex := tse()
+	// Wed 2026-04-22, 10:00 Tokyo → 01:00 UTC same day
+	now := time.Date(2026, 4, 22, 1, 0, 0, 0, time.UTC)
+	if !IsOpen(ex, now) {
+		t.Fatalf("expected open at Tokyo 10:00 Wed")
+	}
+	// 16:00 Tokyo → 07:00 UTC — closed (window is 09–15)
+	closed := time.Date(2026, 4, 22, 7, 0, 0, 0, time.UTC)
+	if IsOpen(ex, closed) {
+		t.Fatalf("expected closed at Tokyo 16:00")
+	}
+}
+
+func TestIsAfterHours_WithinLastFourHours(t *testing.T) {
+	ex := nyse()
+	// Wed 13:00 NY → 2h before 15:00? Actually close is 16:00, so 13:00 is 3h
+	// before close → after-hours.
+	now := time.Date(2026, 4, 22, 18, 0, 0, 0, time.UTC) // NY 13:00
+	if !IsAfterHours(ex, now) {
+		t.Fatalf("expected after-hours at NY 13:00 (3h to close)")
+	}
+}
+
+func TestIsAfterHours_NotYetInWindow(t *testing.T) {
+	ex := nyse()
+	// NY 10:00 — 6h to close → not after-hours
+	now := time.Date(2026, 4, 22, 15, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex, now) {
+		t.Fatalf("expected false at NY 10:00 (6h to close)")
+	}
+}
+
+func TestIsAfterHours_OutsideOpen(t *testing.T) {
+	ex := nyse()
+	// NY 17:00 — market closed
+	now := time.Date(2026, 4, 22, 22, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex, now) {
+		t.Fatalf("after_hours only applies during the open window")
+	}
+}
+
+func TestIsAfterHours_BoundaryExactlyFourHours(t *testing.T) {
+	ex := nyse()
+	// Close 16:00, so 12:00 NY is exactly 4h to close — spec says "less than
+	// 4h", so 4h exactly is NOT after-hours.
+	now := time.Date(2026, 4, 22, 17, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex, now) {
+		t.Fatalf("exactly 4h to close should not count as after-hours")
+	}
+	// 12:01 NY → 3h59m to close → after-hours
+	now = time.Date(2026, 4, 22, 17, 1, 0, 0, time.UTC)
+	if !IsAfterHours(ex, now) {
+		t.Fatalf("3h59m to close should be after-hours")
+	}
+}
+
+func TestIsAfterHours_OverrideDoesNotApply(t *testing.T) {
+	ex := nyse()
+	ex.OpenOverride = true
+	// Sat 3am NY, override is on — IsOpen=true but IsAfterHours=false because
+	// we're not in the clock window at all.
+	now := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex, now) {
+		t.Fatalf("after_hours is clock-based, not override-based")
+	}
+}
+
+func TestParseTZOffset(t *testing.T) {
+	cases := []struct {
+		in   string
+		secs int
+	}{
+		{"+00:00", 0},
+		{"-05:00", -5 * 3600},
+		{"+09:00", 9 * 3600},
+		{"+05:30", 5*3600 + 30*60},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			loc := parseTZOffset(c.in)
+			_, off := time.Now().In(loc).Zone()
+			if off != c.secs {
+				t.Errorf("offset %s: got %d, want %d", c.in, off, c.secs)
+			}
+		})
+	}
+}

--- a/internal/trading/models.go
+++ b/internal/trading/models.go
@@ -50,7 +50,12 @@ type Exchange struct {
 	Polity         string `gorm:"column:polity;type:varchar(127);not null"`
 	Currency       string `gorm:"column:currency;type:varchar(8);not null"`
 	TimeZoneOffset string `gorm:"column:time_zone_offset;type:varchar(8);not null"`
-	OpenOverride   bool   `gorm:"column:open_override;not null;default:false"`
+	// Local-time working hours. Stored as Postgres TIME; surfaced as "HH:MM:SS"
+	// strings so that IsOpen can parse them directly without dragging in a
+	// gorm-specific time-of-day type.
+	OpenTime     string `gorm:"column:open_time;type:time;not null"`
+	CloseTime    string `gorm:"column:close_time;type:time;not null"`
+	OpenOverride bool   `gorm:"column:open_override;not null;default:false"`
 }
 
 func (Exchange) TableName() string { return "exchanges" }

--- a/internal/trading/orders.go
+++ b/internal/trading/orders.go
@@ -77,12 +77,12 @@ func marketReferencePrice(ot OrderType, req *tradingpb.CreateOrderRequest) int64
 	return 0
 }
 
-// resolveInstrumentCurrency returns the currency in which the instrument
-// trades, so it can be compared to the debit account's currency. Listings
-// inherit currency from their exchange; options inherit from their underlying
-// stock's exchange; forex pairs use the quote currency (that's what the user
-// pays out of).
-func (s *Server) resolveInstrumentCurrency(req *tradingpb.CreateOrderRequest) (string, error) {
+// resolveInstrument returns (exchange, currency) for the order's instrument.
+// Listings inherit both from their exchange; options follow the underlying
+// stock's listing to its exchange; forex pairs aren't tied to any exchange
+// and use the quote currency (exchange is returned as nil). Callers that
+// need the clock (IsOpen / IsAfterHours) should skip forex.
+func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*Exchange, string, error) {
 	set := 0
 	if req.ListingId != 0 {
 		set++
@@ -94,7 +94,7 @@ func (s *Server) resolveInstrumentCurrency(req *tradingpb.CreateOrderRequest) (s
 		set++
 	}
 	if set != 1 {
-		return "", status.Error(codes.InvalidArgument, "exactly one of listing_id, option_id, forex_pair_id must be set")
+		return nil, "", status.Error(codes.InvalidArgument, "exactly one of listing_id, option_id, forex_pair_id must be set")
 	}
 
 	switch {
@@ -102,46 +102,46 @@ func (s *Server) resolveInstrumentCurrency(req *tradingpb.CreateOrderRequest) (s
 		var listing Listing
 		if err := s.db.First(&listing, req.ListingId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return "", status.Error(codes.NotFound, "listing not found")
+				return nil, "", status.Error(codes.NotFound, "listing not found")
 			}
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
 		var exch Exchange
 		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
-		return exch.Currency, nil
+		return &exch, exch.Currency, nil
 
 	case req.OptionId != 0:
 		var opt Option
 		if err := s.db.First(&opt, req.OptionId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return "", status.Error(codes.NotFound, "option not found")
+				return nil, "", status.Error(codes.NotFound, "option not found")
 			}
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
 		var listing Listing
 		if err := s.db.Where("stock_id = ?", opt.StockID).First(&listing).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return "", status.Error(codes.FailedPrecondition, "underlying stock has no listing")
+				return nil, "", status.Error(codes.FailedPrecondition, "underlying stock has no listing")
 			}
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
 		var exch Exchange
 		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
-		return exch.Currency, nil
+		return &exch, exch.Currency, nil
 
-	default: // forex pair
+	default: // forex pair — no exchange
 		var fx ForexPair
 		if err := s.db.First(&fx, req.ForexPairId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return "", status.Error(codes.NotFound, "forex pair not found")
+				return nil, "", status.Error(codes.NotFound, "forex pair not found")
 			}
-			return "", status.Errorf(codes.Internal, "%v", err)
+			return nil, "", status.Errorf(codes.Internal, "%v", err)
 		}
-		return fx.QuoteCurrency, nil
+		return nil, fx.QuoteCurrency, nil
 	}
 }
 

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -3,6 +3,8 @@ package trading
 import (
 	"context"
 	"errors"
+	"strings"
+	"time"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
 	"github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
@@ -32,18 +34,24 @@ func (s *Server) ListExchanges(_ context.Context, _ *tradingpb.ListExchangesRequ
 
 	out := make([]*tradingpb.Exchange, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, &tradingpb.Exchange{
-			Id:             r.ID,
-			Name:           r.Name,
-			Acronym:        r.Acronym,
-			MicCode:        r.MICCode,
-			Polity:         r.Polity,
-			Currency:       r.Currency,
-			TimeZoneOffset: r.TimeZoneOffset,
-			OpenOverride:   r.OpenOverride,
-		})
+		out = append(out, exchangeToProto(r))
 	}
 	return &tradingpb.ListExchangesResponse{Exchanges: out}, nil
+}
+
+func exchangeToProto(r Exchange) *tradingpb.Exchange {
+	return &tradingpb.Exchange{
+		Id:             r.ID,
+		Name:           r.Name,
+		Acronym:        r.Acronym,
+		MicCode:        r.MICCode,
+		Polity:         r.Polity,
+		Currency:       r.Currency,
+		TimeZoneOffset: r.TimeZoneOffset,
+		OpenTime:       r.OpenTime,
+		CloseTime:      r.CloseTime,
+		OpenOverride:   r.OpenOverride,
+	}
 }
 
 func (s *Server) ListListings(_ context.Context, _ *tradingpb.ListListingsRequest) (*tradingpb.ListListingsResponse, error) {
@@ -111,7 +119,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		return nil, err
 	}
 
-	instrumentCurrency, err := s.resolveInstrumentCurrency(req)
+	exch, instrumentCurrency, err := s.resolveInstrument(req)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +128,10 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			"account currency %s does not match instrument currency %s",
 			acc.Currency, instrumentCurrency)
 	}
+
+	// after_hours is an exchange-clock concept; forex pairs have no exchange
+	// and always leave the flag false.
+	afterHours := exch != nil && IsAfterHours(*exch, time.Now())
 
 	pricePerUnit := marketReferencePrice(orderType, req)
 	order := Order{
@@ -130,6 +142,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		ContractSize:      1,
 		PricePerUnit:      pricePerUnit,
 		RemainingPortions: req.Quantity,
+		AfterHours:        afterHours,
 		AllOrNone:         req.AllOrNone,
 		Margin:            req.Margin,
 	}
@@ -176,4 +189,50 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		OrderId: order.ID,
 		Status:  string(order.Status),
 	}, nil
+}
+
+// SetExchangeOpenOverride flips exchanges.open_override so the trading flow
+// can be exercised outside real market hours. Supervisor-only: the gateway
+// gates the route with `secured("supervisor")`, and we re-check here as
+// defense-in-depth (same pattern as UpdateEmployeeTradingLimit).
+func (s *Server) SetExchangeOpenOverride(_ context.Context, req *tradingpb.SetExchangeOpenOverrideRequest) (*tradingpb.SetExchangeOpenOverrideResponse, error) {
+	if req.ExchangeId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "exchange_id required")
+	}
+	if !callerIsSupervisor(s.db, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "only admins and supervisors may toggle open_override")
+	}
+
+	var exch Exchange
+	if err := s.db.First(&exch, req.ExchangeId).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "exchange not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if err := s.db.Model(&exch).Update("open_override", req.OpenOverride).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	exch.OpenOverride = req.OpenOverride
+
+	return &tradingpb.SetExchangeOpenOverrideResponse{Exchange: exchangeToProto(exch)}, nil
+}
+
+// callerIsSupervisor checks whether the given employee email has `admin` or
+// `supervisor` in employee_permissions. Trading lives in the bank process so
+// it can hit the same DB directly rather than calling the user service.
+func callerIsSupervisor(db *gorm.DB, email string) bool {
+	if strings.TrimSpace(email) == "" {
+		return false
+	}
+	var count int64
+	err := db.Table("employees").
+		Joins("JOIN employee_permissions ep ON ep.employee_id = employees.id").
+		Joins("JOIN permissions p ON p.id = ep.permission_id").
+		Where("employees.email = ? AND p.name IN (?)", email, []string{"admin", "supervisor"}).
+		Count(&count).Error
+	if err != nil {
+		return false
+	}
+	return count > 0
 }

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -8,6 +8,7 @@ service TradingService {
   rpc ListExchanges(ListExchangesRequest) returns (ListExchangesResponse);
   rpc ListListings(ListListingsRequest) returns (ListListingsResponse);
   rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);
+  rpc SetExchangeOpenOverride(SetExchangeOpenOverrideRequest) returns (SetExchangeOpenOverrideResponse);
 }
 
 message Exchange {
@@ -19,6 +20,25 @@ message Exchange {
   string currency = 6;
   string time_zone_offset = 7;
   bool open_override = 8;
+  // Local-time working hours as "HH:MM:SS" (Postgres TIME). Clients that only
+  // care about HH:MM can truncate.
+  string open_time = 9;
+  string close_time = 10;
+}
+
+// Supervisor-only (gated at the gateway by `secured("supervisor")`; the
+// trading server re-checks against employee_permissions). Flips the
+// exchange's open_override flag — when true, IsOpen returns true regardless
+// of the clock, which lets us exercise the trading flow outside real market
+// hours.
+message SetExchangeOpenOverrideRequest {
+  int64 exchange_id = 1;
+  bool open_override = 2;
+  string caller_email = 3;
+}
+
+message SetExchangeOpenOverrideResponse {
+  Exchange exchange = 1;
 }
 
 message ListExchangesRequest {}

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -289,6 +289,10 @@ CREATE TABLE IF NOT EXISTS exchange_rates (
 -- Trading: securities, listings, orders
 -- ============================================================================
 
+-- open_time / close_time are the exchange's local-time working hours
+-- (see spec p.40). All exchanges within the same polity share the same
+-- hours and holiday calendar; the holiday table is hardcoded in Go
+-- (internal/trading/hours.go) rather than modeled here.
 CREATE TABLE IF NOT EXISTS exchanges (
     id                  BIGSERIAL       PRIMARY KEY,
     name                VARCHAR(127)    NOT NULL,
@@ -297,6 +301,8 @@ CREATE TABLE IF NOT EXISTS exchanges (
     polity              VARCHAR(127)    NOT NULL,
     currency            VARCHAR(8)      NOT NULL REFERENCES currencies(label) ON UPDATE CASCADE ON DELETE RESTRICT,
     time_zone_offset    VARCHAR(8)      NOT NULL,
+    open_time           TIME            NOT NULL DEFAULT '09:30',
+    close_time          TIME            NOT NULL DEFAULT '16:00',
     open_override       BOOLEAN         NOT NULL DEFAULT FALSE,
     UNIQUE(mic_code)
 );

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -698,10 +698,10 @@ ON CONFLICT DO NOTHING;
 -- Trading: a handful of exchanges so the schema is exercised end-to-end.
 -- Listings/orders are seeded in follow-up issues that plug in real data.
 -------------------------------------------------------------------------------
-INSERT INTO exchanges (name, acronym, mic_code, polity, currency, time_zone_offset)
+INSERT INTO exchanges (name, acronym, mic_code, polity, currency, time_zone_offset, open_time, close_time)
 VALUES
-    ('New York Stock Exchange', 'NYSE', 'XNYS', 'United States', 'USD', '-05:00'),
-    ('NASDAQ',                  'NASDAQ', 'XNAS', 'United States', 'USD', '-05:00'),
-    ('London Stock Exchange',   'LSE',  'XLON', 'United Kingdom', 'GBP', '+00:00'),
-    ('Tokyo Stock Exchange',    'TSE',  'XTKS', 'Japan',          'JPY', '+09:00')
+    ('New York Stock Exchange', 'NYSE',   'XNYS', 'United States',  'USD', '-05:00', '09:30', '16:00'),
+    ('NASDAQ',                  'NASDAQ', 'XNAS', 'United States',  'USD', '-05:00', '09:30', '16:00'),
+    ('London Stock Exchange',   'LSE',    'XLON', 'United Kingdom', 'GBP', '+00:00', '08:00', '16:30'),
+    ('Tokyo Stock Exchange',    'TSE',    'XTKS', 'Japan',          'JPY', '+09:00', '09:00', '15:00')
 ON CONFLICT (mic_code) DO NOTHING;


### PR DESCRIPTION
Closes #194.

## Summary
- `exchanges` gains `open_time`/`close_time`; seed fills real local hours for NYSE/NASDAQ/LSE/TSE
- `internal/trading/hours.go` adds `IsOpen(ex, t)` and `IsAfterHours(ex, t)` — TZ via fixed offset, weekends/holidays closed, per-polity 2026 holiday map hardcoded per the issue
- `open_override=true` forces `IsOpen`→true (testing outside market hours). `IsAfterHours` stays clock-based — override does NOT mark after-hours
- New `SetExchangeOpenOverride` RPC + `PATCH /api/exchanges/:id/open-override` gated by `secured("supervisor")`; server re-checks `admin`/`supervisor` via `employee_permissions` as defense-in-depth (same pattern as the trading-limits PATCH)
- `CreateOrder` now sets `orders.after_hours` using `IsAfterHours` — skipped for forex since forex pairs aren't tied to an exchange
- Refactored `resolveInstrumentCurrency` → `resolveInstrument` so it returns the `Exchange` alongside the currency (needed for the clock check)

Unblocks #189 (reject market orders after close) — it can just call `IsOpen`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] `hours_test.go` covers in-window, pre-open, close-exclusive, weekend, holiday, override, positive-offset TZ, after-hours boundaries, and that override does not mark after-hours
- [ ] Manual: `make schema && make seed`, then `PATCH /api/exchanges/1/open-override` as a supervisor → confirm subsequent `CreateOrder` during seeded closed hours is still accepted with `after_hours=false`
- [ ] Manual: with override off, place an order during the last 4h of the NYSE window → `orders.after_hours = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)