### PR TITLE
feat(permissions): admin implies supervisor (#199)

### DIFF
--- a/internal/user/server.go
+++ b/internal/user/server.go
@@ -215,6 +215,16 @@ func (s *Server) GetEmployees(_ context.Context, req *userpb.GetEmployeesRequest
 
 func (s *Server) UpdateEmployee(ctx context.Context, req *userpb.UpdateEmployeeRequest) (*userpb.GetEmployeeResponse, error) {
 	existing, existingErr := getUserByAttribute(Employee{}, s.db_gorm, "id", req.Id)
+
+	// Spec p.38: an admin may not edit another admin. Self-edits are allowed.
+	if existingErr == nil && existing != nil {
+		existingPerms := permissionSet(existing.Permissions)
+		if _, targetIsAdmin := existingPerms["admin"]; targetIsAdmin &&
+			!strings.EqualFold(strings.TrimSpace(req.CallerEmail), existing.Email) {
+			return nil, status.Error(codes.PermissionDenied, "admins cannot edit other admins")
+		}
+	}
+
 	if !req.Active {
 		if existingErr == nil && existing != nil {
 			for _, p := range existing.Permissions {
@@ -223,6 +233,12 @@ func (s *Server) UpdateEmployee(ctx context.Context, req *userpb.UpdateEmployeeR
 				}
 			}
 		}
+	}
+
+	// Spec p.38: every admin is also a supervisor. Granting admin implicitly
+	// grants supervisor; revoking admin leaves supervisor untouched.
+	if req.Permissions != nil {
+		req.Permissions = ensureAdminImpliesSupervisor(req.Permissions)
 	}
 
 	// Only admins may grant or revoke the `agent` / `supervisor` permissions.
@@ -420,6 +436,20 @@ func namesToSet(names []string) map[string]struct{} {
 		out[n] = struct{}{}
 	}
 	return out
+}
+
+// ensureAdminImpliesSupervisor returns perms with "supervisor" appended when
+// "admin" is present but "supervisor" is not (spec p.38: admin is-a supervisor).
+// Idempotent: calling twice yields the same result.
+func ensureAdminImpliesSupervisor(perms []string) []string {
+	set := namesToSet(perms)
+	if _, hasAdmin := set["admin"]; !hasAdmin {
+		return perms
+	}
+	if _, hasSup := set["supervisor"]; hasSup {
+		return perms
+	}
+	return append(perms, "supervisor")
 }
 
 // togglesTradingRole reports whether the `agent` or `supervisor` membership differs
@@ -1003,8 +1033,11 @@ func (s *Server) CreateEmployeeAccount(ctx context.Context, req *userpb.CreateEm
 		log.Printf("Error generating salt %s", salt_err.Error())
 	}
 
-	permissions := make([]Permission, 0, len(req.Permissions))
-	for _, permName := range req.Permissions {
+	// Spec p.38: every admin is also a supervisor.
+	reqPerms := ensureAdminImpliesSupervisor(req.Permissions)
+
+	permissions := make([]Permission, 0, len(reqPerms))
+	for _, permName := range reqPerms {
 		var perm Permission
 		if err := s.db_gorm.First(&perm, "name = ?", permName).Error; err != nil {
 			log.Printf("Permission %q not found, skipping", permName)

--- a/internal/user/trading_limits_test.go
+++ b/internal/user/trading_limits_test.go
@@ -2,8 +2,11 @@ package user
 
 import (
 	"context"
+	"regexp"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/user"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -86,3 +89,74 @@ func TestUpdateEmployeeTradingLimitArgValidation(t *testing.T) {
 }
 
 func ptr64(v int64) *int64 { return &v }
+
+// Spec p.38: granting `admin` implicitly grants `supervisor`. Revoking `admin`
+// does not touch `supervisor`. ensureAdminImpliesSupervisor is the pure helper
+// behind both CreateEmployeeAccount and UpdateEmployee; covering it here pins
+// the invariant without needing a full DB harness.
+func TestEnsureAdminImpliesSupervisor(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"no admin, untouched", []string{"manage_loans"}, []string{"manage_loans"}},
+		{"admin without supervisor → appends", []string{"admin"}, []string{"admin", "supervisor"}},
+		{"admin with supervisor → idempotent", []string{"admin", "supervisor"}, []string{"admin", "supervisor"}},
+		{"supervisor alone stays alone", []string{"supervisor"}, []string{"supervisor"}},
+		{"nil in, nil out", nil, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ensureAdminImpliesSupervisor(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v want %v", got, tc.want)
+			}
+			gotSet := namesToSet(got)
+			for _, p := range tc.want {
+				if _, ok := gotSet[p]; !ok {
+					t.Fatalf("missing %q in result %v", p, got)
+				}
+			}
+		})
+	}
+}
+
+// Spec p.38: an admin may not edit another admin. The server must short-circuit
+// before touching the permissions payload.
+func TestUpdateEmployeeBlocksAdminOnAdmin(t *testing.T) {
+	server, mock, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Now()
+
+	// getUserByAttribute(Employee, "id", 1): returns a target who already has `admin`.
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "employees" WHERE id = $1 ORDER BY "employees"."id" LIMIT $2`)).
+		WithArgs(int64(1), 1).
+		WillReturnRows(sqlmockEmployeeRows().
+			AddRow(uint64(1), "Target", "Admin", birth, "M", "target-admin@banka.raf", "+381", "addr",
+				"tadmin", []byte("pw"), []byte("salt"), "Admin", "IT", true, int64(0), int64(0), false, now, now))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "employee_permissions" WHERE "employee_permissions"."employee_id" = $1`)).
+		WithArgs(uint64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"employee_id", "permission_id"}).AddRow(uint64(1), uint64(1)))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "permissions" WHERE "permissions"."id" = $1`)).
+		WithArgs(uint64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(uint64(1), "admin"))
+
+	_, err := server.UpdateEmployee(context.Background(), &userpb.UpdateEmployeeRequest{
+		Id:          1,
+		Active:      true,
+		CallerEmail: "someone-else@banka.raf",
+		Permissions: []string{"admin"},
+	})
+	if err == nil {
+		t.Fatal("expected PermissionDenied, got nil")
+	}
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("got code %s, want PermissionDenied (err=%v)", status.Code(err), err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -29,11 +29,11 @@ VALUES (
 )
 ON CONFLICT (email) DO NOTHING;
 
--- give admin user the admin permission
+-- give admin user the admin and supervisor permissions (spec p.38: admin implies supervisor)
 INSERT INTO employee_permissions (employee_id, permission_id)
 SELECT e.id, p.id
 FROM employees e, permissions p
-WHERE e.email = :'admin_email' AND p.name = 'admin'
+WHERE e.email = :'admin_email' AND p.name IN ('admin', 'supervisor')
 ON CONFLICT DO NOTHING;
 
 -- full-employee employee (password: "Test1234!") — has all permissions for testing


### PR DESCRIPTION
## Summary
- Granting `admin` now implicitly grants `supervisor` in both `CreateEmployeeAccount` and `UpdateEmployee` (idempotent). Revoking `admin` leaves `supervisor` untouched.
- `UpdateEmployee` blocks an admin caller from editing another admin (self-edits still allowed by email match). Non-admin supervisors remain editable by admins, per spec p.38.
- Seeded admin user now gets `supervisor` alongside `admin`.

Closes #199.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests:
  - `TestEnsureAdminImpliesSupervisor` — grant, idempotency, revoke leaves supervisor alone.
  - `TestUpdateEmployeeBlocksAdminOnAdmin` — sqlmock verifies admin-on-admin edit returns `PermissionDenied`.
- [ ] Fresh `make seed` / DB reset: confirm `admin@banka.raf` has both `admin` and `supervisor`.
- [ ] Manual: as admin, edit another admin → 403; edit a non-admin supervisor → OK.
- [ ] Manual: grant `admin` to a fresh employee → `supervisor` appears in their permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)