### PR TITLE
feat(actuary): supervisor portal + daily used_limit reset

### DIFF
--- a/gen/user/user.pb.go
+++ b/gen/user/user.pb.go
@@ -1770,6 +1770,7 @@ type GetEmployeeResponse struct {
 	Permissions   []string               `protobuf:"bytes,13,rep,name=permissions,proto3" json:"permissions,omitempty"`
 	Limit         int64                  `protobuf:"varint,14,opt,name=limit,proto3" json:"limit,omitempty"`
 	UsedLimit     int64                  `protobuf:"varint,15,opt,name=used_limit,json=usedLimit,proto3" json:"used_limit,omitempty"`
+	NeedApproval  bool                   `protobuf:"varint,16,opt,name=need_approval,json=needApproval,proto3" json:"need_approval,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1907,6 +1908,13 @@ func (x *GetEmployeeResponse) GetUsedLimit() int64 {
 		return x.UsedLimit
 	}
 	return 0
+}
+
+func (x *GetEmployeeResponse) GetNeedApproval() bool {
+	if x != nil {
+		return x.NeedApproval
+	}
+	return false
 }
 
 type GetClientResponse struct {
@@ -2207,6 +2215,66 @@ func (x *UpdateEmployeeTradingLimitRequest) GetCallerEmail() string {
 	return ""
 }
 
+type UpdateEmployeeNeedApprovalRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	NeedApproval  bool                   `protobuf:"varint,2,opt,name=need_approval,json=needApproval,proto3" json:"need_approval,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,3,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateEmployeeNeedApprovalRequest) Reset() {
+	*x = UpdateEmployeeNeedApprovalRequest{}
+	mi := &file_user_user_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateEmployeeNeedApprovalRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateEmployeeNeedApprovalRequest) ProtoMessage() {}
+
+func (x *UpdateEmployeeNeedApprovalRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_user_user_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateEmployeeNeedApprovalRequest.ProtoReflect.Descriptor instead.
+func (*UpdateEmployeeNeedApprovalRequest) Descriptor() ([]byte, []int) {
+	return file_user_user_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *UpdateEmployeeNeedApprovalRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *UpdateEmployeeNeedApprovalRequest) GetNeedApproval() bool {
+	if x != nil {
+		return x.NeedApproval
+	}
+	return false
+}
+
+func (x *UpdateEmployeeNeedApprovalRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
 type GetEmployeesResponse_Employee struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -2216,13 +2284,16 @@ type GetEmployeesResponse_Employee struct {
 	Position      string                 `protobuf:"bytes,5,opt,name=position,proto3" json:"position,omitempty"`
 	PhoneNumber   string                 `protobuf:"bytes,6,opt,name=phone_number,json=phoneNumber,proto3" json:"phone_number,omitempty"`
 	Active        bool                   `protobuf:"varint,8,opt,name=active,proto3" json:"active,omitempty"`
+	Limit         int64                  `protobuf:"varint,9,opt,name=limit,proto3" json:"limit,omitempty"`
+	UsedLimit     int64                  `protobuf:"varint,10,opt,name=used_limit,json=usedLimit,proto3" json:"used_limit,omitempty"`
+	NeedApproval  bool                   `protobuf:"varint,11,opt,name=need_approval,json=needApproval,proto3" json:"need_approval,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetEmployeesResponse_Employee) Reset() {
 	*x = GetEmployeesResponse_Employee{}
-	mi := &file_user_user_proto_msgTypes[33]
+	mi := &file_user_user_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2234,7 +2305,7 @@ func (x *GetEmployeesResponse_Employee) String() string {
 func (*GetEmployeesResponse_Employee) ProtoMessage() {}
 
 func (x *GetEmployeesResponse_Employee) ProtoReflect() protoreflect.Message {
-	mi := &file_user_user_proto_msgTypes[33]
+	mi := &file_user_user_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2295,6 +2366,27 @@ func (x *GetEmployeesResponse_Employee) GetPhoneNumber() string {
 func (x *GetEmployeesResponse_Employee) GetActive() bool {
 	if x != nil {
 		return x.Active
+	}
+	return false
+}
+
+func (x *GetEmployeesResponse_Employee) GetLimit() int64 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *GetEmployeesResponse_Employee) GetUsedLimit() int64 {
+	if x != nil {
+		return x.UsedLimit
+	}
+	return 0
+}
+
+func (x *GetEmployeesResponse_Employee) GetNeedApproval() bool {
+	if x != nil {
+		return x.NeedApproval
 	}
 	return false
 }
@@ -2423,9 +2515,9 @@ const file_user_user_proto_rawDesc = "" +
 	"first_name\x18\x01 \x01(\tR\tfirstName\x12\x1b\n" +
 	"\tlast_name\x18\x02 \x01(\tR\blastName\x12\x14\n" +
 	"\x05email\x18\x03 \x01(\tR\x05email\x12\x1a\n" +
-	"\bposition\x18\x04 \x01(\tR\bposition\"\x9f\x02\n" +
+	"\bposition\x18\x04 \x01(\tR\bposition\"\xf9\x02\n" +
 	"\x14GetEmployeesResponse\x12A\n" +
-	"\temployees\x18\x01 \x03(\v2#.user.GetEmployeesResponse.EmployeeR\temployees\x1a\xc3\x01\n" +
+	"\temployees\x18\x01 \x03(\v2#.user.GetEmployeesResponse.EmployeeR\temployees\x1a\x9d\x02\n" +
 	"\bEmployee\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2434,11 +2526,16 @@ const file_user_user_proto_rawDesc = "" +
 	"\x05email\x18\x04 \x01(\tR\x05email\x12\x1a\n" +
 	"\bposition\x18\x05 \x01(\tR\bposition\x12!\n" +
 	"\fphone_number\x18\x06 \x01(\tR\vphoneNumber\x12\x16\n" +
-	"\x06active\x18\b \x01(\bR\x06active\"$\n" +
+	"\x06active\x18\b \x01(\bR\x06active\x12\x14\n" +
+	"\x05limit\x18\t \x01(\x03R\x05limit\x12\x1d\n" +
+	"\n" +
+	"used_limit\x18\n" +
+	" \x01(\x03R\tusedLimit\x12#\n" +
+	"\rneed_approval\x18\v \x01(\bR\fneedApproval\"$\n" +
 	"\x12GetUserByIdRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"-\n" +
 	"\x15GetUserByEmailRequest\x12\x14\n" +
-	"\x05email\x18\x01 \x01(\tR\x05email\"\xb2\x03\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\"\xd7\x03\n" +
 	"\x13GetEmployeeResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2460,7 +2557,8 @@ const file_user_user_proto_rawDesc = "" +
 	"\vpermissions\x18\r \x03(\tR\vpermissions\x12\x14\n" +
 	"\x05limit\x18\x0e \x01(\x03R\x05limit\x12\x1d\n" +
 	"\n" +
-	"used_limit\x18\x0f \x01(\x03R\tusedLimit\"\xe9\x01\n" +
+	"used_limit\x18\x0f \x01(\x03R\tusedLimit\x12#\n" +
+	"\rneed_approval\x18\x10 \x01(\bR\fneedApproval\"\xe9\x01\n" +
 	"\x11GetClientResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -2495,13 +2593,19 @@ const file_user_user_proto_rawDesc = "" +
 	"used_limit\x18\x03 \x01(\x03H\x01R\tusedLimit\x88\x01\x01\x12!\n" +
 	"\fcaller_email\x18\x04 \x01(\tR\vcallerEmailB\b\n" +
 	"\x06_limitB\r\n" +
-	"\v_used_limit2\xbb\f\n" +
+	"\v_used_limit\"{\n" +
+	"!UpdateEmployeeNeedApprovalRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12#\n" +
+	"\rneed_approval\x18\x02 \x01(\bR\fneedApproval\x12!\n" +
+	"\fcaller_email\x18\x03 \x01(\tR\vcallerEmail2\xe4\r\n" +
 	"\vUserService\x12F\n" +
 	"\x0fGetEmployeeById\x12\x18.user.GetUserByIdRequest\x1a\x19.user.GetEmployeeResponse\x12L\n" +
 	"\x12GetEmployeeByEmail\x12\x1b.user.GetUserByEmailRequest\x1a\x19.user.GetEmployeeResponse\x12E\n" +
 	"\fGetEmployees\x12\x19.user.GetEmployeesRequest\x1a\x1a.user.GetEmployeesResponse\x12H\n" +
 	"\x0eUpdateEmployee\x12\x1b.user.UpdateEmployeeRequest\x1a\x19.user.GetEmployeeResponse\x12`\n" +
-	"\x1aUpdateEmployeeTradingLimit\x12'.user.UpdateEmployeeTradingLimitRequest\x1a\x19.user.GetEmployeeResponse\x12K\n" +
+	"\x1aUpdateEmployeeTradingLimit\x12'.user.UpdateEmployeeTradingLimitRequest\x1a\x19.user.GetEmployeeResponse\x12`\n" +
+	"\x1aUpdateEmployeeNeedApproval\x12'.user.UpdateEmployeeNeedApprovalRequest\x1a\x19.user.GetEmployeeResponse\x12E\n" +
+	"\fGetActuaries\x12\x19.user.GetEmployeesRequest\x1a\x1a.user.GetEmployeesResponse\x12K\n" +
 	"\x0eDeleteEmployee\x12\x1b.user.DeleteEmployeeRequest\x1a\x1c.user.DeleteEmployeeResponse\x120\n" +
 	"\x05Login\x12\x12.user.LoginRequest\x1a\x13.user.LoginResponse\x123\n" +
 	"\x06Logout\x12\x13.user.LogoutRequest\x1a\x14.user.LogoutResponse\x126\n" +
@@ -2532,7 +2636,7 @@ func file_user_user_proto_rawDescGZIP() []byte {
 	return file_user_user_proto_rawDescData
 }
 
-var file_user_user_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_user_user_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_user_user_proto_goTypes = []any{
 	(*GetUserPermissionsRequest)(nil),         // 0: user.GetUserPermissionsRequest
 	(*GetUserPermissionsResponse)(nil),        // 1: user.GetUserPermissionsResponse
@@ -2567,55 +2671,60 @@ var file_user_user_proto_goTypes = []any{
 	(*GetClientResponse)(nil),                 // 30: user.GetClientResponse
 	(*UpdateEmployeeRequest)(nil),             // 31: user.UpdateEmployeeRequest
 	(*UpdateEmployeeTradingLimitRequest)(nil), // 32: user.UpdateEmployeeTradingLimitRequest
-	(*GetEmployeesResponse_Employee)(nil),     // 33: user.GetEmployeesResponse.Employee
+	(*UpdateEmployeeNeedApprovalRequest)(nil), // 33: user.UpdateEmployeeNeedApprovalRequest
+	(*GetEmployeesResponse_Employee)(nil),     // 34: user.GetEmployeesResponse.Employee
 }
 var file_user_user_proto_depIdxs = []int32{
 	20, // 0: user.GetClientsResponse.Clients:type_name -> user.Client
-	33, // 1: user.GetEmployeesResponse.employees:type_name -> user.GetEmployeesResponse.Employee
+	34, // 1: user.GetEmployeesResponse.employees:type_name -> user.GetEmployeesResponse.Employee
 	27, // 2: user.UserService.GetEmployeeById:input_type -> user.GetUserByIdRequest
 	28, // 3: user.UserService.GetEmployeeByEmail:input_type -> user.GetUserByEmailRequest
 	25, // 4: user.UserService.GetEmployees:input_type -> user.GetEmployeesRequest
 	31, // 5: user.UserService.UpdateEmployee:input_type -> user.UpdateEmployeeRequest
 	32, // 6: user.UserService.UpdateEmployeeTradingLimit:input_type -> user.UpdateEmployeeTradingLimitRequest
-	2,  // 7: user.UserService.DeleteEmployee:input_type -> user.DeleteEmployeeRequest
-	11, // 8: user.UserService.Login:input_type -> user.LoginRequest
-	9,  // 9: user.UserService.Logout:input_type -> user.LogoutRequest
-	6,  // 10: user.UserService.Refresh:input_type -> user.RefreshRequest
-	4,  // 11: user.UserService.ValidateAccessToken:input_type -> user.ValidateTokenRequest
-	4,  // 12: user.UserService.ValidateRefreshToken:input_type -> user.ValidateTokenRequest
-	13, // 13: user.UserService.RequestPasswordReset:input_type -> user.PasswordActionRequest
-	13, // 14: user.UserService.RequestInitialPasswordSet:input_type -> user.PasswordActionRequest
-	15, // 15: user.UserService.SetPasswordWithToken:input_type -> user.SetPasswordWithTokenRequest
-	18, // 16: user.UserService.CreateClientAccount:input_type -> user.CreateClientRequest
-	21, // 17: user.UserService.GetClients:input_type -> user.GetClientsRequest
-	23, // 18: user.UserService.UpdateClient:input_type -> user.UpdateClientRequest
-	17, // 19: user.UserService.CreateEmployeeAccount:input_type -> user.CreateEmployeeRequest
-	0,  // 20: user.UserService.GetUserPermissions:input_type -> user.GetUserPermissionsRequest
-	27, // 21: user.UserService.GetClientById:input_type -> user.GetUserByIdRequest
-	28, // 22: user.UserService.GetClientByEmail:input_type -> user.GetUserByEmailRequest
-	29, // 23: user.UserService.GetEmployeeById:output_type -> user.GetEmployeeResponse
-	29, // 24: user.UserService.GetEmployeeByEmail:output_type -> user.GetEmployeeResponse
-	26, // 25: user.UserService.GetEmployees:output_type -> user.GetEmployeesResponse
-	29, // 26: user.UserService.UpdateEmployee:output_type -> user.GetEmployeeResponse
-	29, // 27: user.UserService.UpdateEmployeeTradingLimit:output_type -> user.GetEmployeeResponse
-	3,  // 28: user.UserService.DeleteEmployee:output_type -> user.DeleteEmployeeResponse
-	12, // 29: user.UserService.Login:output_type -> user.LoginResponse
-	10, // 30: user.UserService.Logout:output_type -> user.LogoutResponse
-	7,  // 31: user.UserService.Refresh:output_type -> user.RefreshResponse
-	5,  // 32: user.UserService.ValidateAccessToken:output_type -> user.ValidateTokenResponse
-	5,  // 33: user.UserService.ValidateRefreshToken:output_type -> user.ValidateTokenResponse
-	14, // 34: user.UserService.RequestPasswordReset:output_type -> user.PasswordActionResponse
-	14, // 35: user.UserService.RequestInitialPasswordSet:output_type -> user.PasswordActionResponse
-	16, // 36: user.UserService.SetPasswordWithToken:output_type -> user.SetPasswordWithTokenResponse
-	19, // 37: user.UserService.CreateClientAccount:output_type -> user.CreateClientResponse
-	22, // 38: user.UserService.GetClients:output_type -> user.GetClientsResponse
-	24, // 39: user.UserService.UpdateClient:output_type -> user.UpdateClientResponse
-	29, // 40: user.UserService.CreateEmployeeAccount:output_type -> user.GetEmployeeResponse
-	1,  // 41: user.UserService.GetUserPermissions:output_type -> user.GetUserPermissionsResponse
-	30, // 42: user.UserService.GetClientById:output_type -> user.GetClientResponse
-	30, // 43: user.UserService.GetClientByEmail:output_type -> user.GetClientResponse
-	23, // [23:44] is the sub-list for method output_type
-	2,  // [2:23] is the sub-list for method input_type
+	33, // 7: user.UserService.UpdateEmployeeNeedApproval:input_type -> user.UpdateEmployeeNeedApprovalRequest
+	25, // 8: user.UserService.GetActuaries:input_type -> user.GetEmployeesRequest
+	2,  // 9: user.UserService.DeleteEmployee:input_type -> user.DeleteEmployeeRequest
+	11, // 10: user.UserService.Login:input_type -> user.LoginRequest
+	9,  // 11: user.UserService.Logout:input_type -> user.LogoutRequest
+	6,  // 12: user.UserService.Refresh:input_type -> user.RefreshRequest
+	4,  // 13: user.UserService.ValidateAccessToken:input_type -> user.ValidateTokenRequest
+	4,  // 14: user.UserService.ValidateRefreshToken:input_type -> user.ValidateTokenRequest
+	13, // 15: user.UserService.RequestPasswordReset:input_type -> user.PasswordActionRequest
+	13, // 16: user.UserService.RequestInitialPasswordSet:input_type -> user.PasswordActionRequest
+	15, // 17: user.UserService.SetPasswordWithToken:input_type -> user.SetPasswordWithTokenRequest
+	18, // 18: user.UserService.CreateClientAccount:input_type -> user.CreateClientRequest
+	21, // 19: user.UserService.GetClients:input_type -> user.GetClientsRequest
+	23, // 20: user.UserService.UpdateClient:input_type -> user.UpdateClientRequest
+	17, // 21: user.UserService.CreateEmployeeAccount:input_type -> user.CreateEmployeeRequest
+	0,  // 22: user.UserService.GetUserPermissions:input_type -> user.GetUserPermissionsRequest
+	27, // 23: user.UserService.GetClientById:input_type -> user.GetUserByIdRequest
+	28, // 24: user.UserService.GetClientByEmail:input_type -> user.GetUserByEmailRequest
+	29, // 25: user.UserService.GetEmployeeById:output_type -> user.GetEmployeeResponse
+	29, // 26: user.UserService.GetEmployeeByEmail:output_type -> user.GetEmployeeResponse
+	26, // 27: user.UserService.GetEmployees:output_type -> user.GetEmployeesResponse
+	29, // 28: user.UserService.UpdateEmployee:output_type -> user.GetEmployeeResponse
+	29, // 29: user.UserService.UpdateEmployeeTradingLimit:output_type -> user.GetEmployeeResponse
+	29, // 30: user.UserService.UpdateEmployeeNeedApproval:output_type -> user.GetEmployeeResponse
+	26, // 31: user.UserService.GetActuaries:output_type -> user.GetEmployeesResponse
+	3,  // 32: user.UserService.DeleteEmployee:output_type -> user.DeleteEmployeeResponse
+	12, // 33: user.UserService.Login:output_type -> user.LoginResponse
+	10, // 34: user.UserService.Logout:output_type -> user.LogoutResponse
+	7,  // 35: user.UserService.Refresh:output_type -> user.RefreshResponse
+	5,  // 36: user.UserService.ValidateAccessToken:output_type -> user.ValidateTokenResponse
+	5,  // 37: user.UserService.ValidateRefreshToken:output_type -> user.ValidateTokenResponse
+	14, // 38: user.UserService.RequestPasswordReset:output_type -> user.PasswordActionResponse
+	14, // 39: user.UserService.RequestInitialPasswordSet:output_type -> user.PasswordActionResponse
+	16, // 40: user.UserService.SetPasswordWithToken:output_type -> user.SetPasswordWithTokenResponse
+	19, // 41: user.UserService.CreateClientAccount:output_type -> user.CreateClientResponse
+	22, // 42: user.UserService.GetClients:output_type -> user.GetClientsResponse
+	24, // 43: user.UserService.UpdateClient:output_type -> user.UpdateClientResponse
+	29, // 44: user.UserService.CreateEmployeeAccount:output_type -> user.GetEmployeeResponse
+	1,  // 45: user.UserService.GetUserPermissions:output_type -> user.GetUserPermissionsResponse
+	30, // 46: user.UserService.GetClientById:output_type -> user.GetClientResponse
+	30, // 47: user.UserService.GetClientByEmail:output_type -> user.GetClientResponse
+	25, // [25:48] is the sub-list for method output_type
+	2,  // [2:25] is the sub-list for method input_type
 	2,  // [2:2] is the sub-list for extension type_name
 	2,  // [2:2] is the sub-list for extension extendee
 	0,  // [0:2] is the sub-list for field type_name
@@ -2633,7 +2742,7 @@ func file_user_user_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_user_user_proto_rawDesc), len(file_user_user_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/user/user_grpc.pb.go
+++ b/gen/user/user_grpc.pb.go
@@ -24,6 +24,8 @@ const (
 	UserService_GetEmployees_FullMethodName               = "/user.UserService/GetEmployees"
 	UserService_UpdateEmployee_FullMethodName             = "/user.UserService/UpdateEmployee"
 	UserService_UpdateEmployeeTradingLimit_FullMethodName = "/user.UserService/UpdateEmployeeTradingLimit"
+	UserService_UpdateEmployeeNeedApproval_FullMethodName = "/user.UserService/UpdateEmployeeNeedApproval"
+	UserService_GetActuaries_FullMethodName               = "/user.UserService/GetActuaries"
 	UserService_DeleteEmployee_FullMethodName             = "/user.UserService/DeleteEmployee"
 	UserService_Login_FullMethodName                      = "/user.UserService/Login"
 	UserService_Logout_FullMethodName                     = "/user.UserService/Logout"
@@ -51,6 +53,8 @@ type UserServiceClient interface {
 	GetEmployees(ctx context.Context, in *GetEmployeesRequest, opts ...grpc.CallOption) (*GetEmployeesResponse, error)
 	UpdateEmployee(ctx context.Context, in *UpdateEmployeeRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
 	UpdateEmployeeTradingLimit(ctx context.Context, in *UpdateEmployeeTradingLimitRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
+	UpdateEmployeeNeedApproval(ctx context.Context, in *UpdateEmployeeNeedApprovalRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error)
+	GetActuaries(ctx context.Context, in *GetEmployeesRequest, opts ...grpc.CallOption) (*GetEmployeesResponse, error)
 	DeleteEmployee(ctx context.Context, in *DeleteEmployeeRequest, opts ...grpc.CallOption) (*DeleteEmployeeResponse, error)
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
 	Logout(ctx context.Context, in *LogoutRequest, opts ...grpc.CallOption) (*LogoutResponse, error)
@@ -121,6 +125,26 @@ func (c *userServiceClient) UpdateEmployeeTradingLimit(ctx context.Context, in *
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetEmployeeResponse)
 	err := c.cc.Invoke(ctx, UserService_UpdateEmployeeTradingLimit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userServiceClient) UpdateEmployeeNeedApproval(ctx context.Context, in *UpdateEmployeeNeedApprovalRequest, opts ...grpc.CallOption) (*GetEmployeeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetEmployeeResponse)
+	err := c.cc.Invoke(ctx, UserService_UpdateEmployeeNeedApproval_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userServiceClient) GetActuaries(ctx context.Context, in *GetEmployeesRequest, opts ...grpc.CallOption) (*GetEmployeesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetEmployeesResponse)
+	err := c.cc.Invoke(ctx, UserService_GetActuaries_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -296,6 +320,8 @@ type UserServiceServer interface {
 	GetEmployees(context.Context, *GetEmployeesRequest) (*GetEmployeesResponse, error)
 	UpdateEmployee(context.Context, *UpdateEmployeeRequest) (*GetEmployeeResponse, error)
 	UpdateEmployeeTradingLimit(context.Context, *UpdateEmployeeTradingLimitRequest) (*GetEmployeeResponse, error)
+	UpdateEmployeeNeedApproval(context.Context, *UpdateEmployeeNeedApprovalRequest) (*GetEmployeeResponse, error)
+	GetActuaries(context.Context, *GetEmployeesRequest) (*GetEmployeesResponse, error)
 	DeleteEmployee(context.Context, *DeleteEmployeeRequest) (*DeleteEmployeeResponse, error)
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
 	Logout(context.Context, *LogoutRequest) (*LogoutResponse, error)
@@ -336,6 +362,12 @@ func (UnimplementedUserServiceServer) UpdateEmployee(context.Context, *UpdateEmp
 }
 func (UnimplementedUserServiceServer) UpdateEmployeeTradingLimit(context.Context, *UpdateEmployeeTradingLimitRequest) (*GetEmployeeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateEmployeeTradingLimit not implemented")
+}
+func (UnimplementedUserServiceServer) UpdateEmployeeNeedApproval(context.Context, *UpdateEmployeeNeedApprovalRequest) (*GetEmployeeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateEmployeeNeedApproval not implemented")
+}
+func (UnimplementedUserServiceServer) GetActuaries(context.Context, *GetEmployeesRequest) (*GetEmployeesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetActuaries not implemented")
 }
 func (UnimplementedUserServiceServer) DeleteEmployee(context.Context, *DeleteEmployeeRequest) (*DeleteEmployeeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteEmployee not implemented")
@@ -492,6 +524,42 @@ func _UserService_UpdateEmployeeTradingLimit_Handler(srv interface{}, ctx contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(UserServiceServer).UpdateEmployeeTradingLimit(ctx, req.(*UpdateEmployeeTradingLimitRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserService_UpdateEmployeeNeedApproval_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateEmployeeNeedApprovalRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).UpdateEmployeeNeedApproval(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_UpdateEmployeeNeedApproval_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).UpdateEmployeeNeedApproval(ctx, req.(*UpdateEmployeeNeedApprovalRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserService_GetActuaries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetEmployeesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserServiceServer).GetActuaries(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserService_GetActuaries_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserServiceServer).GetActuaries(ctx, req.(*GetEmployeesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -810,6 +878,14 @@ var UserService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateEmployeeTradingLimit",
 			Handler:    _UserService_UpdateEmployeeTradingLimit_Handler,
+		},
+		{
+			MethodName: "UpdateEmployeeNeedApproval",
+			Handler:    _UserService_UpdateEmployeeNeedApproval_Handler,
+		},
+		{
+			MethodName: "GetActuaries",
+			Handler:    _UserService_GetActuaries_Handler,
 		},
 		{
 			MethodName: "DeleteEmployee",

--- a/internal/bank/cron.go
+++ b/internal/bank/cron.go
@@ -16,6 +16,8 @@ func (s *Server) StartScheduler() func() {
 
 	go s.runOnSchedule(ctx, 2, isFirstOfMonth, s.RunMonthlyVariableRateUpdate)
 	go s.runOnSchedule(ctx, 6, always, s.RunDailyInstallmentCollection)
+	// Spec p.39: zero each agent's used_limit at end of day so the next day starts fresh.
+	go s.runOnScheduleAt(ctx, 23, 59, always, s.RunDailyUsedLimitReset)
 
 	return cancel
 }
@@ -25,9 +27,14 @@ func isFirstOfMonth(t time.Time) bool { return t.Day() == 1 }
 
 // poor man's cron - wakes up at the target hour, runs fn if filter says yes
 func (s *Server) runOnSchedule(ctx context.Context, hour int, filter func(time.Time) bool, fn func()) {
+	s.runOnScheduleAt(ctx, hour, 0, filter, fn)
+}
+
+// runOnScheduleAt is the same as runOnSchedule but lets the caller specify the minute too.
+func (s *Server) runOnScheduleAt(ctx context.Context, hour, minute int, filter func(time.Time) bool, fn func()) {
 	for {
 		now := time.Now()
-		next := time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, now.Location())
+		next := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
 		if !next.After(now) {
 			next = next.Add(24 * time.Hour)
 		}
@@ -42,6 +49,20 @@ func (s *Server) runOnSchedule(ctx context.Context, hour int, filter func(time.T
 			}
 		}
 	}
+}
+
+// RunDailyUsedLimitReset zeroes used_limit on every employee row at end of day so
+// the per-actuary daily trading limit refreshes for the next day (spec p.39).
+func (s *Server) RunDailyUsedLimitReset() {
+	log.Println("[Cron] Resetting employees.used_limit")
+	res := s.db_gorm.Table("employees").
+		Where("used_limit > 0").
+		Updates(map[string]any{"used_limit": 0, "updated_at": time.Now()})
+	if res.Error != nil {
+		log.Printf("[Cron] ERROR resetting used_limit: %v", res.Error)
+		return
+	}
+	log.Printf("[Cron] used_limit reset for %d employees", res.RowsAffected)
 }
 
 // recalculates rates for variable loans on the 1st of each month

--- a/internal/gateway/actuaries.go
+++ b/internal/gateway/actuaries.go
@@ -1,0 +1,146 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/user"
+	"github.com/gin-gonic/gin"
+)
+
+func actuaryToJSON(e *userpb.GetEmployeeResponse) gin.H {
+	perms := e.Permissions
+	if perms == nil {
+		perms = []string{}
+	}
+	return gin.H{
+		"id":            e.Id,
+		"first_name":    e.FirstName,
+		"last_name":     e.LastName,
+		"email":         e.Email,
+		"position":      e.Position,
+		"phone":         e.PhoneNumber,
+		"active":        e.Active,
+		"permissions":   perms,
+		"limit":         e.Limit,
+		"used_limit":    e.UsedLimit,
+		"need_approval": e.NeedApproval,
+	}
+}
+
+func (s *Server) GetActuaries(c *gin.Context) {
+	var query getEmployeesQuery
+	if err := c.ShouldBindQuery(&query); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.UserClient.GetActuaries(ctx, &userpb.GetEmployeesRequest{
+		FirstName: query.FirstName,
+		LastName:  query.LastName,
+		Email:     query.Email,
+		Position:  query.Position,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(resp.Employees))
+	for _, e := range resp.Employees {
+		out = append(out, gin.H{
+			"id":            e.Id,
+			"first_name":    e.FirstName,
+			"last_name":     e.LastName,
+			"email":         e.Email,
+			"position":      e.Position,
+			"phone":         e.PhoneNumber,
+			"active":        e.Active,
+			"limit":         e.Limit,
+			"used_limit":    e.UsedLimit,
+			"need_approval": e.NeedApproval,
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (s *Server) SetActuaryLimit(c *gin.Context) {
+	var uri actuaryByIDURI
+	if err := c.ShouldBindUri(&uri); err != nil {
+		c.String(http.StatusBadRequest, "actuary id is required and must be a valid integer")
+		return
+	}
+	var body updateActuaryLimitRequest
+	if err := c.BindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.UserClient.UpdateEmployeeTradingLimit(ctx, &userpb.UpdateEmployeeTradingLimitRequest{
+		Id:          uri.ActuaryID,
+		Limit:       body.Limit,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, actuaryToJSON(resp))
+}
+
+func (s *Server) ResetActuaryUsedLimit(c *gin.Context) {
+	var uri actuaryByIDURI
+	if err := c.ShouldBindUri(&uri); err != nil {
+		c.String(http.StatusBadRequest, "actuary id is required and must be a valid integer")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	zero := int64(0)
+	resp, err := s.UserClient.UpdateEmployeeTradingLimit(ctx, &userpb.UpdateEmployeeTradingLimitRequest{
+		Id:          uri.ActuaryID,
+		UsedLimit:   &zero,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, actuaryToJSON(resp))
+}
+
+func (s *Server) SetActuaryNeedApproval(c *gin.Context) {
+	var uri actuaryByIDURI
+	if err := c.ShouldBindUri(&uri); err != nil {
+		c.String(http.StatusBadRequest, "actuary id is required and must be a valid integer")
+		return
+	}
+	var body updateActuaryNeedApprovalRequest
+	if err := c.BindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.UserClient.UpdateEmployeeNeedApproval(ctx, &userpb.UpdateEmployeeNeedApprovalRequest{
+		Id:           uri.ActuaryID,
+		NeedApproval: *body.NeedApproval,
+		CallerEmail:  c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, actuaryToJSON(resp))
+}

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -88,6 +88,15 @@ func SetupApi(router *gin.Engine, server *Server) {
 	// and/or reset their used_limit. Gated by `supervisor`; admin bypass still applies.
 	api.PATCH("/employees/:employeeId/trading-limit", auth, secured("supervisor"), server.UpdateEmployeeTradingLimit)
 
+	// Supervisor portal for actuaries (spec p.39).
+	actuaries := api.Group("/actuaries", auth, secured("supervisor"))
+	{
+		actuaries.GET("", server.GetActuaries)
+		actuaries.PATCH("/:id/limit", server.SetActuaryLimit)
+		actuaries.POST("/:id/reset-used-limit", server.ResetActuaryUsedLimit)
+		actuaries.PATCH("/:id/need-approval", server.SetActuaryNeedApproval)
+	}
+
 	companies := api.Group("/companies", auth, secured("manage_companies"))
 	{
 		companies.POST("", server.CreateCompany)

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -57,6 +57,18 @@ type updateEmployeeTradingLimitRequest struct {
 	UsedLimit *int64 `json:"used_limit"`
 }
 
+type actuaryByIDURI struct {
+	ActuaryID int64 `uri:"id" binding:"required"`
+}
+
+type updateActuaryLimitRequest struct {
+	Limit *int64 `json:"limit" binding:"required"`
+}
+
+type updateActuaryNeedApprovalRequest struct {
+	NeedApproval *bool `json:"need_approval" binding:"required"`
+}
+
 type createClientAccountRequest struct {
 	FirstName   string `json:"first_name" binding:"required"`
 	LastName    string `json:"last_name" binding:"required"`

--- a/internal/user/actuaries_test.go
+++ b/internal/user/actuaries_test.go
@@ -1,0 +1,112 @@
+package user
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/user"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UpdateEmployeeNeedApproval shares the validation/permission shape of the
+// trading-limit RPC; we cover the same arg-rejection paths so a future refactor
+// of the gate doesn't silently widen who can flip the flag.
+func TestUpdateEmployeeNeedApprovalArgValidation(t *testing.T) {
+	server, _, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	cases := []struct {
+		name string
+		req  *userpb.UpdateEmployeeNeedApprovalRequest
+		code codes.Code
+	}{
+		{
+			name: "zero id",
+			req:  &userpb.UpdateEmployeeNeedApprovalRequest{Id: 0, NeedApproval: true},
+			code: codes.InvalidArgument,
+		},
+		{
+			// permission check runs before any DB lookup; empty CallerEmail can't be admin/supervisor.
+			name: "caller not supervisor or admin",
+			req:  &userpb.UpdateEmployeeNeedApprovalRequest{Id: 1, NeedApproval: true},
+			code: codes.PermissionDenied,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := server.UpdateEmployeeNeedApproval(context.Background(), tc.req)
+			if err == nil {
+				t.Fatalf("expected error with code %s, got nil", tc.code)
+			}
+			if status.Code(err) != tc.code {
+				t.Fatalf("got code %s, want %s (err=%v)", status.Code(err), tc.code, err)
+			}
+		})
+	}
+}
+
+// GetActuaries pulls every employee row through the standard filter pipeline
+// then drops anyone without the `agent` permission. This test checks that drop:
+// two employees come back from the DB, only the one tagged `agent` survives,
+// and used_limit / need_approval flow through to the response.
+func TestGetActuariesKeepsOnlyAgents(t *testing.T) {
+	server, mock, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "employees"`)).
+		WillReturnRows(sqlmockEmployeeRows().
+			AddRow(uint64(1), "Ana", "Agent", birth, "F", "ana@banka.raf", "+381600000001", "Adresa 1",
+				"ana", []byte("pw"), []byte("salt"), "Actuary", "Trading", true, int64(1000000), int64(250000), true, now, now).
+			AddRow(uint64(2), "Boris", "Boss", birth, "M", "boris@banka.raf", "+381600000002", "Adresa 2",
+				"boris", []byte("pw"), []byte("salt"), "Manager", "Trading", true, int64(0), int64(0), false, now, now))
+
+	// Preload("Permissions") on a many2many issues two follow-up queries: one against
+	// the join table, then one against permissions filtered by the join rows.
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "employee_permissions" WHERE "employee_permissions"."employee_id" IN ($1,$2)`)).
+		WithArgs(uint64(1), uint64(2)).
+		WillReturnRows(sqlmock.NewRows([]string{"employee_id", "permission_id"}).
+			AddRow(uint64(1), uint64(10)).
+			AddRow(uint64(2), uint64(11)))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "permissions" WHERE "permissions"."id" IN ($1,$2)`)).
+		WithArgs(uint64(10), uint64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).
+			AddRow(uint64(10), "agent").
+			AddRow(uint64(11), "supervisor"))
+
+	resp, err := server.GetActuaries(context.Background(), &userpb.GetEmployeesRequest{})
+	if err != nil {
+		t.Fatalf("GetActuaries returned error: %v", err)
+	}
+	if len(resp.Employees) != 1 {
+		t.Fatalf("expected 1 actuary (agent only), got %d", len(resp.Employees))
+	}
+	got := resp.Employees[0]
+	if got.Email != "ana@banka.raf" {
+		t.Fatalf("unexpected actuary email: %s", got.Email)
+	}
+	if got.Limit != 1000000 || got.UsedLimit != 250000 {
+		t.Fatalf("limit/used_limit not propagated: limit=%d used_limit=%d", got.Limit, got.UsedLimit)
+	}
+	if !got.NeedApproval {
+		t.Fatalf("expected NeedApproval=true to flow through")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func sqlmockEmployeeRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id", "first_name", "last_name", "date_of_birth", "gender", "email", "phone_number", "address",
+		"username", "password", "salt_password", "position", "department", "active",
+		"limit", "used_limit", "need_approval", "created_at", "updated_at",
+	})
+}

--- a/internal/user/models.go
+++ b/internal/user/models.go
@@ -38,6 +38,7 @@ type (
 		Active        bool         `gorm:"column:active;type:bool; not null"`
 		Limit         int64        `gorm:"column:limit;type:bigint;not null;default:0"`
 		Used_limit    int64        `gorm:"column:used_limit;type:bigint;not null;default:0"`
+		Need_approval bool         `gorm:"column:need_approval;type:bool;not null;default:false"`
 		Created_at    time.Time    `gorm:"column:created_at;not null;autoCreateTime"`
 		Updated_at    time.Time    `gorm:"column:updated_at;not null;autoUpdateTime"`
 		Permissions   []Permission `gorm:"many2many:employee_permissions;joinForeignKey:Employee_id;joinReferences:PermissionId"`

--- a/internal/user/server.go
+++ b/internal/user/server.go
@@ -100,21 +100,22 @@ func (emp Employee) toProtobuf() *userpb.GetEmployeeResponse {
 		permissions[i] = v.Name
 	}
 	return &userpb.GetEmployeeResponse{
-		Id:          int64(emp.Id),
-		FirstName:   emp.First_name,
-		LastName:    emp.Last_name,
-		BirthDate:   emp.Date_of_birth.Unix(),
-		Gender:      emp.Gender,
-		Email:       emp.Email,
-		PhoneNumber: emp.Phone_number,
-		Address:     emp.Address,
-		Username:    emp.Username,
-		Position:    emp.Position,
-		Department:  emp.Department,
-		Active:      emp.Active,
-		Permissions: permissions,
-		Limit:       emp.Limit,
-		UsedLimit:   emp.Used_limit,
+		Id:           int64(emp.Id),
+		FirstName:    emp.First_name,
+		LastName:     emp.Last_name,
+		BirthDate:    emp.Date_of_birth.Unix(),
+		Gender:       emp.Gender,
+		Email:        emp.Email,
+		PhoneNumber:  emp.Phone_number,
+		Address:      emp.Address,
+		Username:     emp.Username,
+		Position:     emp.Position,
+		Department:   emp.Department,
+		Active:       emp.Active,
+		Permissions:  permissions,
+		Limit:        emp.Limit,
+		UsedLimit:    emp.Used_limit,
+		NeedApproval: emp.Need_approval,
 	}
 }
 
@@ -184,13 +185,16 @@ func (s *Server) DeleteEmployee(_ context.Context, req *userpb.DeleteEmployeeReq
 func (s *Server) GetEmployees(_ context.Context, req *userpb.GetEmployeesRequest) (*userpb.GetEmployeesResponse, error) {
 	map_func := func(emp Employee) *userpb.GetEmployeesResponse_Employee {
 		return &userpb.GetEmployeesResponse_Employee{
-			Id:          int64(emp.Id),
-			FirstName:   emp.First_name,
-			LastName:    emp.Last_name,
-			Email:       emp.Email,
-			Position:    emp.Position,
-			PhoneNumber: emp.Phone_number,
-			Active:      emp.Active,
+			Id:           int64(emp.Id),
+			FirstName:    emp.First_name,
+			LastName:     emp.Last_name,
+			Email:        emp.Email,
+			Position:     emp.Position,
+			PhoneNumber:  emp.Phone_number,
+			Active:       emp.Active,
+			Limit:        emp.Limit,
+			UsedLimit:    emp.Used_limit,
+			NeedApproval: emp.Need_approval,
 		}
 	}
 	restrictions := user_restrictions{"first_name": req.FirstName, "last_name": req.LastName, "email": req.Email, "position": req.Position}
@@ -323,6 +327,82 @@ func (s *Server) UpdateEmployeeTradingLimit(ctx context.Context, req *userpb.Upd
 		return nil, status.Error(codes.Internal, "failed to reload employee")
 	}
 	return reloaded.toProtobuf(), nil
+}
+
+// UpdateEmployeeNeedApproval flips the need_approval flag on an employee. Admins
+// and supervisors only — caller is identified by CallerEmail.
+func (s *Server) UpdateEmployeeNeedApproval(ctx context.Context, req *userpb.UpdateEmployeeNeedApprovalRequest) (*userpb.GetEmployeeResponse, error) {
+	if req.Id <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "id must be greater than zero")
+	}
+	if !callerCanManageLimits(ctx, s, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "only admins and supervisors may change need_approval")
+	}
+
+	target, err := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "employee not found")
+		}
+		return nil, status.Error(codes.Internal, "failed to load employee")
+	}
+
+	if err := s.db_gorm.Model(&Employee{}).Where("id = ?", target.Id).Updates(map[string]any{
+		"need_approval": req.NeedApproval,
+		"updated_at":    time.Now(),
+	}).Error; err != nil {
+		return nil, status.Error(codes.Internal, "failed to update need_approval")
+	}
+
+	reloaded, err := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to reload employee")
+	}
+	return reloaded.toProtobuf(), nil
+}
+
+// GetActuaries returns employees that hold the `agent` permission, with the same
+// filter set as GetEmployees. Spec page 39 — supervisor portal.
+func (s *Server) GetActuaries(_ context.Context, req *userpb.GetEmployeesRequest) (*userpb.GetEmployeesResponse, error) {
+	restrictions := user_restrictions{
+		"first_name": req.FirstName,
+		"last_name":  req.LastName,
+		"email":      req.Email,
+		"position":   req.Position,
+	}
+
+	employees, err := GetAllUsersFromModel(Employee{}, s, restrictions)
+	if err != nil {
+		log.Printf("Error in retrieving actuaries: %s", err.Error())
+		return nil, status.Error(codes.Internal, "Failed to retrieve actuaries")
+	}
+
+	out := make([]*userpb.GetEmployeesResponse_Employee, 0, len(employees))
+	for _, emp := range employees {
+		isAgent := false
+		for _, p := range emp.Permissions {
+			if p.Name == "agent" {
+				isAgent = true
+				break
+			}
+		}
+		if !isAgent {
+			continue
+		}
+		out = append(out, &userpb.GetEmployeesResponse_Employee{
+			Id:           int64(emp.Id),
+			FirstName:    emp.First_name,
+			LastName:     emp.Last_name,
+			Email:        emp.Email,
+			Position:     emp.Position,
+			PhoneNumber:  emp.Phone_number,
+			Active:       emp.Active,
+			Limit:        emp.Limit,
+			UsedLimit:    emp.Used_limit,
+			NeedApproval: emp.Need_approval,
+		})
+	}
+	return &userpb.GetEmployeesResponse{Employees: out}, nil
 }
 
 // permissionSet converts a list of Permission rows to a string set for easy membership tests.

--- a/proto/user/user.proto
+++ b/proto/user/user.proto
@@ -10,6 +10,8 @@ service UserService {
   rpc GetEmployees(GetEmployeesRequest) returns (GetEmployeesResponse);
   rpc UpdateEmployee(UpdateEmployeeRequest) returns (GetEmployeeResponse);
   rpc UpdateEmployeeTradingLimit(UpdateEmployeeTradingLimitRequest) returns (GetEmployeeResponse);
+  rpc UpdateEmployeeNeedApproval(UpdateEmployeeNeedApprovalRequest) returns (GetEmployeeResponse);
+  rpc GetActuaries(GetEmployeesRequest) returns (GetEmployeesResponse);
   rpc DeleteEmployee(DeleteEmployeeRequest) returns (DeleteEmployeeResponse);
   rpc Login(LoginRequest) returns (LoginResponse);
   rpc Logout(LogoutRequest) returns (LogoutResponse);
@@ -203,6 +205,9 @@ message GetEmployeesResponse {
     string position = 5;
     string phone_number = 6;
     bool active = 8;
+    int64 limit = 9;
+    int64 used_limit = 10;
+    bool need_approval = 11;
   }
   repeated Employee employees = 1;
 }
@@ -231,6 +236,7 @@ message GetEmployeeResponse {
   repeated string permissions = 13;
   int64 limit = 14;
   int64 used_limit = 15;
+  bool need_approval = 16;
 }
 
 message GetClientResponse {
@@ -269,4 +275,10 @@ message UpdateEmployeeTradingLimitRequest {
   optional int64 used_limit = 3;
   // email of the caller; required so the user service can verify the caller is admin/supervisor.
   string caller_email = 4;
+}
+
+message UpdateEmployeeNeedApprovalRequest {
+  int64 id = 1;
+  bool need_approval = 2;
+  string caller_email = 3;
 }

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS employees (
     -- Supervisors and admins ignore the limit.
     "limit"       BIGINT       NOT NULL DEFAULT 0 CHECK ("limit" >= 0),
     used_limit    BIGINT       NOT NULL DEFAULT 0 CHECK (used_limit >= 0),
+    need_approval BOOLEAN      NOT NULL DEFAULT false,
     created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMP    NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
Closes #198. Implements the actuary supervisor portal (spec p.39):
- `need_approval BOOLEAN NOT NULL DEFAULT false` on `employees` (schema + Go model + proto).
- New gRPCs `UpdateEmployeeNeedApproval` and `GetActuaries` (filters by `agent` permission).
- Gateway routes under `/api/actuaries` (supervisor-gated, admin bypass intact):
  - `GET /api/actuaries` — filters: `email`, `first_name`, `last_name`, `position`
  - `PATCH /api/actuaries/:id/limit`
  - `POST /api/actuaries/:id/reset-used-limit` (delegates to `UpdateEmployeeTradingLimit` with `used_limit=0`)
  - `PATCH /api/actuaries/:id/need-approval`
- Daily 23:59 cron in `internal/bank/cron.go` (`RunDailyUsedLimitReset`) that zeroes `employees.used_limit`. Reuses the existing poor-man's-cron harness via a new `runOnScheduleAt(hour, minute, …)` helper.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` (incl. new `internal/user/actuaries_test.go` covering arg/permission validation on `UpdateEmployeeNeedApproval` and the agent-only filter in `GetActuaries`)
- [ ] Manual: hit `/api/actuaries` as supervisor and verify filters; flip `need_approval`; reset `used_limit`; let cron fire (or call once) and confirm reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)