### PR TITLE
feat(trading): CreateOrder approval routing (#200)

### DIFF
--- a/internal/bank/account.go
+++ b/internal/bank/account.go
@@ -42,6 +42,12 @@ func (s *Server) AuthorizeAccountAccess(ctx context.Context, acc *Account) error
 	return s.authorizeAccountAccess(ctx, acc)
 }
 
+// GetExchangeRateToRSD is exported for in-process callers (trading uses it to
+// convert approximate order price into RSD for agent-limit accounting).
+func (s *Server) GetExchangeRateToRSD(currencyLabel string) (float64, error) {
+	return s.getExchangeRateToRSD(currencyLabel)
+}
+
 func (s *Server) ListAccounts(ctx context.Context, req *bankpb.ListAccountsRequest) (*bankpb.ListAccountsResponse, error) {
 	caller, err := s.resolveCaller(ctx)
 	if err != nil {

--- a/internal/trading/approval.go
+++ b/internal/trading/approval.go
@@ -1,0 +1,155 @@
+package trading
+
+import (
+	"errors"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// callerRole classifies who is placing the order for status-routing purposes
+// (spec p.51). Supervisor wins over agent when an employee happens to carry
+// both permissions.
+type callerRole int
+
+const (
+	roleClient callerRole = iota
+	roleSupervisor
+	roleAgent
+	roleOtherEmployee
+)
+
+// agentLimits captures the employee-level knobs that gate an agent's orders.
+// limit/used_limit are RSD minor units; need_approval forces every order to
+// supervisor review regardless of headroom (spec p.39).
+type agentLimits struct {
+	Limit        int64
+	UsedLimit    int64
+	NeedApproval bool
+}
+
+// approvalPricePerUnit returns the unit price that feeds the approximate-price
+// formula (spec p.57). Market orders use the current listing/option/forex
+// quote; limit & stop-limit use the user-provided limit value; stop uses the
+// stop value.
+func approvalPricePerUnit(ot OrderType, req *tradingpb.CreateOrderRequest, marketPrice int64) int64 {
+	switch ot {
+	case OrderMarket:
+		return marketPrice
+	case OrderLimit, OrderStopLimit:
+		return req.LimitPrice
+	case OrderStop:
+		return req.StopPrice
+	}
+	return 0
+}
+
+// decideOrderStatus encodes the spec p.51 routing table:
+//   - expired underlying → decline immediately.
+//   - client or supervisor placer → approve.
+//   - agent placer → pending when need_approval is set, when used_limit has
+//     already hit limit, or when this order would push the agent over limit.
+//   - other employees (no agent/supervisor perms) → approve; the spec only
+//     calls out agents for supervisor review.
+func decideOrderStatus(role callerRole, limits agentLimits, approxRSD int64, pastSettlement bool) OrderStatus {
+	if pastSettlement {
+		return StatusDeclined
+	}
+	if role != roleAgent {
+		return StatusApproved
+	}
+	if limits.NeedApproval {
+		return StatusPending
+	}
+	if limits.UsedLimit >= limits.Limit {
+		return StatusPending
+	}
+	if approxRSD+limits.UsedLimit > limits.Limit {
+		return StatusPending
+	}
+	return StatusApproved
+}
+
+// isPastSettlement is centralized so time semantics stay consistent — we
+// compare dates (a settlement on today's date hasn't passed yet).
+func isPastSettlement(sd *time.Time, now time.Time) bool {
+	if sd == nil {
+		return false
+	}
+	return sd.Before(now.Truncate(24 * time.Hour))
+}
+
+// approxPriceRSD converts the native-currency approximate price to RSD minor
+// units via the bank's menjacnica rate (no commission — spec p.57). RSD-native
+// instruments skip the lookup to avoid a DB round-trip.
+func (s *Server) approxPriceRSD(currency string, contractSize, pricePerUnit, quantity int64) (int64, error) {
+	native := contractSize * pricePerUnit * quantity
+	if currency == "RSD" {
+		return native, nil
+	}
+	rate, err := s.bank.GetExchangeRateToRSD(currency)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", currency, err)
+	}
+	return int64(float64(native) * rate), nil
+}
+
+// resolveEmployeeRole loads the placer's limits and classifies their trading
+// role from their permission set. admin and supervisor map to roleSupervisor
+// (admin implies supervisor per spec p.38 / #199), agent maps to roleAgent,
+// anything else falls through to roleOtherEmployee.
+func resolveEmployeeRole(tx *gorm.DB, email string) (int64, callerRole, agentLimits, error) {
+	var emp struct {
+		ID           int64
+		Limit        int64 `gorm:"column:limit"`
+		UsedLimit    int64 `gorm:"column:used_limit"`
+		NeedApproval bool  `gorm:"column:need_approval"`
+	}
+	err := tx.Table("employees").
+		Select(`id, "limit", used_limit, need_approval`).
+		Where("email = ?", email).
+		Take(&emp).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, 0, agentLimits{}, status.Error(codes.NotFound, "employee not found")
+		}
+		return 0, 0, agentLimits{}, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	var perms []string
+	err = tx.Table("permissions AS p").
+		Joins("JOIN employee_permissions ep ON ep.permission_id = p.id").
+		Where("ep.employee_id = ?", emp.ID).
+		Pluck("p.name", &perms).Error
+	if err != nil {
+		return 0, 0, agentLimits{}, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	limits := agentLimits{
+		Limit:        emp.Limit,
+		UsedLimit:    emp.UsedLimit,
+		NeedApproval: emp.NeedApproval,
+	}
+
+	isSupervisor := false
+	isAgent := false
+	for _, p := range perms {
+		switch p {
+		case "admin", "supervisor":
+			isSupervisor = true
+		case "agent":
+			isAgent = true
+		}
+	}
+	switch {
+	case isSupervisor:
+		return emp.ID, roleSupervisor, limits, nil
+	case isAgent:
+		return emp.ID, roleAgent, limits, nil
+	default:
+		return emp.ID, roleOtherEmployee, limits, nil
+	}
+}

--- a/internal/trading/approval_test.go
+++ b/internal/trading/approval_test.go
@@ -1,0 +1,88 @@
+package trading
+
+import (
+	"testing"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+)
+
+func TestApprovalPricePerUnit(t *testing.T) {
+	req := &tradingpb.CreateOrderRequest{LimitPrice: 150, StopPrice: 120}
+	cases := []struct {
+		name        string
+		ot          OrderType
+		marketPrice int64
+		want        int64
+	}{
+		{"market uses listing quote", OrderMarket, 99, 99},
+		{"limit uses limit value", OrderLimit, 99, 150},
+		{"stop uses stop value", OrderStop, 99, 120},
+		{"stop_limit uses limit value", OrderStopLimit, 99, 150},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := approvalPricePerUnit(c.ot, req, c.marketPrice); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDecideOrderStatus(t *testing.T) {
+	agent := agentLimits{Limit: 1000, UsedLimit: 200, NeedApproval: false}
+	needApproval := agentLimits{Limit: 1000, UsedLimit: 0, NeedApproval: true}
+	exhausted := agentLimits{Limit: 1000, UsedLimit: 1000, NeedApproval: false}
+
+	cases := []struct {
+		name           string
+		role           callerRole
+		limits         agentLimits
+		approxRSD      int64
+		pastSettlement bool
+		want           OrderStatus
+	}{
+		{"past settlement declines all", roleClient, agentLimits{}, 0, true, StatusDeclined},
+		{"client approved", roleClient, agentLimits{}, 100, false, StatusApproved},
+		{"supervisor approved", roleSupervisor, agentLimits{}, 100, false, StatusApproved},
+		{"other employee approved", roleOtherEmployee, agentLimits{}, 100, false, StatusApproved},
+		{"agent within limit", roleAgent, agent, 500, false, StatusApproved},
+		{"agent need_approval pending", roleAgent, needApproval, 10, false, StatusPending},
+		{"agent used_limit reached pending", roleAgent, exhausted, 10, false, StatusPending},
+		{"agent approx pushes over limit", roleAgent, agent, 900, false, StatusPending},
+		{"agent exactly at limit approved", roleAgent, agent, 800, false, StatusApproved},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := decideOrderStatus(c.role, c.limits, c.approxRSD, c.pastSettlement)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsPastSettlement(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	yesterday := now.AddDate(0, 0, -1)
+	today := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+	tomorrow := now.AddDate(0, 0, 1)
+
+	cases := []struct {
+		name string
+		sd   *time.Time
+		want bool
+	}{
+		{"nil settlement (stock/forex) not past", nil, false},
+		{"yesterday is past", &yesterday, true},
+		{"today is not past", &today, false},
+		{"tomorrow is not past", &tomorrow, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isPastSettlement(c.sd, now); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/trading/orders.go
+++ b/internal/trading/orders.go
@@ -2,6 +2,7 @@ package trading
 
 import (
 	"errors"
+	"time"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
 	"google.golang.org/grpc/codes"
@@ -77,12 +78,26 @@ func marketReferencePrice(ot OrderType, req *tradingpb.CreateOrderRequest) int64
 	return 0
 }
 
-// resolveInstrument returns (exchange, currency) for the order's instrument.
-// Listings inherit both from their exchange; options follow the underlying
-// stock's listing to its exchange; forex pairs aren't tied to any exchange
-// and use the quote currency (exchange is returned as nil). Callers that
+// instrumentInfo bundles everything CreateOrder needs to know about the
+// underlying for auth, accounting, and approval routing. Exchange is nil for
+// forex pairs (they have no listing/exchange per spec). SettlementDate is set
+// only for futures and options — stocks and forex don't expire. MarketPrice is
+// the reference price used when the order type is `market` (issue #200's
+// approximate-price formula — page 57).
+type instrumentInfo struct {
+	Exchange       *Exchange
+	Currency       string
+	ContractSize   int64
+	MarketPrice    int64
+	SettlementDate *time.Time
+}
+
+// resolveInstrument loads the underlying referenced by the CreateOrder request
+// and returns the derived fields used downstream. Listings inherit currency
+// from their exchange; options follow the underlying stock's listing; forex
+// pairs aren't tied to any exchange and use the quote currency. Callers that
 // need the clock (IsOpen / IsAfterHours) should skip forex.
-func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*Exchange, string, error) {
+func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrumentInfo, error) {
 	set := 0
 	if req.ListingId != 0 {
 		set++
@@ -94,7 +109,7 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*Exchange
 		set++
 	}
 	if set != 1 {
-		return nil, "", status.Error(codes.InvalidArgument, "exactly one of listing_id, option_id, forex_pair_id must be set")
+		return nil, status.Error(codes.InvalidArgument, "exactly one of listing_id, option_id, forex_pair_id must be set")
 	}
 
 	switch {
@@ -102,63 +117,74 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*Exchange
 		var listing Listing
 		if err := s.db.First(&listing, req.ListingId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, "", status.Error(codes.NotFound, "listing not found")
+				return nil, status.Error(codes.NotFound, "listing not found")
 			}
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		var exch Exchange
 		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
-		return &exch, exch.Currency, nil
+		info := &instrumentInfo{
+			Exchange:     &exch,
+			Currency:     exch.Currency,
+			ContractSize: 1,
+			MarketPrice:  listing.Price,
+		}
+		if listing.FutureID != nil {
+			var fut Future
+			if err := s.db.First(&fut, *listing.FutureID).Error; err != nil {
+				return nil, status.Errorf(codes.Internal, "%v", err)
+			}
+			info.ContractSize = fut.ContractSize
+			sd := fut.SettlementDate
+			info.SettlementDate = &sd
+		}
+		return info, nil
 
 	case req.OptionId != 0:
 		var opt Option
 		if err := s.db.First(&opt, req.OptionId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, "", status.Error(codes.NotFound, "option not found")
+				return nil, status.Error(codes.NotFound, "option not found")
 			}
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		var listing Listing
 		if err := s.db.Where("stock_id = ?", opt.StockID).First(&listing).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, "", status.Error(codes.FailedPrecondition, "underlying stock has no listing")
+				return nil, status.Error(codes.FailedPrecondition, "underlying stock has no listing")
 			}
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		var exch Exchange
 		if err := s.db.First(&exch, listing.ExchangeID).Error; err != nil {
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
-		return &exch, exch.Currency, nil
+		sd := opt.SettlementDate
+		return &instrumentInfo{
+			Exchange:       &exch,
+			Currency:       exch.Currency,
+			ContractSize:   1,
+			MarketPrice:    opt.Premium,
+			SettlementDate: &sd,
+		}, nil
 
 	default: // forex pair — no exchange
 		var fx ForexPair
 		if err := s.db.First(&fx, req.ForexPairId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, "", status.Error(codes.NotFound, "forex pair not found")
+				return nil, status.Error(codes.NotFound, "forex pair not found")
 			}
-			return nil, "", status.Errorf(codes.Internal, "%v", err)
+			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
-		return nil, fx.QuoteCurrency, nil
+		// Forex convention (spec p.48, mirrored by ListForexPairs): contract
+		// size 1000, price in minor units is exchange_rate * 100.
+		return &instrumentInfo{
+			Currency:     fx.QuoteCurrency,
+			ContractSize: 1000,
+			MarketPrice:  int64(fx.ExchangeRate * 100),
+		}, nil
 	}
 }
 
-// lookupEmployeeID resolves an employee email to its bank-side id. We query
-// the employees table directly since we already have a DB handle; going
-// through the user gRPC service would add a hop for data that lives here.
-func lookupEmployeeID(tx *gorm.DB, email string) (int64, error) {
-	var row struct{ ID int64 }
-	err := tx.Table("employees").
-		Select("id").
-		Where("email = ?", email).
-		Take(&row).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return 0, status.Error(codes.NotFound, "employee not found")
-		}
-		return 0, status.Errorf(codes.Internal, "%v", err)
-	}
-	return row.ID, nil
-}

--- a/internal/trading/orders.go
+++ b/internal/trading/orders.go
@@ -187,4 +187,3 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrume
 		}, nil
 	}
 }
-

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -90,28 +90,38 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		return nil, err
 	}
 
-	exch, instrumentCurrency, err := s.resolveInstrument(req)
+	info, err := s.resolveInstrument(req)
 	if err != nil {
 		return nil, err
 	}
-	if acc.Currency != instrumentCurrency {
+	if acc.Currency != info.Currency {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"account currency %s does not match instrument currency %s",
-			acc.Currency, instrumentCurrency)
+			acc.Currency, info.Currency)
 	}
 
+	now := time.Now()
 	// after_hours is an exchange-clock concept; forex pairs have no exchange
 	// and always leave the flag false.
-	afterHours := exch != nil && IsAfterHours(*exch, time.Now())
+	afterHours := info.Exchange != nil && IsAfterHours(*info.Exchange, now)
 
-	pricePerUnit := marketReferencePrice(orderType, req)
+	// Approximate-price inputs (spec p.57). We keep PricePerUnit=0 on market
+	// orders so the execution engine (#189) re-reads the quote at fill time,
+	// but approval math still needs a concrete number — that's what
+	// approvalPricePerUnit provides.
+	approvalPPU := approvalPricePerUnit(orderType, req, info.MarketPrice)
+	approxRSD, err := s.approxPriceRSD(info.Currency, info.ContractSize, approvalPPU, req.Quantity)
+	if err != nil {
+		return nil, err
+	}
+	pastSettlement := isPastSettlement(info.SettlementDate, now)
+
 	order := Order{
 		OrderType:         orderType,
 		Direction:         direction,
-		Status:            StatusPending,
 		Quantity:          req.Quantity,
-		ContractSize:      1,
-		PricePerUnit:      pricePerUnit,
+		ContractSize:      info.ContractSize,
+		PricePerUnit:      marketReferencePrice(orderType, req),
 		RemainingPortions: req.Quantity,
 		AfterHours:        afterHours,
 		AllOrNone:         req.AllOrNone,
@@ -132,6 +142,10 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 
 	if err := s.db.Transaction(func(tx *gorm.DB) error {
 		placer := OrderPlacer{}
+		role := roleClient
+		var limits agentLimits
+		var employeeID int64
+
 		if caller.IsClient {
 			id := caller.ClientID
 			placer.ClientID = &id
@@ -139,20 +153,43 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			if caller.Email == "" {
 				return status.Error(codes.Internal, "employee email missing from caller")
 			}
-			empID, lookupErr := lookupEmployeeID(tx, caller.Email)
-			if lookupErr != nil {
-				return lookupErr
+			empID, r, lim, roleErr := resolveEmployeeRole(tx, caller.Email)
+			if roleErr != nil {
+				return roleErr
 			}
+			employeeID = empID
+			role = r
+			limits = lim
 			placer.EmployeeID = &empID
 		} else {
 			return status.Error(codes.PermissionDenied, "caller is neither client nor employee")
 		}
+
+		order.Status = decideOrderStatus(role, limits, approxRSD, pastSettlement)
+
 		if err := tx.Create(&placer).Error; err != nil {
 			return err
 		}
 		order.PlacerID = placer.ID
-		return tx.Create(&order).Error
+		if err := tx.Create(&order).Error; err != nil {
+			return err
+		}
+
+		// Agent self-approved orders consume daily limit immediately so a
+		// follow-on order sees the updated headroom. Pending orders stay out
+		// of used_limit until the supervisor approves them (#204).
+		if role == roleAgent && order.Status == StatusApproved {
+			if err := tx.Table("employees").
+				Where("id = ?", employeeID).
+				Update("used_limit", gorm.Expr("used_limit + ?", approxRSD)).Error; err != nil {
+				return err
+			}
+		}
+		return nil
 	}); err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `pending` with spec p.51 routing: clients & supervisors `approved`; agents `pending` when `need_approval`, `used_limit >= limit`, or approx + used_limit exceeds limit; otherwise `approved`.
- Decline immediately when the underlying future/option is past settlement (spec p.51).
- Approximate price follows spec p.57 (`contract_size * price_per_unit * quantity`) with RSD conversion via menjacnica (no commission) for non-RSD instruments. `price_per_unit` is listing/option quote for market, user limit/stop values for limit/stop/stop-limit.
- Agent-approved orders bump `used_limit` inside the same transaction so follow-on orders see updated headroom. Pending orders do not consume limit yet (that moves to #204 on approve).
- `Order.ContractSize` now reflects the underlying (`Future.ContractSize` for futures, 1000 for forex pairs per spec p.48) instead of the hardcoded 1.
- `bank.GetExchangeRateToRSD` exported for in-process trading usage, same pattern as `ResolveCaller`/`AuthorizeAccountAccess`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual: place an agent order via gateway with `limit` close to exhausted; verify follow-on returns `pending`.
- [ ] Manual: place a future order whose settlement is in the past; verify immediate `declined`.
- [ ] Manual: supervisor placing an order gets `approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)