### PR TITLE
feat(trading): cross-currency debit flow on CreateOrder

### DIFF
--- a/internal/trading/commission.go
+++ b/internal/trading/commission.go
@@ -2,6 +2,7 @@ package trading
 
 import (
 	"errors"
+	"math"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -18,6 +19,10 @@ const (
 	// 14% = 140‰, 24% = 240‰.
 	commissionPermilleMarket int64 = 140
 	commissionPermilleLimit  int64 = 240
+	// menjacnicaCommissionPermille mirrors bank.commission_rate (1%). Applied
+	// to the account-currency equivalent of a cross-currency debit when the
+	// placer is a client (spec pp.27, 57).
+	menjacnicaCommissionPermille int64 = 10
 )
 
 // bankSystemOwnerEmail is the system client whose per-currency internal
@@ -44,12 +49,66 @@ func computeCommission(ot OrderType, approxNative int64) int64 {
 	return capAmount
 }
 
-// chargeCommission debits the placer's account and credits the bank's
-// fee-collection account in the same currency, atomically inside the caller's
-// transaction. Returns FailedPrecondition if the placer cannot cover the fee,
-// FailedPrecondition if no bank fee account exists for the currency.
-func chargeCommission(tx *gorm.DB, debitAccount, currency string, amount int64) error {
-	if amount <= 0 {
+// commissionPlan captures the bookkeeping for charging a placement commission
+// across potentially different account and instrument currencies. Same-currency
+// orders leave InstrumentCurrency == DebitCurrency, FeeInstrument == DebitAmount,
+// and MenjacnicaFee == 0 so chargeCommission collapses to a single debit/credit
+// pair. Cross-currency orders additionally pocket a menjacnica commission in
+// the account's currency (clients only — spec pp.27, 57).
+type commissionPlan struct {
+	DebitAccount       string
+	DebitCurrency      string
+	DebitAmount        int64
+	InstrumentCurrency string
+	FeeInstrument      int64
+	MenjacnicaFee      int64
+}
+
+// planCommissionCharge derives how much to pull from the placer's account and
+// how much to credit each fee pool, given the instrument-currency commission
+// and the account/instrument exchange rates. Rates are RSD-per-unit so a
+// conversion from instrument to account currency is `x * rateInstrRSD /
+// rateAccRSD`. Clients eat a 1% menjacnica fee on the converted amount
+// (isClient=true); employee placers pay no conversion fee — bank-owned
+// accounts are debited in the employee case too (spec p.57).
+func planCommissionCharge(
+	debitAccount, debitCurrency, instrumentCurrency string,
+	feeInstrument int64,
+	rateAccRSD, rateInstrRSD float64,
+	isClient bool,
+) commissionPlan {
+	plan := commissionPlan{
+		DebitAccount:       debitAccount,
+		DebitCurrency:      debitCurrency,
+		InstrumentCurrency: instrumentCurrency,
+		FeeInstrument:      feeInstrument,
+	}
+	if feeInstrument <= 0 {
+		return plan
+	}
+	if debitCurrency == instrumentCurrency {
+		plan.DebitAmount = feeInstrument
+		return plan
+	}
+	// Round up so rounding never under-charges the placer.
+	feeInAccount := int64(math.Ceil(float64(feeInstrument) * rateInstrRSD / rateAccRSD))
+	var menjacnica int64
+	if isClient {
+		menjacnica = (feeInAccount*menjacnicaCommissionPermille + 999) / 1000
+	}
+	plan.DebitAmount = feeInAccount + menjacnica
+	plan.MenjacnicaFee = menjacnica
+	return plan
+}
+
+// chargeCommission debits the placer's account in its own currency and credits
+// the bank's fee-collection accounts: the instrument-currency pool for the
+// order commission and, for cross-currency client orders, the account-currency
+// pool for the menjacnica commission. Runs inside the caller's transaction.
+// Returns FailedPrecondition if the placer cannot cover the debit or a fee
+// pool for the needed currency does not exist.
+func chargeCommission(tx *gorm.DB, p commissionPlan) error {
+	if p.DebitAmount <= 0 {
 		return nil
 	}
 
@@ -57,7 +116,7 @@ func chargeCommission(tx *gorm.DB, debitAccount, currency string, amount int64) 
 	// silently driving the account negative.
 	res := tx.Exec(
 		`UPDATE accounts SET balance = balance - ? WHERE number = ? AND balance >= ?`,
-		amount, debitAccount, amount,
+		p.DebitAmount, p.DebitAccount, p.DebitAmount,
 	)
 	if res.Error != nil {
 		return status.Errorf(codes.Internal, "%v", res.Error)
@@ -66,8 +125,23 @@ func chargeCommission(tx *gorm.DB, debitAccount, currency string, amount int64) 
 		return status.Error(codes.FailedPrecondition, "insufficient funds for commission")
 	}
 
-	// Credit the bank's fee-collection account for this currency. Seeded per
-	// currency under the system client; see seed.sql.
+	if p.FeeInstrument > 0 {
+		if err := creditFeeAccount(tx, p.InstrumentCurrency, p.FeeInstrument); err != nil {
+			return err
+		}
+	}
+	if p.MenjacnicaFee > 0 {
+		if err := creditFeeAccount(tx, p.DebitCurrency, p.MenjacnicaFee); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// creditFeeAccount adds `amount` to the bank's system account for `currency`.
+// System accounts are seeded per supported currency (seed.sql) and act as both
+// the commission collector and the menjacnica intermediary.
+func creditFeeAccount(tx *gorm.DB, currency string, amount int64) error {
 	var feeAccount string
 	err := tx.Raw(
 		`SELECT a.number FROM accounts a
@@ -86,7 +160,7 @@ func chargeCommission(tx *gorm.DB, debitAccount, currency string, amount int64) 
 		return status.Errorf(codes.FailedPrecondition, "no fee-collection account for %s", currency)
 	}
 
-	res = tx.Exec(
+	res := tx.Exec(
 		`UPDATE accounts SET balance = balance + ? WHERE number = ?`,
 		amount, feeAccount,
 	)

--- a/internal/trading/commission_test.go
+++ b/internal/trading/commission_test.go
@@ -23,40 +23,40 @@ func TestPlanCommissionCharge(t *testing.T) {
 		wantMenjacnica int64
 	}{
 		{
-			name:         "same currency — no conversion, no menjacnica",
-			debitCur:     "USD", instrCur: "USD",
+			name:     "same currency — no conversion, no menjacnica",
+			debitCur: "USD", instrCur: "USD",
 			feeInstrument: 700, rateAccRSD: rateUSD, rateInstrRSD: rateUSD,
-			isClient: true,
+			isClient:  true,
 			wantDebit: 700, wantFeeInstr: 700, wantMenjacnica: 0,
 		},
 		{
-			name:         "RSD debit for USD instrument, client pays 1%",
-			debitCur:     "RSD", instrCur: "USD",
+			name:     "RSD debit for USD instrument, client pays 1%",
+			debitCur: "RSD", instrCur: "USD",
 			feeInstrument: 700, rateAccRSD: rateRSD, rateInstrRSD: rateUSD,
 			isClient: true,
 			// 700 USD-minor * 100 / 1 = 70000 RSD-minor; 1% = 700.
 			wantDebit: 70700, wantFeeInstr: 700, wantMenjacnica: 700,
 		},
 		{
-			name:         "RSD debit for USD instrument, employee skips menjacnica",
-			debitCur:     "RSD", instrCur: "USD",
+			name:     "RSD debit for USD instrument, employee skips menjacnica",
+			debitCur: "RSD", instrCur: "USD",
 			feeInstrument: 700, rateAccRSD: rateRSD, rateInstrRSD: rateUSD,
-			isClient: false,
+			isClient:  false,
 			wantDebit: 70000, wantFeeInstr: 700, wantMenjacnica: 0,
 		},
 		{
-			name:         "EUR debit for USD instrument, client",
-			debitCur:     "EUR", instrCur: "USD",
+			name:     "EUR debit for USD instrument, client",
+			debitCur: "EUR", instrCur: "USD",
 			feeInstrument: 1200, rateAccRSD: rateEUR, rateInstrRSD: rateUSD,
 			isClient: true,
 			// 1200 * 100 / 117.69 = 1019.63 → ceil 1020; 1% of 1020 = 10.2 → ceil 11.
 			wantDebit: 1031, wantFeeInstr: 1200, wantMenjacnica: 11,
 		},
 		{
-			name:         "zero commission — no-op",
-			debitCur:     "EUR", instrCur: "USD",
+			name:     "zero commission — no-op",
+			debitCur: "EUR", instrCur: "USD",
 			feeInstrument: 0, rateAccRSD: rateEUR, rateInstrRSD: rateUSD,
-			isClient: true,
+			isClient:  true,
 			wantDebit: 0, wantFeeInstr: 0, wantMenjacnica: 0,
 		},
 	}

--- a/internal/trading/commission_test.go
+++ b/internal/trading/commission_test.go
@@ -2,6 +2,86 @@ package trading
 
 import "testing"
 
+func TestPlanCommissionCharge(t *testing.T) {
+	// Rates: 1 EUR = 117.69 RSD, 1 USD = 100 RSD.
+	const (
+		rateEUR = 117.69
+		rateUSD = 100.0
+		rateRSD = 1.0
+	)
+
+	cases := []struct {
+		name           string
+		debitCur       string
+		instrCur       string
+		feeInstrument  int64
+		rateAccRSD     float64
+		rateInstrRSD   float64
+		isClient       bool
+		wantDebit      int64
+		wantFeeInstr   int64
+		wantMenjacnica int64
+	}{
+		{
+			name:         "same currency — no conversion, no menjacnica",
+			debitCur:     "USD", instrCur: "USD",
+			feeInstrument: 700, rateAccRSD: rateUSD, rateInstrRSD: rateUSD,
+			isClient: true,
+			wantDebit: 700, wantFeeInstr: 700, wantMenjacnica: 0,
+		},
+		{
+			name:         "RSD debit for USD instrument, client pays 1%",
+			debitCur:     "RSD", instrCur: "USD",
+			feeInstrument: 700, rateAccRSD: rateRSD, rateInstrRSD: rateUSD,
+			isClient: true,
+			// 700 USD-minor * 100 / 1 = 70000 RSD-minor; 1% = 700.
+			wantDebit: 70700, wantFeeInstr: 700, wantMenjacnica: 700,
+		},
+		{
+			name:         "RSD debit for USD instrument, employee skips menjacnica",
+			debitCur:     "RSD", instrCur: "USD",
+			feeInstrument: 700, rateAccRSD: rateRSD, rateInstrRSD: rateUSD,
+			isClient: false,
+			wantDebit: 70000, wantFeeInstr: 700, wantMenjacnica: 0,
+		},
+		{
+			name:         "EUR debit for USD instrument, client",
+			debitCur:     "EUR", instrCur: "USD",
+			feeInstrument: 1200, rateAccRSD: rateEUR, rateInstrRSD: rateUSD,
+			isClient: true,
+			// 1200 * 100 / 117.69 = 1019.63 → ceil 1020; 1% of 1020 = 10.2 → ceil 11.
+			wantDebit: 1031, wantFeeInstr: 1200, wantMenjacnica: 11,
+		},
+		{
+			name:         "zero commission — no-op",
+			debitCur:     "EUR", instrCur: "USD",
+			feeInstrument: 0, rateAccRSD: rateEUR, rateInstrRSD: rateUSD,
+			isClient: true,
+			wantDebit: 0, wantFeeInstr: 0, wantMenjacnica: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := planCommissionCharge(
+				"acc-123", c.debitCur, c.instrCur,
+				c.feeInstrument, c.rateAccRSD, c.rateInstrRSD, c.isClient,
+			)
+			if got.DebitAmount != c.wantDebit {
+				t.Errorf("DebitAmount = %d, want %d", got.DebitAmount, c.wantDebit)
+			}
+			if got.FeeInstrument != c.wantFeeInstr {
+				t.Errorf("FeeInstrument = %d, want %d", got.FeeInstrument, c.wantFeeInstr)
+			}
+			if got.MenjacnicaFee != c.wantMenjacnica {
+				t.Errorf("MenjacnicaFee = %d, want %d", got.MenjacnicaFee, c.wantMenjacnica)
+			}
+			if got.DebitCurrency != c.debitCur || got.InstrumentCurrency != c.instrCur {
+				t.Errorf("currencies not preserved: %+v", got)
+			}
+		})
+	}
+}
+
 func TestComputeCommission(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -103,10 +103,18 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	if err != nil {
 		return nil, err
 	}
+
+	// Cross-currency orders go through Menjačnica (spec pp.27, 57). Rates are
+	// loaded once here so downstream math (margin eligibility, commission
+	// conversion) uses a consistent snapshot.
+	var rateAccRSD, rateInstrRSD float64 = 1, 1
 	if acc.Currency != info.Currency {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"account currency %s does not match instrument currency %s",
-			acc.Currency, info.Currency)
+		if rateAccRSD, err = s.bank.GetExchangeRateToRSD(acc.Currency); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", acc.Currency, err)
+		}
+		if rateInstrRSD, err = s.bank.GetExchangeRateToRSD(info.Currency); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", info.Currency, err)
+		}
 	}
 
 	now := time.Now()
@@ -188,7 +196,13 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			if caller.IsClient {
 				clientID = caller.ClientID
 			}
-			if err := s.checkMarginEligibility(tx, clientID, caller.IsClient, acc.Balance, info, req.Quantity); err != nil {
+			// Margin's native-currency check compares against the instrument
+			// currency, so cross-currency balances convert through RSD first.
+			debitBalance := acc.Balance
+			if acc.Currency != info.Currency {
+				debitBalance = int64(float64(acc.Balance) * rateAccRSD / rateInstrRSD)
+			}
+			if err := s.checkMarginEligibility(tx, clientID, caller.IsClient, debitBalance, info, req.Quantity); err != nil {
 				return err
 			}
 		}
@@ -201,11 +215,17 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			return err
 		}
 
-		// Commission is reserved at placement (spec pp. 51–52): transfer from
-		// the placer's account to the bank's fee-collection account in the
-		// same currency. Declined orders (past settlement) skip the charge.
+		// Commission is reserved at placement (spec pp. 51–52): debit the
+		// placer's account and credit the bank's fee pool. Cross-currency
+		// orders convert through RSD and, for client placers, additionally
+		// charge the Menjačnica commission (spec pp.27, 57). Declined orders
+		// (past settlement) skip the whole charge.
 		if order.Status != StatusDeclined {
-			if err := chargeCommission(tx, req.AccountNumber, info.Currency, commission); err != nil {
+			plan := planCommissionCharge(
+				req.AccountNumber, acc.Currency, info.Currency,
+				commission, rateAccRSD, rateInstrRSD, caller.IsClient,
+			)
+			if err := chargeCommission(tx, plan); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- Allow `CreateOrder` when the debit account's currency differs from the instrument currency (spec pp.27, 57) — the old `InvalidArgument` rejection is gone.
- Commission is converted to the account currency via the Menjačnica rate; client placers additionally pay a 1% Menjačnica commission into the account-currency fee pool, employee placers do not.
- Margin eligibility's native-currency balance check now converts `acc.Balance` through RSD so cross-currency margin orders are evaluated against the instrument currency.

## Test plan
- [x] `go test ./internal/trading/...` — covers `planCommissionCharge` same-currency, RSD↔USD client/employee, EUR→USD client (exercises ceil rounding), and zero-commission no-op.
- [x] `go build ./...`
- [ ] Manual smoke: place an order with a USD listing against an RSD account as a client → commission debited in RSD + 1% menjacnica; as an employee → no menjacnica.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)