### PR TITLE
feat(trading): margin eligibility check on CreateOrder

### DIFF
--- a/internal/trading/margin.go
+++ b/internal/trading/margin.go
@@ -1,0 +1,110 @@
+package trading
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// maintenanceMargin computes the maintenance margin in instrument-native minor
+// units for a position of the given quantity (spec pp.47–49). The formula is
+// uniform once MarginBasePrice / MarginPermille are resolved per security
+// type (see resolveInstrument):
+//
+//	stock   : 1            × price       × 50%  × qty
+//	future  : contract_size× price       × 10%  × qty
+//	forex   : 1000         × price       × 10%  × qty
+//	option  : 1            × stock_price × 50%  × qty
+func maintenanceMargin(contractSize, basePrice, quantity, permille int64) int64 {
+	return contractSize * basePrice * quantity * permille / 1000
+}
+
+// initialMarginCost returns the Initial Margin Cost in the same units as the
+// input: IMC = Maintenance Margin × 1.1 (spec p.56).
+func initialMarginCost(mm int64) int64 {
+	return mm * 11 / 10
+}
+
+// callerHasMarginPermission checks whether the given employee email has the
+// `margin_trading` permission (admin bypasses). Used to gate employee-placed
+// margin orders per spec p.56.
+func callerHasMarginPermission(db *gorm.DB, email string) bool {
+	if email == "" {
+		return false
+	}
+	var count int64
+	err := db.Table("employees").
+		Joins("JOIN employee_permissions ep ON ep.employee_id = employees.id").
+		Joins("JOIN permissions p ON p.id = ep.permission_id").
+		Where("employees.email = ? AND p.name IN (?)", email, []string{"admin", "margin_trading"}).
+		Count(&count).Error
+	if err != nil {
+		return false
+	}
+	return count > 0
+}
+
+// checkMarginEligibility enforces the spec p.56 rules when an order is placed
+// on margin. Clients qualify if they hold any approved loan whose remaining
+// debt (converted to RSD) exceeds IMC_RSD; otherwise — and always for
+// employee placers — the debit account's balance must exceed IMC in the
+// instrument's native currency. Rejects with InvalidArgument when neither
+// condition holds.
+func (s *Server) checkMarginEligibility(tx *gorm.DB, clientID int64, isClient bool, debitBalance int64, info *instrumentInfo, quantity int64) error {
+	mm := maintenanceMargin(info.ContractSize, info.MarginBasePrice, quantity, info.MarginPermille)
+	imcNative := initialMarginCost(mm)
+
+	if isClient {
+		imcRSD, err := s.approxPriceRSD(info.Currency, 1, imcNative, 1)
+		if err != nil {
+			return err
+		}
+		ok, err := clientHasQualifyingLoan(tx, s.bank.GetExchangeRateToRSD, clientID, imcRSD)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+	}
+
+	if debitBalance > imcNative {
+		return nil
+	}
+	return status.Error(codes.InvalidArgument,
+		"margin eligibility failed: debit account balance and approved loans do not cover the initial margin cost")
+}
+
+// clientHasQualifyingLoan returns true when the client has any approved loan
+// whose remaining_debt (converted to RSD via the bank's menjacnica rate)
+// strictly exceeds imcRSD. Loans denominated in RSD skip the lookup.
+func clientHasQualifyingLoan(tx *gorm.DB, rateFn func(string) (float64, error), clientID int64, imcRSD int64) (bool, error) {
+	var rows []struct {
+		RemainingDebt int64  `gorm:"column:remaining_debt"`
+		Currency      string `gorm:"column:currency"`
+	}
+	err := tx.Raw(`
+		SELECT l.remaining_debt, cur.label AS currency
+		FROM loans l
+		JOIN accounts a ON a.id = l.account_id
+		JOIN currencies cur ON cur.id = l.currency_id
+		WHERE a.owner = ? AND l.loan_status = 'approved'
+	`, clientID).Scan(&rows).Error
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "%v", err)
+	}
+	for _, r := range rows {
+		debtRSD := r.RemainingDebt
+		if r.Currency != "RSD" {
+			rate, err := rateFn(r.Currency)
+			if err != nil {
+				return false, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", r.Currency, err)
+			}
+			debtRSD = int64(float64(r.RemainingDebt) * rate)
+		}
+		if debtRSD > imcRSD {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/trading/margin_test.go
+++ b/internal/trading/margin_test.go
@@ -1,0 +1,52 @@
+package trading
+
+import "testing"
+
+func TestMaintenanceMargin(t *testing.T) {
+	cases := []struct {
+		name         string
+		contractSize int64
+		basePrice    int64
+		quantity     int64
+		permille     int64
+		want         int64
+	}{
+		// Stock: 50% × 10000 × 2 = 10000
+		{"stock 2 shares @100", 1, 10000, 2, 500, 10000},
+		// Future: contract_size 100 × 26500000 × 1 × 10% = 265000000
+		{"future gold 1 contract", 100, 26500000, 1, 100, 265000000},
+		// Forex: 1000 × 11715 × 1 × 10% = 1171500
+		{"forex EUR/RSD 1 lot", 1000, 11715, 1, 100, 1171500},
+		// Option: 1 × stock_price 20000 × 3 × 50% = 30000
+		{"option 3 contracts", 1, 20000, 3, 500, 30000},
+		// Zero quantity → zero
+		{"zero qty", 1, 10000, 0, 500, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := maintenanceMargin(c.contractSize, c.basePrice, c.quantity, c.permille); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestInitialMarginCost(t *testing.T) {
+	cases := []struct {
+		name string
+		mm   int64
+		want int64
+	}{
+		// IMC = MM × 1.1
+		{"round", 10000, 11000},
+		{"odd → truncates", 10001, 11001}, // 10001*11/10 = 11001 (integer div)
+		{"zero", 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := initialMarginCost(c.mm); got != c.want {
+				t.Errorf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/trading/orders.go
+++ b/internal/trading/orders.go
@@ -90,6 +90,13 @@ type instrumentInfo struct {
 	ContractSize   int64
 	MarketPrice    int64
 	SettlementDate *time.Time
+	// MarginBasePrice is the price used in the maintenance-margin formula
+	// (spec pp.47–49). For options it's the underlying stock's listing price,
+	// not the option premium; for everything else it matches MarketPrice.
+	MarginBasePrice int64
+	// MarginPermille is the maintenance-margin percentage expressed as permille
+	// (spec pp.47–49): stocks/options 500 (50%), futures/forex 100 (10%).
+	MarginPermille int64
 }
 
 // resolveInstrument loads the underlying referenced by the CreateOrder request
@@ -126,10 +133,12 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrume
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		info := &instrumentInfo{
-			Exchange:     &exch,
-			Currency:     exch.Currency,
-			ContractSize: 1,
-			MarketPrice:  listing.Price,
+			Exchange:        &exch,
+			Currency:        exch.Currency,
+			ContractSize:    1,
+			MarketPrice:     listing.Price,
+			MarginBasePrice: listing.Price,
+			MarginPermille:  500,
 		}
 		if listing.FutureID != nil {
 			var fut Future
@@ -137,6 +146,7 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrume
 				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
 			info.ContractSize = fut.ContractSize
+			info.MarginPermille = 100
 			sd := fut.SettlementDate
 			info.SettlementDate = &sd
 		}
@@ -163,11 +173,13 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrume
 		}
 		sd := opt.SettlementDate
 		return &instrumentInfo{
-			Exchange:       &exch,
-			Currency:       exch.Currency,
-			ContractSize:   1,
-			MarketPrice:    opt.Premium,
-			SettlementDate: &sd,
+			Exchange:        &exch,
+			Currency:        exch.Currency,
+			ContractSize:    1,
+			MarketPrice:     opt.Premium,
+			SettlementDate:  &sd,
+			MarginBasePrice: listing.Price,
+			MarginPermille:  500,
 		}, nil
 
 	default: // forex pair — no exchange
@@ -180,10 +192,13 @@ func (s *Server) resolveInstrument(req *tradingpb.CreateOrderRequest) (*instrume
 		}
 		// Forex convention (spec p.48, mirrored by ListForexPairs): contract
 		// size 1000, price in minor units is exchange_rate * 100.
+		fxPrice := int64(fx.ExchangeRate * 100)
 		return &instrumentInfo{
-			Currency:     fx.QuoteCurrency,
-			ContractSize: 1000,
-			MarketPrice:  int64(fx.ExchangeRate * 100),
+			Currency:        fx.QuoteCurrency,
+			ContractSize:    1000,
+			MarketPrice:     fxPrice,
+			MarginBasePrice: fxPrice,
+			MarginPermille:  100,
 		}, nil
 	}
 }

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -79,6 +79,15 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		return nil, err
 	}
 
+	// Margin orders require the `margin_trading` permission for employee
+	// placers (spec p.56). Checked up front so clients skip the DB round-trip
+	// and the denial surfaces before we touch the DB.
+	if req.Margin && caller.IsEmployee {
+		if !callerHasMarginPermission(s.db, caller.Email) {
+			return nil, status.Error(codes.PermissionDenied, "margin_trading permission required")
+		}
+	}
+
 	acc, err := s.bank.GetAccountByNumber(req.AccountNumber)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -169,6 +178,20 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		}
 
 		order.Status = decideOrderStatus(role, limits, approxRSD, pastSettlement)
+
+		// Margin eligibility runs only for orders that would actually debit
+		// (so past-settlement declines skip it). Clients qualify via an
+		// approved loan with remaining debt > IMC, otherwise both clients and
+		// employees fall back to the account's balance (spec p.56).
+		if order.Margin && order.Status != StatusDeclined {
+			var clientID int64
+			if caller.IsClient {
+				clientID = caller.ClientID
+			}
+			if err := s.checkMarginEligibility(tx, clientID, caller.IsClient, acc.Balance, info, req.Quantity); err != nil {
+				return err
+			}
+		}
 
 		if err := tx.Create(&placer).Error; err != nil {
 			return err

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -11,7 +11,8 @@ VALUES
     ('manage_companies'),
     ('manage_cards'),
     ('agent'),
-    ('supervisor')
+    ('supervisor'),
+    ('margin_trading')
 ON CONFLICT (name) DO NOTHING;
 
 -- default admin (password: "Admin123!")
@@ -57,7 +58,7 @@ FROM employees e, permissions p
 WHERE e.email = 'full_emp@banka.raf' AND p.name IN (
     'manage_employees', 'manage_clients', 'manage_accounts',
     'manage_companies', 'manage_loans', 'manage_cards',
-    'trade_stocks', 'view_stocks'
+    'trade_stocks', 'view_stocks', 'margin_trading'
 )
 ON CONFLICT DO NOTHING;
 
@@ -121,7 +122,7 @@ ON CONFLICT (email) DO NOTHING;
 INSERT INTO employee_permissions (employee_id, permission_id)
 SELECT e.id, p.id
 FROM employees e, permissions p
-WHERE e.email = 'supervisor@banka.raf' AND p.name IN ('supervisor', 'trade_stocks', 'view_stocks')
+WHERE e.email = 'supervisor@banka.raf' AND p.name IN ('supervisor', 'trade_stocks', 'view_stocks', 'margin_trading')
 ON CONFLICT DO NOTHING;
 
 -- test client (password: "Test1234!")


### PR DESCRIPTION
Closes #202.

## Summary
- New `margin_trading` permission, seeded and granted to `full_emp@banka.raf` and `supervisor@banka.raf` (agent employee intentionally left without it so the deny path is exercisable).
- Employee placers using `margin=true` are gated up front with `PermissionDenied` unless they hold `admin` or `margin_trading`.
- Inside the `CreateOrder` transaction, margin orders (that weren't past-settlement declined) run through `checkMarginEligibility` — client qualifies via an approved loan with remaining debt (in RSD) > IMC_RSD, otherwise the debit account balance must exceed IMC in the instrument's native currency. Rejections surface as `InvalidArgument`.
- `instrumentInfo` picked up `MarginBasePrice` / `MarginPermille` so the margin formula is driven from `resolveInstrument` rather than re-branching per security type. Options correctly use the underlying stock's listing price.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual: seed DB, attempt margin=true as `agent@banka.raf` → expect 403 (no margin_trading).
- [ ] Manual: margin=true as `supervisor@banka.raf` with sufficient balance → expect order created.
- [ ] Manual: margin=true as the seeded client Petar (has 21.8M RSD approved loan + RSD checking) against a small stock quantity → expect order created via loan eligibility.
- [ ] Manual: margin=true on a large position that exceeds both balance and loan remaining_debt → expect `InvalidArgument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)