### PR TITLE
feat(trading): commission on order placement (#201)

### DIFF
--- a/internal/trading/commission.go
+++ b/internal/trading/commission.go
@@ -1,0 +1,100 @@
+package trading
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// Commission capAmounts in native-currency minor units (spec pp. 51–52). We treat
+// "$7" / "$12" as 7.00 / 12.00 in the instrument's currency — matching how
+// price_per_unit is stored (e.g. forex `int64(ExchangeRate * 100)`).
+const (
+	commissionCapMarket int64 = 700
+	commissionCapLimit  int64 = 1200
+	// Percentages are taken as integer permille to avoid float rounding:
+	// 14% = 140‰, 24% = 240‰.
+	commissionPermilleMarket int64 = 140
+	commissionPermilleLimit  int64 = 240
+)
+
+// bankSystemOwnerEmail is the system client whose per-currency internal
+// accounts act as the bank's fee-collection accounts (seeded in seed.sql).
+const bankSystemOwnerEmail = "system@banka3.rs"
+
+// computeCommission returns the commission in the instrument's currency minor
+// units. Stop orders bill like market (they become market at trigger),
+// stop_limit bills like limit (spec p. 51).
+func computeCommission(ot OrderType, approxNative int64) int64 {
+	var permille, capAmount int64
+	switch ot {
+	case OrderMarket, OrderStop:
+		permille, capAmount = commissionPermilleMarket, commissionCapMarket
+	case OrderLimit, OrderStopLimit:
+		permille, capAmount = commissionPermilleLimit, commissionCapLimit
+	default:
+		return 0
+	}
+	pct := (approxNative * permille) / 1000
+	if pct < capAmount {
+		return pct
+	}
+	return capAmount
+}
+
+// chargeCommission debits the placer's account and credits the bank's
+// fee-collection account in the same currency, atomically inside the caller's
+// transaction. Returns FailedPrecondition if the placer cannot cover the fee,
+// FailedPrecondition if no bank fee account exists for the currency.
+func chargeCommission(tx *gorm.DB, debitAccount, currency string, amount int64) error {
+	if amount <= 0 {
+		return nil
+	}
+
+	// Debit placer with a balance guard so overdrafts fail loudly rather than
+	// silently driving the account negative.
+	res := tx.Exec(
+		`UPDATE accounts SET balance = balance - ? WHERE number = ? AND balance >= ?`,
+		amount, debitAccount, amount,
+	)
+	if res.Error != nil {
+		return status.Errorf(codes.Internal, "%v", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return status.Error(codes.FailedPrecondition, "insufficient funds for commission")
+	}
+
+	// Credit the bank's fee-collection account for this currency. Seeded per
+	// currency under the system client; see seed.sql.
+	var feeAccount string
+	err := tx.Raw(
+		`SELECT a.number FROM accounts a
+		 JOIN clients c ON c.id = a.owner
+		 WHERE c.email = ? AND a.currency = ?
+		 LIMIT 1`,
+		bankSystemOwnerEmail, currency,
+	).Scan(&feeAccount).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return status.Errorf(codes.FailedPrecondition, "no fee-collection account for %s", currency)
+		}
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	if feeAccount == "" {
+		return status.Errorf(codes.FailedPrecondition, "no fee-collection account for %s", currency)
+	}
+
+	res = tx.Exec(
+		`UPDATE accounts SET balance = balance + ? WHERE number = ?`,
+		amount, feeAccount,
+	)
+	if res.Error != nil {
+		return status.Errorf(codes.Internal, "%v", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return status.Errorf(codes.FailedPrecondition, "no fee-collection account for %s", currency)
+	}
+	return nil
+}

--- a/internal/trading/commission_test.go
+++ b/internal/trading/commission_test.go
@@ -1,0 +1,35 @@
+package trading
+
+import "testing"
+
+func TestComputeCommission(t *testing.T) {
+	cases := []struct {
+		name   string
+		ot     OrderType
+		approx int64
+		want   int64
+	}{
+		// Market/stop: 14% of approx, capped at 700.
+		{"market tiny → pct", OrderMarket, 1000, 140},
+		{"market at cap", OrderMarket, 5000, 700},
+		{"market above cap", OrderMarket, 100000, 700},
+		{"stop follows market", OrderStop, 1000, 140},
+		{"stop above cap", OrderStop, 100000, 700},
+
+		// Limit/stop_limit: 24% of approx, capped at 1200.
+		{"limit tiny → pct", OrderLimit, 1000, 240},
+		{"limit at cap", OrderLimit, 5000, 1200},
+		{"limit above cap", OrderLimit, 100000, 1200},
+		{"stop_limit follows limit", OrderStopLimit, 1000, 240},
+		{"stop_limit above cap", OrderStopLimit, 100000, 1200},
+
+		{"zero approx → zero", OrderMarket, 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := computeCommission(c.ot, c.approx); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/trading/models.go
+++ b/internal/trading/models.go
@@ -155,6 +155,7 @@ type Order struct {
 	ContractSize      int64          `gorm:"column:contract_size;not null;default:1"`
 	PricePerUnit      int64          `gorm:"column:price_per_unit;not null"`
 	RemainingPortions int64          `gorm:"column:remaining_portions;not null"`
+	Commission        int64          `gorm:"column:commission;not null;default:0"`
 	ApprovedBy        *int64         `gorm:"column:approved_by"`
 	IsDone            bool           `gorm:"column:is_done;not null;default:false"`
 	AfterHours        bool           `gorm:"column:after_hours;not null;default:false"`

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -110,11 +110,13 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	// but approval math still needs a concrete number — that's what
 	// approvalPricePerUnit provides.
 	approvalPPU := approvalPricePerUnit(orderType, req, info.MarketPrice)
+	approxNative := info.ContractSize * approvalPPU * req.Quantity
 	approxRSD, err := s.approxPriceRSD(info.Currency, info.ContractSize, approvalPPU, req.Quantity)
 	if err != nil {
 		return nil, err
 	}
 	pastSettlement := isPastSettlement(info.SettlementDate, now)
+	commission := computeCommission(orderType, approxNative)
 
 	order := Order{
 		OrderType:         orderType,
@@ -126,6 +128,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		AfterHours:        afterHours,
 		AllOrNone:         req.AllOrNone,
 		Margin:            req.Margin,
+		Commission:        commission,
 	}
 	if req.ListingId != 0 {
 		v := req.ListingId
@@ -173,6 +176,15 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		order.PlacerID = placer.ID
 		if err := tx.Create(&order).Error; err != nil {
 			return err
+		}
+
+		// Commission is reserved at placement (spec pp. 51–52): transfer from
+		// the placer's account to the bank's fee-collection account in the
+		// same currency. Declined orders (past settlement) skip the charge.
+		if order.Status != StatusDeclined {
+			if err := chargeCommission(tx, req.AccountNumber, info.Currency, commission); err != nil {
+				return err
+			}
 		}
 
 		// Agent self-approved orders consume daily limit immediately so a

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -412,6 +412,7 @@ CREATE TABLE IF NOT EXISTS orders (
     contract_size       BIGINT          NOT NULL DEFAULT 1,
     price_per_unit      BIGINT          NOT NULL,
     remaining_portions  BIGINT          NOT NULL,
+    commission          BIGINT          NOT NULL DEFAULT 0,
     approved_by         BIGINT          REFERENCES employees(id) ON UPDATE CASCADE ON DELETE SET NULL,
     is_done             BOOLEAN         NOT NULL DEFAULT FALSE,
     after_hours         BOOLEAN         NOT NULL DEFAULT FALSE,

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -244,7 +244,7 @@ ON CONFLICT (currency_code) DO NOTHING;
 -- Internal bank accounts (one per currency)
 --
 -- These are the bank's own accounts used for:
---   1. Receiving transaction commissions
+--   1. Receiving transaction commissions (payments + trading, spec pp. 51–52)
 --   2. Intermediary in currency exchange (menjacnica)
 --   3. Loan disbursements and repayments
 --


### PR DESCRIPTION
## Summary
- Reserve-at-placement: compute commission from approximate native-currency price and transfer it to the bank at `CreateOrder` time (declined orders skip the charge).
- Formulas (spec pp. 51–52, minor-unit caps matching how `price_per_unit` is stored):
  - market / stop: `min(14% * approx_native, 700)`
  - limit / stop_limit: `min(24% * approx_native, 1200)`
- Persist commission on `orders.commission` so the supervisor portal can display it.
- Debit placer's account, credit the matching bank fee-collection account in the same currency — atomically inside the existing gorm tx.
- Reuses the per-currency Banka 3 internal accounts already seeded under `system@banka3.rs`; no new seed rows.

## Decisions
- **Reserve-at-placement** chosen over pay-on-fill: execution (#189) isn't wired yet, and the issue asks us to pick + document one. Simpler audit trail and fails loudly up front.
- Cap units: `$7` / `$12` from spec treated as 700 / 1200 in the instrument's currency minor units, matching the existing minor-unit convention across trading (e.g. forex `int64(ExchangeRate * 100)`).

## Test plan
- [x] Unit: `computeCommission` covers pct / at-cap / above-cap for all four order types + zero.
- [x] `go test ./...` passes.
- [ ] Manual: place a market/limit/stop/stop_limit order; verify `orders.commission` is populated, placer balance decreased by commission, Banka 3 account in matching currency increased.
- [ ] Manual: place an order that would be declined (past-settlement option/future) → no commission transfer, `commission` still recorded on the row.
- [ ] Manual: place an order whose account has insufficient funds for the commission → `FailedPrecondition` and no row created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)