### PR TITLE
feat(trading): listing read API through the gateway (#196)

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -328,18 +328,35 @@ func (x *ListExchangesResponse) GetExchanges() []*Exchange {
 	return nil
 }
 
+// Listing carries denormalized instrument identity (ticker/name/type) and
+// server-derived analytics fields alongside the row itself so that clients
+// do not need to join or compute anything. security_type is either "stock"
+// or "future" — the listings table only references those two. Futures-only
+// fields (settlement_date_unix, contract_size) are 0 for stock listings.
 type Listing struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Id              int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	ExchangeId      int64                  `protobuf:"varint,2,opt,name=exchange_id,json=exchangeId,proto3" json:"exchange_id,omitempty"`
-	StockId         int64                  `protobuf:"varint,3,opt,name=stock_id,json=stockId,proto3" json:"stock_id,omitempty"`
-	FutureId        int64                  `protobuf:"varint,4,opt,name=future_id,json=futureId,proto3" json:"future_id,omitempty"`
-	Price           int64                  `protobuf:"varint,5,opt,name=price,proto3" json:"price,omitempty"`
-	AskPrice        int64                  `protobuf:"varint,6,opt,name=ask_price,json=askPrice,proto3" json:"ask_price,omitempty"`
-	BidPrice        int64                  `protobuf:"varint,7,opt,name=bid_price,json=bidPrice,proto3" json:"bid_price,omitempty"`
-	LastRefreshUnix int64                  `protobuf:"varint,8,opt,name=last_refresh_unix,json=lastRefreshUnix,proto3" json:"last_refresh_unix,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Id                 int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	ExchangeId         int64                  `protobuf:"varint,2,opt,name=exchange_id,json=exchangeId,proto3" json:"exchange_id,omitempty"`
+	StockId            int64                  `protobuf:"varint,3,opt,name=stock_id,json=stockId,proto3" json:"stock_id,omitempty"`
+	FutureId           int64                  `protobuf:"varint,4,opt,name=future_id,json=futureId,proto3" json:"future_id,omitempty"`
+	Price              int64                  `protobuf:"varint,5,opt,name=price,proto3" json:"price,omitempty"`
+	AskPrice           int64                  `protobuf:"varint,6,opt,name=ask_price,json=askPrice,proto3" json:"ask_price,omitempty"`
+	BidPrice           int64                  `protobuf:"varint,7,opt,name=bid_price,json=bidPrice,proto3" json:"bid_price,omitempty"`
+	LastRefreshUnix    int64                  `protobuf:"varint,8,opt,name=last_refresh_unix,json=lastRefreshUnix,proto3" json:"last_refresh_unix,omitempty"`
+	Ticker             string                 `protobuf:"bytes,9,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	Name               string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	SecurityType       string                 `protobuf:"bytes,11,opt,name=security_type,json=securityType,proto3" json:"security_type,omitempty"`
+	Volume             int64                  `protobuf:"varint,12,opt,name=volume,proto3" json:"volume,omitempty"`
+	Change             int64                  `protobuf:"varint,13,opt,name=change,proto3" json:"change,omitempty"`
+	SettlementDateUnix int64                  `protobuf:"varint,14,opt,name=settlement_date_unix,json=settlementDateUnix,proto3" json:"settlement_date_unix,omitempty"`
+	ContractSize       int64                  `protobuf:"varint,15,opt,name=contract_size,json=contractSize,proto3" json:"contract_size,omitempty"`
+	MaintenanceMargin  int64                  `protobuf:"varint,16,opt,name=maintenance_margin,json=maintenanceMargin,proto3" json:"maintenance_margin,omitempty"`
+	InitialMarginCost  int64                  `protobuf:"varint,17,opt,name=initial_margin_cost,json=initialMarginCost,proto3" json:"initial_margin_cost,omitempty"`
+	MarketCap          int64                  `protobuf:"varint,18,opt,name=market_cap,json=marketCap,proto3" json:"market_cap,omitempty"`
+	NominalValue       int64                  `protobuf:"varint,19,opt,name=nominal_value,json=nominalValue,proto3" json:"nominal_value,omitempty"`
+	ExchangeAcronym    string                 `protobuf:"bytes,20,opt,name=exchange_acronym,json=exchangeAcronym,proto3" json:"exchange_acronym,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Listing) Reset() {
@@ -428,8 +445,113 @@ func (x *Listing) GetLastRefreshUnix() int64 {
 	return 0
 }
 
+func (x *Listing) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *Listing) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Listing) GetSecurityType() string {
+	if x != nil {
+		return x.SecurityType
+	}
+	return ""
+}
+
+func (x *Listing) GetVolume() int64 {
+	if x != nil {
+		return x.Volume
+	}
+	return 0
+}
+
+func (x *Listing) GetChange() int64 {
+	if x != nil {
+		return x.Change
+	}
+	return 0
+}
+
+func (x *Listing) GetSettlementDateUnix() int64 {
+	if x != nil {
+		return x.SettlementDateUnix
+	}
+	return 0
+}
+
+func (x *Listing) GetContractSize() int64 {
+	if x != nil {
+		return x.ContractSize
+	}
+	return 0
+}
+
+func (x *Listing) GetMaintenanceMargin() int64 {
+	if x != nil {
+		return x.MaintenanceMargin
+	}
+	return 0
+}
+
+func (x *Listing) GetInitialMarginCost() int64 {
+	if x != nil {
+		return x.InitialMarginCost
+	}
+	return 0
+}
+
+func (x *Listing) GetMarketCap() int64 {
+	if x != nil {
+		return x.MarketCap
+	}
+	return 0
+}
+
+func (x *Listing) GetNominalValue() int64 {
+	if x != nil {
+		return x.NominalValue
+	}
+	return 0
+}
+
+func (x *Listing) GetExchangeAcronym() string {
+	if x != nil {
+		return x.ExchangeAcronym
+	}
+	return ""
+}
+
+// Filters applied server-side. Zero-valued numeric bounds mean "unbounded"
+// — e.g. price_min=0 and price_max=0 disables the price filter entirely.
+// settlement_from_unix / settlement_to_unix apply only to future listings;
+// passing them filters out all stock listings.
 type ListListingsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail        string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	ExchangePrefix     string                 `protobuf:"bytes,2,opt,name=exchange_prefix,json=exchangePrefix,proto3" json:"exchange_prefix,omitempty"`
+	Search             string                 `protobuf:"bytes,3,opt,name=search,proto3" json:"search,omitempty"`
+	PriceMin           int64                  `protobuf:"varint,4,opt,name=price_min,json=priceMin,proto3" json:"price_min,omitempty"`
+	PriceMax           int64                  `protobuf:"varint,5,opt,name=price_max,json=priceMax,proto3" json:"price_max,omitempty"`
+	AskMin             int64                  `protobuf:"varint,6,opt,name=ask_min,json=askMin,proto3" json:"ask_min,omitempty"`
+	AskMax             int64                  `protobuf:"varint,7,opt,name=ask_max,json=askMax,proto3" json:"ask_max,omitempty"`
+	BidMin             int64                  `protobuf:"varint,8,opt,name=bid_min,json=bidMin,proto3" json:"bid_min,omitempty"`
+	BidMax             int64                  `protobuf:"varint,9,opt,name=bid_max,json=bidMax,proto3" json:"bid_max,omitempty"`
+	VolumeMin          int64                  `protobuf:"varint,10,opt,name=volume_min,json=volumeMin,proto3" json:"volume_min,omitempty"`
+	VolumeMax          int64                  `protobuf:"varint,11,opt,name=volume_max,json=volumeMax,proto3" json:"volume_max,omitempty"`
+	SettlementFromUnix int64                  `protobuf:"varint,12,opt,name=settlement_from_unix,json=settlementFromUnix,proto3" json:"settlement_from_unix,omitempty"`
+	SettlementToUnix   int64                  `protobuf:"varint,13,opt,name=settlement_to_unix,json=settlementToUnix,proto3" json:"settlement_to_unix,omitempty"`
+	// sort_by: "price" | "volume" | "maintenance_margin". Empty = id asc.
+	SortBy string `protobuf:"bytes,14,opt,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
+	// sort_order: "asc" | "desc". Empty defaults to "asc".
+	SortOrder     string `protobuf:"bytes,15,opt,name=sort_order,json=sortOrder,proto3" json:"sort_order,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -462,6 +584,111 @@ func (x *ListListingsRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ListListingsRequest.ProtoReflect.Descriptor instead.
 func (*ListListingsRequest) Descriptor() ([]byte, []int) {
 	return file_trading_trading_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListListingsRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+func (x *ListListingsRequest) GetExchangePrefix() string {
+	if x != nil {
+		return x.ExchangePrefix
+	}
+	return ""
+}
+
+func (x *ListListingsRequest) GetSearch() string {
+	if x != nil {
+		return x.Search
+	}
+	return ""
+}
+
+func (x *ListListingsRequest) GetPriceMin() int64 {
+	if x != nil {
+		return x.PriceMin
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetPriceMax() int64 {
+	if x != nil {
+		return x.PriceMax
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetAskMin() int64 {
+	if x != nil {
+		return x.AskMin
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetAskMax() int64 {
+	if x != nil {
+		return x.AskMax
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetBidMin() int64 {
+	if x != nil {
+		return x.BidMin
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetBidMax() int64 {
+	if x != nil {
+		return x.BidMax
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetVolumeMin() int64 {
+	if x != nil {
+		return x.VolumeMin
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetVolumeMax() int64 {
+	if x != nil {
+		return x.VolumeMax
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetSettlementFromUnix() int64 {
+	if x != nil {
+		return x.SettlementFromUnix
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetSettlementToUnix() int64 {
+	if x != nil {
+		return x.SettlementToUnix
+	}
+	return 0
+}
+
+func (x *ListListingsRequest) GetSortBy() string {
+	if x != nil {
+		return x.SortBy
+	}
+	return ""
+}
+
+func (x *ListListingsRequest) GetSortOrder() string {
+	if x != nil {
+		return x.SortOrder
+	}
+	return ""
 }
 
 type ListListingsResponse struct {
@@ -508,6 +735,498 @@ func (x *ListListingsResponse) GetListings() []*Listing {
 	return nil
 }
 
+type GetListingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,2,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingRequest) Reset() {
+	*x = GetListingRequest{}
+	mi := &file_trading_trading_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingRequest) ProtoMessage() {}
+
+func (x *GetListingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingRequest.ProtoReflect.Descriptor instead.
+func (*GetListingRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetListingRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *GetListingRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type GetListingResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Listing       *Listing               `protobuf:"bytes,1,opt,name=listing,proto3" json:"listing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetListingResponse) Reset() {
+	*x = GetListingResponse{}
+	mi := &file_trading_trading_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetListingResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetListingResponse) ProtoMessage() {}
+
+func (x *GetListingResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetListingResponse.ProtoReflect.Descriptor instead.
+func (*GetListingResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetListingResponse) GetListing() *Listing {
+	if x != nil {
+		return x.Listing
+	}
+	return nil
+}
+
+// period: "day" | "week" | "month" | "year" | "5y" | "all". Anything else
+// rejected with InvalidArgument.
+type ListListingHistoryRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ListingId     int64                  `protobuf:"varint,1,opt,name=listing_id,json=listingId,proto3" json:"listing_id,omitempty"`
+	Period        string                 `protobuf:"bytes,2,opt,name=period,proto3" json:"period,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,3,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListListingHistoryRequest) Reset() {
+	*x = ListListingHistoryRequest{}
+	mi := &file_trading_trading_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListListingHistoryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListListingHistoryRequest) ProtoMessage() {}
+
+func (x *ListListingHistoryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListListingHistoryRequest.ProtoReflect.Descriptor instead.
+func (*ListListingHistoryRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ListListingHistoryRequest) GetListingId() int64 {
+	if x != nil {
+		return x.ListingId
+	}
+	return 0
+}
+
+func (x *ListListingHistoryRequest) GetPeriod() string {
+	if x != nil {
+		return x.Period
+	}
+	return ""
+}
+
+func (x *ListListingHistoryRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type ListingHistoryPoint struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DateUnix      int64                  `protobuf:"varint,1,opt,name=date_unix,json=dateUnix,proto3" json:"date_unix,omitempty"`
+	Price         int64                  `protobuf:"varint,2,opt,name=price,proto3" json:"price,omitempty"`
+	AskPrice      int64                  `protobuf:"varint,3,opt,name=ask_price,json=askPrice,proto3" json:"ask_price,omitempty"`
+	BidPrice      int64                  `protobuf:"varint,4,opt,name=bid_price,json=bidPrice,proto3" json:"bid_price,omitempty"`
+	Change        int64                  `protobuf:"varint,5,opt,name=change,proto3" json:"change,omitempty"`
+	Volume        int64                  `protobuf:"varint,6,opt,name=volume,proto3" json:"volume,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListingHistoryPoint) Reset() {
+	*x = ListingHistoryPoint{}
+	mi := &file_trading_trading_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListingHistoryPoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListingHistoryPoint) ProtoMessage() {}
+
+func (x *ListingHistoryPoint) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListingHistoryPoint.ProtoReflect.Descriptor instead.
+func (*ListingHistoryPoint) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ListingHistoryPoint) GetDateUnix() int64 {
+	if x != nil {
+		return x.DateUnix
+	}
+	return 0
+}
+
+func (x *ListingHistoryPoint) GetPrice() int64 {
+	if x != nil {
+		return x.Price
+	}
+	return 0
+}
+
+func (x *ListingHistoryPoint) GetAskPrice() int64 {
+	if x != nil {
+		return x.AskPrice
+	}
+	return 0
+}
+
+func (x *ListingHistoryPoint) GetBidPrice() int64 {
+	if x != nil {
+		return x.BidPrice
+	}
+	return 0
+}
+
+func (x *ListingHistoryPoint) GetChange() int64 {
+	if x != nil {
+		return x.Change
+	}
+	return 0
+}
+
+func (x *ListingHistoryPoint) GetVolume() int64 {
+	if x != nil {
+		return x.Volume
+	}
+	return 0
+}
+
+type ListListingHistoryResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Points        []*ListingHistoryPoint `protobuf:"bytes,1,rep,name=points,proto3" json:"points,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListListingHistoryResponse) Reset() {
+	*x = ListListingHistoryResponse{}
+	mi := &file_trading_trading_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListListingHistoryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListListingHistoryResponse) ProtoMessage() {}
+
+func (x *ListListingHistoryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListListingHistoryResponse.ProtoReflect.Descriptor instead.
+func (*ListListingHistoryResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ListListingHistoryResponse) GetPoints() []*ListingHistoryPoint {
+	if x != nil {
+		return x.Points
+	}
+	return nil
+}
+
+// Forex is employee-only — clients get PermissionDenied. Spec Idea 1: forex
+// pairs have no listings, we surface them directly.
+type ForexPair struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Ticker            string                 `protobuf:"bytes,2,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	Name              string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	BaseCurrency      string                 `protobuf:"bytes,4,opt,name=base_currency,json=baseCurrency,proto3" json:"base_currency,omitempty"`
+	QuoteCurrency     string                 `protobuf:"bytes,5,opt,name=quote_currency,json=quoteCurrency,proto3" json:"quote_currency,omitempty"`
+	ExchangeRate      float64                `protobuf:"fixed64,6,opt,name=exchange_rate,json=exchangeRate,proto3" json:"exchange_rate,omitempty"`
+	Liquidity         string                 `protobuf:"bytes,7,opt,name=liquidity,proto3" json:"liquidity,omitempty"`
+	ContractSize      int64                  `protobuf:"varint,8,opt,name=contract_size,json=contractSize,proto3" json:"contract_size,omitempty"`
+	MaintenanceMargin int64                  `protobuf:"varint,9,opt,name=maintenance_margin,json=maintenanceMargin,proto3" json:"maintenance_margin,omitempty"`
+	NominalValue      int64                  `protobuf:"varint,10,opt,name=nominal_value,json=nominalValue,proto3" json:"nominal_value,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ForexPair) Reset() {
+	*x = ForexPair{}
+	mi := &file_trading_trading_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForexPair) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForexPair) ProtoMessage() {}
+
+func (x *ForexPair) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForexPair.ProtoReflect.Descriptor instead.
+func (*ForexPair) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ForexPair) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ForexPair) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *ForexPair) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ForexPair) GetBaseCurrency() string {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return ""
+}
+
+func (x *ForexPair) GetQuoteCurrency() string {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return ""
+}
+
+func (x *ForexPair) GetExchangeRate() float64 {
+	if x != nil {
+		return x.ExchangeRate
+	}
+	return 0
+}
+
+func (x *ForexPair) GetLiquidity() string {
+	if x != nil {
+		return x.Liquidity
+	}
+	return ""
+}
+
+func (x *ForexPair) GetContractSize() int64 {
+	if x != nil {
+		return x.ContractSize
+	}
+	return 0
+}
+
+func (x *ForexPair) GetMaintenanceMargin() int64 {
+	if x != nil {
+		return x.MaintenanceMargin
+	}
+	return 0
+}
+
+func (x *ForexPair) GetNominalValue() int64 {
+	if x != nil {
+		return x.NominalValue
+	}
+	return 0
+}
+
+type ListForexPairsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListForexPairsRequest) Reset() {
+	*x = ListForexPairsRequest{}
+	mi := &file_trading_trading_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListForexPairsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListForexPairsRequest) ProtoMessage() {}
+
+func (x *ListForexPairsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListForexPairsRequest.ProtoReflect.Descriptor instead.
+func (*ListForexPairsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ListForexPairsRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type ListForexPairsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Pairs         []*ForexPair           `protobuf:"bytes,1,rep,name=pairs,proto3" json:"pairs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListForexPairsResponse) Reset() {
+	*x = ListForexPairsResponse{}
+	mi := &file_trading_trading_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListForexPairsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListForexPairsResponse) ProtoMessage() {}
+
+func (x *ListForexPairsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListForexPairsResponse.ProtoReflect.Descriptor instead.
+func (*ListForexPairsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ListForexPairsResponse) GetPairs() []*ForexPair {
+	if x != nil {
+		return x.Pairs
+	}
+	return nil
+}
+
 // Exactly one of listing_id / option_id / forex_pair_id must be set — that's
 // the instrument being traded. limit_price / stop_price are required only
 // for LIMIT / STOP / STOP_LIMIT; senders must leave them 0 otherwise.
@@ -530,7 +1249,7 @@ type CreateOrderRequest struct {
 
 func (x *CreateOrderRequest) Reset() {
 	*x = CreateOrderRequest{}
-	mi := &file_trading_trading_proto_msgTypes[8]
+	mi := &file_trading_trading_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -542,7 +1261,7 @@ func (x *CreateOrderRequest) String() string {
 func (*CreateOrderRequest) ProtoMessage() {}
 
 func (x *CreateOrderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[8]
+	mi := &file_trading_trading_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -555,7 +1274,7 @@ func (x *CreateOrderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrderRequest.ProtoReflect.Descriptor instead.
 func (*CreateOrderRequest) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{8}
+	return file_trading_trading_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateOrderRequest) GetListingId() int64 {
@@ -645,7 +1364,7 @@ type CreateOrderResponse struct {
 
 func (x *CreateOrderResponse) Reset() {
 	*x = CreateOrderResponse{}
-	mi := &file_trading_trading_proto_msgTypes[9]
+	mi := &file_trading_trading_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -657,7 +1376,7 @@ func (x *CreateOrderResponse) String() string {
 func (*CreateOrderResponse) ProtoMessage() {}
 
 func (x *CreateOrderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_trading_proto_msgTypes[9]
+	mi := &file_trading_trading_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -670,7 +1389,7 @@ func (x *CreateOrderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrderResponse.ProtoReflect.Descriptor instead.
 func (*CreateOrderResponse) Descriptor() ([]byte, []int) {
-	return file_trading_trading_proto_rawDescGZIP(), []int{9}
+	return file_trading_trading_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateOrderResponse) GetOrderId() int64 {
@@ -714,7 +1433,7 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\bexchange\x18\x01 \x01(\v2\x11.trading.ExchangeR\bexchange\"\x16\n" +
 	"\x14ListExchangesRequest\"H\n" +
 	"\x15ListExchangesResponse\x12/\n" +
-	"\texchanges\x18\x01 \x03(\v2\x11.trading.ExchangeR\texchanges\"\xee\x01\n" +
+	"\texchanges\x18\x01 \x03(\v2\x11.trading.ExchangeR\texchanges\"\x94\x05\n" +
 	"\aListing\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1f\n" +
 	"\vexchange_id\x18\x02 \x01(\x03R\n" +
@@ -724,10 +1443,78 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x05price\x18\x05 \x01(\x03R\x05price\x12\x1b\n" +
 	"\task_price\x18\x06 \x01(\x03R\baskPrice\x12\x1b\n" +
 	"\tbid_price\x18\a \x01(\x03R\bbidPrice\x12*\n" +
-	"\x11last_refresh_unix\x18\b \x01(\x03R\x0flastRefreshUnix\"\x15\n" +
-	"\x13ListListingsRequest\"D\n" +
+	"\x11last_refresh_unix\x18\b \x01(\x03R\x0flastRefreshUnix\x12\x16\n" +
+	"\x06ticker\x18\t \x01(\tR\x06ticker\x12\x12\n" +
+	"\x04name\x18\n" +
+	" \x01(\tR\x04name\x12#\n" +
+	"\rsecurity_type\x18\v \x01(\tR\fsecurityType\x12\x16\n" +
+	"\x06volume\x18\f \x01(\x03R\x06volume\x12\x16\n" +
+	"\x06change\x18\r \x01(\x03R\x06change\x120\n" +
+	"\x14settlement_date_unix\x18\x0e \x01(\x03R\x12settlementDateUnix\x12#\n" +
+	"\rcontract_size\x18\x0f \x01(\x03R\fcontractSize\x12-\n" +
+	"\x12maintenance_margin\x18\x10 \x01(\x03R\x11maintenanceMargin\x12.\n" +
+	"\x13initial_margin_cost\x18\x11 \x01(\x03R\x11initialMarginCost\x12\x1d\n" +
+	"\n" +
+	"market_cap\x18\x12 \x01(\x03R\tmarketCap\x12#\n" +
+	"\rnominal_value\x18\x13 \x01(\x03R\fnominalValue\x12)\n" +
+	"\x10exchange_acronym\x18\x14 \x01(\tR\x0fexchangeAcronym\"\xed\x03\n" +
+	"\x13ListListingsRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\x12'\n" +
+	"\x0fexchange_prefix\x18\x02 \x01(\tR\x0eexchangePrefix\x12\x16\n" +
+	"\x06search\x18\x03 \x01(\tR\x06search\x12\x1b\n" +
+	"\tprice_min\x18\x04 \x01(\x03R\bpriceMin\x12\x1b\n" +
+	"\tprice_max\x18\x05 \x01(\x03R\bpriceMax\x12\x17\n" +
+	"\aask_min\x18\x06 \x01(\x03R\x06askMin\x12\x17\n" +
+	"\aask_max\x18\a \x01(\x03R\x06askMax\x12\x17\n" +
+	"\abid_min\x18\b \x01(\x03R\x06bidMin\x12\x17\n" +
+	"\abid_max\x18\t \x01(\x03R\x06bidMax\x12\x1d\n" +
+	"\n" +
+	"volume_min\x18\n" +
+	" \x01(\x03R\tvolumeMin\x12\x1d\n" +
+	"\n" +
+	"volume_max\x18\v \x01(\x03R\tvolumeMax\x120\n" +
+	"\x14settlement_from_unix\x18\f \x01(\x03R\x12settlementFromUnix\x12,\n" +
+	"\x12settlement_to_unix\x18\r \x01(\x03R\x10settlementToUnix\x12\x17\n" +
+	"\asort_by\x18\x0e \x01(\tR\x06sortBy\x12\x1d\n" +
+	"\n" +
+	"sort_order\x18\x0f \x01(\tR\tsortOrder\"D\n" +
 	"\x14ListListingsResponse\x12,\n" +
-	"\blistings\x18\x01 \x03(\v2\x10.trading.ListingR\blistings\"\xec\x02\n" +
+	"\blistings\x18\x01 \x03(\v2\x10.trading.ListingR\blistings\"F\n" +
+	"\x11GetListingRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12!\n" +
+	"\fcaller_email\x18\x02 \x01(\tR\vcallerEmail\"@\n" +
+	"\x12GetListingResponse\x12*\n" +
+	"\alisting\x18\x01 \x01(\v2\x10.trading.ListingR\alisting\"u\n" +
+	"\x19ListListingHistoryRequest\x12\x1d\n" +
+	"\n" +
+	"listing_id\x18\x01 \x01(\x03R\tlistingId\x12\x16\n" +
+	"\x06period\x18\x02 \x01(\tR\x06period\x12!\n" +
+	"\fcaller_email\x18\x03 \x01(\tR\vcallerEmail\"\xb2\x01\n" +
+	"\x13ListingHistoryPoint\x12\x1b\n" +
+	"\tdate_unix\x18\x01 \x01(\x03R\bdateUnix\x12\x14\n" +
+	"\x05price\x18\x02 \x01(\x03R\x05price\x12\x1b\n" +
+	"\task_price\x18\x03 \x01(\x03R\baskPrice\x12\x1b\n" +
+	"\tbid_price\x18\x04 \x01(\x03R\bbidPrice\x12\x16\n" +
+	"\x06change\x18\x05 \x01(\x03R\x06change\x12\x16\n" +
+	"\x06volume\x18\x06 \x01(\x03R\x06volume\"R\n" +
+	"\x1aListListingHistoryResponse\x124\n" +
+	"\x06points\x18\x01 \x03(\v2\x1c.trading.ListingHistoryPointR\x06points\"\xcf\x02\n" +
+	"\tForexPair\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x16\n" +
+	"\x06ticker\x18\x02 \x01(\tR\x06ticker\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12#\n" +
+	"\rbase_currency\x18\x04 \x01(\tR\fbaseCurrency\x12%\n" +
+	"\x0equote_currency\x18\x05 \x01(\tR\rquoteCurrency\x12#\n" +
+	"\rexchange_rate\x18\x06 \x01(\x01R\fexchangeRate\x12\x1c\n" +
+	"\tliquidity\x18\a \x01(\tR\tliquidity\x12#\n" +
+	"\rcontract_size\x18\b \x01(\x03R\fcontractSize\x12-\n" +
+	"\x12maintenance_margin\x18\t \x01(\x03R\x11maintenanceMargin\x12#\n" +
+	"\rnominal_value\x18\n" +
+	" \x01(\x03R\fnominalValue\":\n" +
+	"\x15ListForexPairsRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\"B\n" +
+	"\x16ListForexPairsResponse\x12(\n" +
+	"\x05pairs\x18\x01 \x03(\v2\x12.trading.ForexPairR\x05pairs\"\xec\x02\n" +
 	"\x12CreateOrderRequest\x12\x1d\n" +
 	"\n" +
 	"listing_id\x18\x01 \x01(\x03R\tlistingId\x12\x1b\n" +
@@ -747,10 +1534,14 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x06margin\x18\v \x01(\bR\x06margin\"H\n" +
 	"\x13CreateOrderResponse\x12\x19\n" +
 	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status2\xe5\x02\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status2\xde\x04\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
-	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12H\n" +
+	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
+	"\n" +
+	"GetListing\x12\x1a.trading.GetListingRequest\x1a\x1b.trading.GetListingResponse\x12]\n" +
+	"\x12ListListingHistory\x12\".trading.ListListingHistoryRequest\x1a#.trading.ListListingHistoryResponse\x12Q\n" +
+	"\x0eListForexPairs\x12\x1e.trading.ListForexPairsRequest\x1a\x1f.trading.ListForexPairsResponse\x12H\n" +
 	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponse\x12l\n" +
 	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
@@ -766,7 +1557,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),                        // 0: trading.Exchange
 	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
@@ -776,26 +1567,43 @@ var file_trading_trading_proto_goTypes = []any{
 	(*Listing)(nil),                         // 5: trading.Listing
 	(*ListListingsRequest)(nil),             // 6: trading.ListListingsRequest
 	(*ListListingsResponse)(nil),            // 7: trading.ListListingsResponse
-	(*CreateOrderRequest)(nil),              // 8: trading.CreateOrderRequest
-	(*CreateOrderResponse)(nil),             // 9: trading.CreateOrderResponse
+	(*GetListingRequest)(nil),               // 8: trading.GetListingRequest
+	(*GetListingResponse)(nil),              // 9: trading.GetListingResponse
+	(*ListListingHistoryRequest)(nil),       // 10: trading.ListListingHistoryRequest
+	(*ListingHistoryPoint)(nil),             // 11: trading.ListingHistoryPoint
+	(*ListListingHistoryResponse)(nil),      // 12: trading.ListListingHistoryResponse
+	(*ForexPair)(nil),                       // 13: trading.ForexPair
+	(*ListForexPairsRequest)(nil),           // 14: trading.ListForexPairsRequest
+	(*ListForexPairsResponse)(nil),          // 15: trading.ListForexPairsResponse
+	(*CreateOrderRequest)(nil),              // 16: trading.CreateOrderRequest
+	(*CreateOrderResponse)(nil),             // 17: trading.CreateOrderResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
-	0, // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
-	0, // 1: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
-	5, // 2: trading.ListListingsResponse.listings:type_name -> trading.Listing
-	3, // 3: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
-	6, // 4: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	8, // 5: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	1, // 6: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
-	4, // 7: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	7, // 8: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	9, // 9: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	2, // 10: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	7, // [7:11] is the sub-list for method output_type
-	3, // [3:7] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	0,  // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
+	0,  // 1: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
+	5,  // 2: trading.ListListingsResponse.listings:type_name -> trading.Listing
+	5,  // 3: trading.GetListingResponse.listing:type_name -> trading.Listing
+	11, // 4: trading.ListListingHistoryResponse.points:type_name -> trading.ListingHistoryPoint
+	13, // 5: trading.ListForexPairsResponse.pairs:type_name -> trading.ForexPair
+	3,  // 6: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
+	6,  // 7: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	8,  // 8: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
+	10, // 9: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
+	14, // 10: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
+	16, // 11: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	1,  // 12: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
+	4,  // 13: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7,  // 14: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9,  // 15: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	12, // 16: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	15, // 17: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	17, // 18: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	2,  // 19: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	13, // [13:20] is the sub-list for method output_type
+	6,  // [6:13] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_trading_trading_proto_init() }
@@ -809,7 +1617,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -21,6 +21,9 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	TradingService_ListExchanges_FullMethodName           = "/trading.TradingService/ListExchanges"
 	TradingService_ListListings_FullMethodName            = "/trading.TradingService/ListListings"
+	TradingService_GetListing_FullMethodName              = "/trading.TradingService/GetListing"
+	TradingService_ListListingHistory_FullMethodName      = "/trading.TradingService/ListListingHistory"
+	TradingService_ListForexPairs_FullMethodName          = "/trading.TradingService/ListForexPairs"
 	TradingService_CreateOrder_FullMethodName             = "/trading.TradingService/CreateOrder"
 	TradingService_SetExchangeOpenOverride_FullMethodName = "/trading.TradingService/SetExchangeOpenOverride"
 )
@@ -31,6 +34,9 @@ const (
 type TradingServiceClient interface {
 	ListExchanges(ctx context.Context, in *ListExchangesRequest, opts ...grpc.CallOption) (*ListExchangesResponse, error)
 	ListListings(ctx context.Context, in *ListListingsRequest, opts ...grpc.CallOption) (*ListListingsResponse, error)
+	GetListing(ctx context.Context, in *GetListingRequest, opts ...grpc.CallOption) (*GetListingResponse, error)
+	ListListingHistory(ctx context.Context, in *ListListingHistoryRequest, opts ...grpc.CallOption) (*ListListingHistoryResponse, error)
+	ListForexPairs(ctx context.Context, in *ListForexPairsRequest, opts ...grpc.CallOption) (*ListForexPairsResponse, error)
 	CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error)
 	SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error)
 }
@@ -63,6 +69,36 @@ func (c *tradingServiceClient) ListListings(ctx context.Context, in *ListListing
 	return out, nil
 }
 
+func (c *tradingServiceClient) GetListing(ctx context.Context, in *GetListingRequest, opts ...grpc.CallOption) (*GetListingResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetListingResponse)
+	err := c.cc.Invoke(ctx, TradingService_GetListing_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) ListListingHistory(ctx context.Context, in *ListListingHistoryRequest, opts ...grpc.CallOption) (*ListListingHistoryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListListingHistoryResponse)
+	err := c.cc.Invoke(ctx, TradingService_ListListingHistory_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) ListForexPairs(ctx context.Context, in *ListForexPairsRequest, opts ...grpc.CallOption) (*ListForexPairsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListForexPairsResponse)
+	err := c.cc.Invoke(ctx, TradingService_ListForexPairs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *tradingServiceClient) CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateOrderResponse)
@@ -89,6 +125,9 @@ func (c *tradingServiceClient) SetExchangeOpenOverride(ctx context.Context, in *
 type TradingServiceServer interface {
 	ListExchanges(context.Context, *ListExchangesRequest) (*ListExchangesResponse, error)
 	ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error)
+	GetListing(context.Context, *GetListingRequest) (*GetListingResponse, error)
+	ListListingHistory(context.Context, *ListListingHistoryRequest) (*ListListingHistoryResponse, error)
+	ListForexPairs(context.Context, *ListForexPairsRequest) (*ListForexPairsResponse, error)
 	CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error)
 	SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
@@ -106,6 +145,15 @@ func (UnimplementedTradingServiceServer) ListExchanges(context.Context, *ListExc
 }
 func (UnimplementedTradingServiceServer) ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListListings not implemented")
+}
+func (UnimplementedTradingServiceServer) GetListing(context.Context, *GetListingRequest) (*GetListingResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetListing not implemented")
+}
+func (UnimplementedTradingServiceServer) ListListingHistory(context.Context, *ListListingHistoryRequest) (*ListListingHistoryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListListingHistory not implemented")
+}
+func (UnimplementedTradingServiceServer) ListForexPairs(context.Context, *ListForexPairsRequest) (*ListForexPairsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListForexPairs not implemented")
 }
 func (UnimplementedTradingServiceServer) CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateOrder not implemented")
@@ -170,6 +218,60 @@ func _TradingService_ListListings_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_GetListing_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetListingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).GetListing(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_GetListing_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).GetListing(ctx, req.(*GetListingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_ListListingHistory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListListingHistoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ListListingHistory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ListListingHistory_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ListListingHistory(ctx, req.(*ListListingHistoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_ListForexPairs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListForexPairsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ListForexPairs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ListForexPairs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ListForexPairs(ctx, req.(*ListForexPairsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _TradingService_CreateOrder_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateOrderRequest)
 	if err := dec(in); err != nil {
@@ -220,6 +322,18 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListListings",
 			Handler:    _TradingService_ListListings_Handler,
+		},
+		{
+			MethodName: "GetListing",
+			Handler:    _TradingService_GetListing_Handler,
+		},
+		{
+			MethodName: "ListListingHistory",
+			Handler:    _TradingService_ListListingHistory_Handler,
+		},
+		{
+			MethodName: "ListForexPairs",
+			Handler:    _TradingService_ListForexPairs_Handler,
 		},
 		{
 			MethodName: "CreateOrder",

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -139,6 +139,18 @@ func SetupApi(router *gin.Engine, server *Server) {
 		orders.POST("", server.CreateOrder)
 	}
 
+	// Trading read API (issue #196). Clients and employees share the same
+	// routes; forex is gated inside the trading RPC since listings only
+	// ever carry stocks/futures.
+	tradingReaders := api.Group("", auth, secured("role:client|employee"))
+	{
+		tradingReaders.GET("/exchanges", server.ListExchanges)
+		tradingReaders.GET("/listings", server.ListListings)
+		tradingReaders.GET("/listings/:id", server.GetListing)
+		tradingReaders.GET("/listings/:id/history", server.GetListingHistory)
+		tradingReaders.GET("/forex-pairs", server.ListForexPairs)
+	}
+
 	// Supervisor-only toggle used to exercise the trading flow outside real
 	// market hours (see spec p.40 and issue #194). Admin bypass still applies
 	// through `secured("supervisor")`.

--- a/internal/gateway/listings.go
+++ b/internal/gateway/listings.go
@@ -1,0 +1,250 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/metadata"
+)
+
+// tradingCtx builds a 5s gRPC context carrying the caller's email. The
+// trading server's ResolveCaller reads user-email from metadata the same
+// way bank does — see internal/bank/account.go.
+func tradingCtx(c *gin.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+	return ctx, cancel
+}
+
+func (s *Server) ListExchanges(c *gin.Context) {
+	ctx, cancel := tradingCtx(c)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListExchanges(ctx, &tradingpb.ListExchangesRequest{})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(resp.Exchanges))
+	for _, e := range resp.Exchanges {
+		out = append(out, exchangeToJSON(e))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func exchangeToJSON(e *tradingpb.Exchange) gin.H {
+	return gin.H{
+		"id":               e.Id,
+		"name":             e.Name,
+		"acronym":          e.Acronym,
+		"mic_code":         e.MicCode,
+		"polity":           e.Polity,
+		"currency":         e.Currency,
+		"time_zone_offset": e.TimeZoneOffset,
+		"open_time":        e.OpenTime,
+		"close_time":       e.CloseTime,
+		"open_override":    e.OpenOverride,
+	}
+}
+
+// parseInt64Query reads an int64 query param; empty string returns 0. An
+// unparseable value surfaces a 400.
+func parseInt64Query(c *gin.Context, key string) (int64, bool) {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0, true
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": key + " must be an integer"})
+		return 0, false
+	}
+	return v, true
+}
+
+func (s *Server) ListListings(c *gin.Context) {
+	priceMin, ok := parseInt64Query(c, "price_min")
+	if !ok {
+		return
+	}
+	priceMax, ok := parseInt64Query(c, "price_max")
+	if !ok {
+		return
+	}
+	askMin, ok := parseInt64Query(c, "ask_min")
+	if !ok {
+		return
+	}
+	askMax, ok := parseInt64Query(c, "ask_max")
+	if !ok {
+		return
+	}
+	bidMin, ok := parseInt64Query(c, "bid_min")
+	if !ok {
+		return
+	}
+	bidMax, ok := parseInt64Query(c, "bid_max")
+	if !ok {
+		return
+	}
+	volMin, ok := parseInt64Query(c, "volume_min")
+	if !ok {
+		return
+	}
+	volMax, ok := parseInt64Query(c, "volume_max")
+	if !ok {
+		return
+	}
+	settleFrom, ok := parseInt64Query(c, "settlement_from")
+	if !ok {
+		return
+	}
+	settleTo, ok := parseInt64Query(c, "settlement_to")
+	if !ok {
+		return
+	}
+
+	ctx, cancel := tradingCtx(c)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListListings(ctx, &tradingpb.ListListingsRequest{
+		CallerEmail:        c.GetString("email"),
+		ExchangePrefix:     c.Query("exchange"),
+		Search:             c.Query("search"),
+		PriceMin:           priceMin,
+		PriceMax:           priceMax,
+		AskMin:             askMin,
+		AskMax:             askMax,
+		BidMin:             bidMin,
+		BidMax:             bidMax,
+		VolumeMin:          volMin,
+		VolumeMax:          volMax,
+		SettlementFromUnix: settleFrom,
+		SettlementToUnix:   settleTo,
+		SortBy:             c.Query("sort_by"),
+		SortOrder:          c.Query("sort_order"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(resp.Listings))
+	for _, l := range resp.Listings {
+		out = append(out, listingToJSON(l))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func listingToJSON(l *tradingpb.Listing) gin.H {
+	return gin.H{
+		"id":                  l.Id,
+		"exchange_id":         l.ExchangeId,
+		"exchange_acronym":    l.ExchangeAcronym,
+		"security_type":       l.SecurityType,
+		"stock_id":            l.StockId,
+		"future_id":           l.FutureId,
+		"ticker":              l.Ticker,
+		"name":                l.Name,
+		"price":               l.Price,
+		"ask_price":           l.AskPrice,
+		"bid_price":           l.BidPrice,
+		"volume":              l.Volume,
+		"change":              l.Change,
+		"last_refresh":        l.LastRefreshUnix,
+		"settlement_date":     l.SettlementDateUnix,
+		"contract_size":       l.ContractSize,
+		"maintenance_margin":  l.MaintenanceMargin,
+		"initial_margin_cost": l.InitialMarginCost,
+		"market_cap":          l.MarketCap,
+		"nominal_value":       l.NominalValue,
+	}
+}
+
+func (s *Server) GetListing(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id must be a positive integer"})
+		return
+	}
+	ctx, cancel := tradingCtx(c)
+	defer cancel()
+
+	resp, err := s.TradingClient.GetListing(ctx, &tradingpb.GetListingRequest{
+		Id:          id,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, listingToJSON(resp.Listing))
+}
+
+func (s *Server) GetListingHistory(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id must be a positive integer"})
+		return
+	}
+	period := c.DefaultQuery("period", "month")
+
+	ctx, cancel := tradingCtx(c)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListListingHistory(ctx, &tradingpb.ListListingHistoryRequest{
+		ListingId:   id,
+		Period:      period,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	points := make([]gin.H, 0, len(resp.Points))
+	for _, p := range resp.Points {
+		points = append(points, gin.H{
+			"date":      p.DateUnix,
+			"price":     p.Price,
+			"ask_price": p.AskPrice,
+			"bid_price": p.BidPrice,
+			"change":    p.Change,
+			"volume":    p.Volume,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"period": period, "points": points})
+}
+
+func (s *Server) ListForexPairs(c *gin.Context) {
+	ctx, cancel := tradingCtx(c)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListForexPairs(ctx, &tradingpb.ListForexPairsRequest{
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(resp.Pairs))
+	for _, p := range resp.Pairs {
+		out = append(out, gin.H{
+			"id":                 p.Id,
+			"ticker":             p.Ticker,
+			"name":               p.Name,
+			"base_currency":      p.BaseCurrency,
+			"quote_currency":     p.QuoteCurrency,
+			"exchange_rate":      p.ExchangeRate,
+			"liquidity":          p.Liquidity,
+			"contract_size":      p.ContractSize,
+			"maintenance_margin": p.MaintenanceMargin,
+			"nominal_value":      p.NominalValue,
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/internal/trading/listings.go
+++ b/internal/trading/listings.go
@@ -367,4 +367,3 @@ func (s *Server) ListForexPairs(ctx context.Context, req *tradingpb.ListForexPai
 	}
 	return &tradingpb.ListForexPairsResponse{Pairs: out}, nil
 }
-

--- a/internal/trading/listings.go
+++ b/internal/trading/listings.go
@@ -1,0 +1,370 @@
+package trading
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// listingRow is the denormalized listing+instrument row we load in one
+// query. Pointers distinguish "stock listing" vs "future listing" —
+// exactly one of the two instrument blocks is populated per row.
+type listingRow struct {
+	Listing
+	ExchangeAcronym   string
+	StockTicker       *string
+	StockName         *string
+	OutstandingShares *int64
+	FutureTicker      *string
+	FutureName        *string
+	ContractSize      *int64
+	SettlementDate    *time.Time
+}
+
+// fetchListingRows runs the joined query for one or all listings, applying
+// the SQL-expressible filters. Derived-field filters/sort are applied in Go
+// by callers since they depend on per-instrument formulas.
+func (s *Server) fetchListingRows(req *tradingpb.ListListingsRequest, singleID int64) ([]listingRow, error) {
+	q := s.db.Table("listings AS l").
+		Select(`l.*,
+			e.acronym AS exchange_acronym,
+			s.ticker AS stock_ticker,
+			s.name AS stock_name,
+			s.outstanding_shares,
+			f.ticker AS future_ticker,
+			f.name AS future_name,
+			f.contract_size,
+			f.settlement_date`).
+		Joins("JOIN exchanges e ON e.id = l.exchange_id").
+		Joins("LEFT JOIN stocks s ON s.id = l.stock_id").
+		Joins("LEFT JOIN futures f ON f.id = l.future_id")
+
+	if singleID != 0 {
+		q = q.Where("l.id = ?", singleID)
+	}
+
+	if req != nil {
+		if p := strings.TrimSpace(req.ExchangePrefix); p != "" {
+			q = q.Where("e.acronym ILIKE ?", p+"%")
+		}
+		if search := strings.TrimSpace(req.Search); search != "" {
+			pat := "%" + search + "%"
+			q = q.Where(`(s.ticker ILIKE ? OR s.name ILIKE ? OR f.ticker ILIKE ? OR f.name ILIKE ?)`,
+				pat, pat, pat, pat)
+		}
+		q = applyRange(q, "l.price", req.PriceMin, req.PriceMax)
+		q = applyRange(q, "l.ask_price", req.AskMin, req.AskMax)
+		q = applyRange(q, "l.bid_price", req.BidMin, req.BidMax)
+		if req.SettlementFromUnix != 0 || req.SettlementToUnix != 0 {
+			// Settlement is only defined for futures — passing a bound
+			// implicitly drops stock listings.
+			q = q.Where("l.future_id IS NOT NULL")
+			if req.SettlementFromUnix != 0 {
+				q = q.Where("f.settlement_date >= ?", time.Unix(req.SettlementFromUnix, 0).UTC())
+			}
+			if req.SettlementToUnix != 0 {
+				q = q.Where("f.settlement_date <= ?", time.Unix(req.SettlementToUnix, 0).UTC())
+			}
+		}
+	}
+
+	var rows []listingRow
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func applyRange(q *gorm.DB, col string, min, max int64) *gorm.DB {
+	if min > 0 {
+		q = q.Where(col+" >= ?", min)
+	}
+	if max > 0 {
+		q = q.Where(col+" <= ?", max)
+	}
+	return q
+}
+
+// latestDailyInfo returns the most recent listing_daily_price_info row per
+// listing id, which is where volume and change live (spec p.46). Missing
+// rows are fine — callers default to 0.
+func (s *Server) latestDailyInfo(ids []int64) (map[int64]ListingDailyPriceInfo, error) {
+	out := map[int64]ListingDailyPriceInfo{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var rows []ListingDailyPriceInfo
+	// DISTINCT ON is Postgres-specific; the project is PG-only.
+	err := s.db.Raw(`
+		SELECT DISTINCT ON (listing_id) *
+		FROM listing_daily_price_info
+		WHERE listing_id IN (?)
+		ORDER BY listing_id, date DESC
+	`, ids).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.ListingID] = r
+	}
+	return out, nil
+}
+
+// buildListingProto applies the derived-field formulas from spec p.47–48.
+// Prices are int64 minor units; derived amounts stay in the same units so
+// the formulas become plain integer math (we lose sub-unit precision on the
+// 10%/50% splits but that matches the current money model).
+func buildListingProto(r listingRow, today ListingDailyPriceInfo) *tradingpb.Listing {
+	out := &tradingpb.Listing{
+		Id:              r.ID,
+		ExchangeId:      r.ExchangeID,
+		Price:           r.Price,
+		AskPrice:        r.AskPrice,
+		BidPrice:        r.BidPrice,
+		LastRefreshUnix: r.LastRefresh.Unix(),
+		Volume:          today.Volume,
+		Change:          today.Change,
+		ExchangeAcronym: r.ExchangeAcronym,
+	}
+	if r.StockID != nil {
+		out.StockId = *r.StockID
+		out.SecurityType = "stock"
+		if r.StockTicker != nil {
+			out.Ticker = *r.StockTicker
+		}
+		if r.StockName != nil {
+			out.Name = *r.StockName
+		}
+		out.ContractSize = 1
+		out.MaintenanceMargin = r.Price / 2
+		if r.OutstandingShares != nil {
+			out.MarketCap = *r.OutstandingShares * r.Price
+		}
+	}
+	if r.FutureID != nil {
+		out.FutureId = *r.FutureID
+		out.SecurityType = "future"
+		if r.FutureTicker != nil {
+			out.Ticker = *r.FutureTicker
+		}
+		if r.FutureName != nil {
+			out.Name = *r.FutureName
+		}
+		if r.ContractSize != nil {
+			out.ContractSize = *r.ContractSize
+			out.MaintenanceMargin = (*r.ContractSize * r.Price) / 10
+			out.NominalValue = *r.ContractSize * r.Price
+		}
+		if r.SettlementDate != nil {
+			out.SettlementDateUnix = r.SettlementDate.Unix()
+		}
+	}
+	out.InitialMarginCost = (out.MaintenanceMargin * 11) / 10
+	return out
+}
+
+// ListListings replaces the older placeholder implementation. Filters are
+// expressed on the request; derived-field filters (volume) and derived-field
+// sort (maintenance_margin) run in Go after rows are assembled.
+func (s *Server) ListListings(_ context.Context, req *tradingpb.ListListingsRequest) (*tradingpb.ListListingsResponse, error) {
+	rows, err := s.fetchListingRows(req, 0)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	ids := make([]int64, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	daily, err := s.latestDailyInfo(ids)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	out := make([]*tradingpb.Listing, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, buildListingProto(r, daily[r.ID]))
+	}
+
+	// Volume filter runs post-derive since volume is not stored on the
+	// listings row.
+	if req != nil && (req.VolumeMin > 0 || req.VolumeMax > 0) {
+		filtered := out[:0]
+		for _, l := range out {
+			if req.VolumeMin > 0 && l.Volume < req.VolumeMin {
+				continue
+			}
+			if req.VolumeMax > 0 && l.Volume > req.VolumeMax {
+				continue
+			}
+			filtered = append(filtered, l)
+		}
+		out = filtered
+	}
+
+	if req != nil && req.SortBy != "" {
+		if err := sortListings(out, req.SortBy, req.SortOrder); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tradingpb.ListListingsResponse{Listings: out}, nil
+}
+
+func sortListings(rows []*tradingpb.Listing, sortBy, sortOrder string) error {
+	var less func(a, b *tradingpb.Listing) bool
+	switch sortBy {
+	case "price":
+		less = func(a, b *tradingpb.Listing) bool { return a.Price < b.Price }
+	case "volume":
+		less = func(a, b *tradingpb.Listing) bool { return a.Volume < b.Volume }
+	case "maintenance_margin":
+		less = func(a, b *tradingpb.Listing) bool { return a.MaintenanceMargin < b.MaintenanceMargin }
+	default:
+		return status.Errorf(codes.InvalidArgument, "invalid sort_by %q", sortBy)
+	}
+	desc := sortOrder == "desc"
+	sort.SliceStable(rows, func(i, j int) bool {
+		if desc {
+			return less(rows[j], rows[i])
+		}
+		return less(rows[i], rows[j])
+	})
+	return nil
+}
+
+// GetListing returns a single row enriched with the same derived fields as
+// ListListings. 404 when the row is missing.
+func (s *Server) GetListing(_ context.Context, req *tradingpb.GetListingRequest) (*tradingpb.GetListingResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "id required")
+	}
+	rows, err := s.fetchListingRows(nil, req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if len(rows) == 0 {
+		return nil, status.Error(codes.NotFound, "listing not found")
+	}
+	daily, err := s.latestDailyInfo([]int64{req.Id})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.GetListingResponse{
+		Listing: buildListingProto(rows[0], daily[req.Id]),
+	}, nil
+}
+
+// ListListingHistory returns the daily price info rows for the requested
+// period, ordered ascending by date so the chart can plot directly. "all"
+// skips the lower bound entirely.
+func (s *Server) ListListingHistory(_ context.Context, req *tradingpb.ListListingHistoryRequest) (*tradingpb.ListListingHistoryResponse, error) {
+	if req.ListingId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "listing_id required")
+	}
+	since, ok := periodStart(req.Period, time.Now())
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid period %q", req.Period)
+	}
+
+	// Confirm the listing exists so callers get 404 instead of an empty
+	// series when they type the wrong id.
+	var count int64
+	if err := s.db.Model(&Listing{}).Where("id = ?", req.ListingId).Count(&count).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if count == 0 {
+		return nil, status.Error(codes.NotFound, "listing not found")
+	}
+
+	q := s.db.Where("listing_id = ?", req.ListingId).Order("date ASC")
+	if !since.IsZero() {
+		q = q.Where("date >= ?", since)
+	}
+	var rows []ListingDailyPriceInfo
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	points := make([]*tradingpb.ListingHistoryPoint, 0, len(rows))
+	for _, r := range rows {
+		points = append(points, &tradingpb.ListingHistoryPoint{
+			DateUnix: r.Date.Unix(),
+			Price:    r.Price,
+			AskPrice: r.AskPrice,
+			BidPrice: r.BidPrice,
+			Change:   r.Change,
+			Volume:   r.Volume,
+		})
+	}
+	return &tradingpb.ListListingHistoryResponse{Points: points}, nil
+}
+
+// periodStart maps the spec's period strings to a lower-bound date. "all"
+// returns the zero time, which the caller treats as "no lower bound".
+func periodStart(period string, now time.Time) (time.Time, bool) {
+	switch period {
+	case "day":
+		return now.AddDate(0, 0, -1), true
+	case "week":
+		return now.AddDate(0, 0, -7), true
+	case "month":
+		return now.AddDate(0, -1, 0), true
+	case "year":
+		return now.AddDate(-1, 0, 0), true
+	case "5y":
+		return now.AddDate(-5, 0, 0), true
+	case "all", "":
+		return time.Time{}, true
+	}
+	return time.Time{}, false
+}
+
+// ListForexPairs surfaces every forex pair. Clients are forbidden per spec
+// p.58 — only actuaries (employees) may see forex. caller_email must be set;
+// the trading server asks bank which role it maps to.
+func (s *Server) ListForexPairs(ctx context.Context, req *tradingpb.ListForexPairsRequest) (*tradingpb.ListForexPairsResponse, error) {
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caller.IsClient {
+		return nil, status.Error(codes.PermissionDenied, "forex is available to employees only")
+	}
+	_ = req // caller_email is forwarded but bank.ResolveCaller reads it from context metadata
+
+	var rows []ForexPair
+	if err := s.db.Find(&rows).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	out := make([]*tradingpb.ForexPair, 0, len(rows))
+	for _, r := range rows {
+		// Forex derived fields (spec p.48): contract_size = 1000 by default,
+		// maintenance_margin = contract_size * price * 10%, nominal_value =
+		// contract_size * price. "price" for forex is exchange_rate, and we
+		// cast to int64 minor units the same way the rest of the system
+		// treats monetary values.
+		price := int64(r.ExchangeRate * 100)
+		contract := int64(1000)
+		out = append(out, &tradingpb.ForexPair{
+			Id:                r.ID,
+			Ticker:            r.Ticker,
+			Name:              r.Name,
+			BaseCurrency:      r.BaseCurrency,
+			QuoteCurrency:     r.QuoteCurrency,
+			ExchangeRate:      r.ExchangeRate,
+			Liquidity:         string(r.Liquidity),
+			ContractSize:      contract,
+			MaintenanceMargin: (contract * price) / 10,
+			NominalValue:      contract * price,
+		})
+	}
+	return &tradingpb.ListForexPairsResponse{Pairs: out}, nil
+}
+

--- a/internal/trading/repository.go
+++ b/internal/trading/repository.go
@@ -8,14 +8,6 @@ func (s *Server) ListExchangesRecord() ([]Exchange, error) {
 	return out, nil
 }
 
-func (s *Server) ListListingsRecord() ([]Listing, error) {
-	var out []Listing
-	if err := s.db.Find(&out).Error; err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (s *Server) CreateOrderPlacerRecord(p *OrderPlacer) error {
 	return s.db.Create(p).Error
 }

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -54,35 +54,6 @@ func exchangeToProto(r Exchange) *tradingpb.Exchange {
 	}
 }
 
-func (s *Server) ListListings(_ context.Context, _ *tradingpb.ListListingsRequest) (*tradingpb.ListListingsResponse, error) {
-	rows, err := s.ListListingsRecord()
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
-	}
-
-	out := make([]*tradingpb.Listing, 0, len(rows))
-	for _, r := range rows {
-		var stockID, futureID int64
-		if r.StockID != nil {
-			stockID = *r.StockID
-		}
-		if r.FutureID != nil {
-			futureID = *r.FutureID
-		}
-		out = append(out, &tradingpb.Listing{
-			Id:              r.ID,
-			ExchangeId:      r.ExchangeID,
-			StockId:         stockID,
-			FutureId:        futureID,
-			Price:           r.Price,
-			AskPrice:        r.AskPrice,
-			BidPrice:        r.BidPrice,
-			LastRefreshUnix: r.LastRefresh.Unix(),
-		})
-	}
-	return &tradingpb.ListListingsResponse{Listings: out}, nil
-}
-
 func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequest) (*tradingpb.CreateOrderResponse, error) {
 	if req.Quantity <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "quantity must be positive")

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -7,6 +7,9 @@ option go_package = "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading";
 service TradingService {
   rpc ListExchanges(ListExchangesRequest) returns (ListExchangesResponse);
   rpc ListListings(ListListingsRequest) returns (ListListingsResponse);
+  rpc GetListing(GetListingRequest) returns (GetListingResponse);
+  rpc ListListingHistory(ListListingHistoryRequest) returns (ListListingHistoryResponse);
+  rpc ListForexPairs(ListForexPairsRequest) returns (ListForexPairsResponse);
   rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);
   rpc SetExchangeOpenOverride(SetExchangeOpenOverrideRequest) returns (SetExchangeOpenOverrideResponse);
 }
@@ -47,6 +50,11 @@ message ListExchangesResponse {
   repeated Exchange exchanges = 1;
 }
 
+// Listing carries denormalized instrument identity (ticker/name/type) and
+// server-derived analytics fields alongside the row itself so that clients
+// do not need to join or compute anything. security_type is either "stock"
+// or "future" — the listings table only references those two. Futures-only
+// fields (settlement_date_unix, contract_size) are 0 for stock listings.
 message Listing {
   int64 id = 1;
   int64 exchange_id = 2;
@@ -56,12 +64,99 @@ message Listing {
   int64 ask_price = 6;
   int64 bid_price = 7;
   int64 last_refresh_unix = 8;
+  string ticker = 9;
+  string name = 10;
+  string security_type = 11;
+  int64 volume = 12;
+  int64 change = 13;
+  int64 settlement_date_unix = 14;
+  int64 contract_size = 15;
+  int64 maintenance_margin = 16;
+  int64 initial_margin_cost = 17;
+  int64 market_cap = 18;
+  int64 nominal_value = 19;
+  string exchange_acronym = 20;
 }
 
-message ListListingsRequest {}
+// Filters applied server-side. Zero-valued numeric bounds mean "unbounded"
+// — e.g. price_min=0 and price_max=0 disables the price filter entirely.
+// settlement_from_unix / settlement_to_unix apply only to future listings;
+// passing them filters out all stock listings.
+message ListListingsRequest {
+  string caller_email = 1;
+  string exchange_prefix = 2;
+  string search = 3;
+  int64 price_min = 4;
+  int64 price_max = 5;
+  int64 ask_min = 6;
+  int64 ask_max = 7;
+  int64 bid_min = 8;
+  int64 bid_max = 9;
+  int64 volume_min = 10;
+  int64 volume_max = 11;
+  int64 settlement_from_unix = 12;
+  int64 settlement_to_unix = 13;
+  // sort_by: "price" | "volume" | "maintenance_margin". Empty = id asc.
+  string sort_by = 14;
+  // sort_order: "asc" | "desc". Empty defaults to "asc".
+  string sort_order = 15;
+}
 
 message ListListingsResponse {
   repeated Listing listings = 1;
+}
+
+message GetListingRequest {
+  int64 id = 1;
+  string caller_email = 2;
+}
+
+message GetListingResponse {
+  Listing listing = 1;
+}
+
+// period: "day" | "week" | "month" | "year" | "5y" | "all". Anything else
+// rejected with InvalidArgument.
+message ListListingHistoryRequest {
+  int64 listing_id = 1;
+  string period = 2;
+  string caller_email = 3;
+}
+
+message ListingHistoryPoint {
+  int64 date_unix = 1;
+  int64 price = 2;
+  int64 ask_price = 3;
+  int64 bid_price = 4;
+  int64 change = 5;
+  int64 volume = 6;
+}
+
+message ListListingHistoryResponse {
+  repeated ListingHistoryPoint points = 1;
+}
+
+// Forex is employee-only — clients get PermissionDenied. Spec Idea 1: forex
+// pairs have no listings, we surface them directly.
+message ForexPair {
+  int64 id = 1;
+  string ticker = 2;
+  string name = 3;
+  string base_currency = 4;
+  string quote_currency = 5;
+  double exchange_rate = 6;
+  string liquidity = 7;
+  int64 contract_size = 8;
+  int64 maintenance_margin = 9;
+  int64 nominal_value = 10;
+}
+
+message ListForexPairsRequest {
+  string caller_email = 1;
+}
+
+message ListForexPairsResponse {
+  repeated ForexPair pairs = 1;
 }
 
 // Exactly one of listing_id / option_id / forex_pair_id must be set — that's


### PR DESCRIPTION
## Summary
- Proto: `Listing` gains denormalized + derived fields; `ListListingsRequest` gets filters/sort/caller; new RPCs `GetListing`, `ListListingHistory`, `ListForexPairs`.
- Trading server: joined query over listings/exchanges/stocks/futures; latest-row lookup in `listing_daily_price_info` via Postgres `DISTINCT ON` for volume/change; derived fields applied per spec p.47–48 (stocks: margin = price/2, market cap = shares×price; futures: margin = size×price×10%, nominal = size×price; initial margin = maintenance × 1.1). Forex list is employee-only (clients → `PermissionDenied`).
- Gateway: `GET /api/exchanges`, `/listings` (with exchange/search/price/ask/bid/volume/settlement filters + sort_by=price|volume|maintenance_margin), `/listings/:id`, `/listings/:id/history?period=day|week|month|year|5y|all`, `/forex-pairs`. All under `auth + secured("role:client|employee")`.

Closes #196. Spec pages 46–49, 58–59.

## Test plan
- [ ] `GET /api/listings` returns derived fields for both stock and future listings
- [ ] Filters: `?exchange=NYS`, `?search=APPL`, `?price_min=…&price_max=…`, `?volume_min=…`, `?settlement_from=…`
- [ ] `?sort_by=maintenance_margin&sort_order=desc`
- [ ] `GET /api/listings/:id` returns 404 for unknown id
- [ ] `GET /api/listings/:id/history?period=month` returns ascending points
- [ ] `GET /api/forex-pairs` returns 403 for client JWT, 200 for employee
- [ ] Existing `/api/orders` flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)