### PR TITLE
feat(trading): supervisor orders portal (list, approve, decline, cancel)

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -1886,6 +1886,584 @@ func (x *CreateOrderResponse) GetStatus() string {
 	return ""
 }
 
+// OrderDetail is the row shape used by the supervisor orders portal (spec
+// pp.57–58). asset_label is a human-readable instrument identifier: the
+// listing's ticker for stocks/futures, the option or forex-pair ticker
+// otherwise. placer_name is derived from the placer row (employee or client).
+// past_settlement signals "approve blocked, decline only" at the UI layer —
+// the RPC re-checks server-side.
+type OrderDetail struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Status            string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	OrderType         string                 `protobuf:"bytes,3,opt,name=order_type,json=orderType,proto3" json:"order_type,omitempty"`
+	Direction         string                 `protobuf:"bytes,4,opt,name=direction,proto3" json:"direction,omitempty"`
+	Quantity          int64                  `protobuf:"varint,5,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	ContractSize      int64                  `protobuf:"varint,6,opt,name=contract_size,json=contractSize,proto3" json:"contract_size,omitempty"`
+	PricePerUnit      int64                  `protobuf:"varint,7,opt,name=price_per_unit,json=pricePerUnit,proto3" json:"price_per_unit,omitempty"`
+	RemainingPortions int64                  `protobuf:"varint,8,opt,name=remaining_portions,json=remainingPortions,proto3" json:"remaining_portions,omitempty"`
+	AssetLabel        string                 `protobuf:"bytes,9,opt,name=asset_label,json=assetLabel,proto3" json:"asset_label,omitempty"`
+	PlacerName        string                 `protobuf:"bytes,10,opt,name=placer_name,json=placerName,proto3" json:"placer_name,omitempty"`
+	PlacerEmployeeId  int64                  `protobuf:"varint,11,opt,name=placer_employee_id,json=placerEmployeeId,proto3" json:"placer_employee_id,omitempty"`
+	PlacerClientId    int64                  `protobuf:"varint,12,opt,name=placer_client_id,json=placerClientId,proto3" json:"placer_client_id,omitempty"`
+	PastSettlement    bool                   `protobuf:"varint,13,opt,name=past_settlement,json=pastSettlement,proto3" json:"past_settlement,omitempty"`
+	ApprovedBy        int64                  `protobuf:"varint,14,opt,name=approved_by,json=approvedBy,proto3" json:"approved_by,omitempty"`
+	CreatedAtUnix     int64                  `protobuf:"varint,15,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	Margin            bool                   `protobuf:"varint,16,opt,name=margin,proto3" json:"margin,omitempty"`
+	AllOrNone         bool                   `protobuf:"varint,17,opt,name=all_or_none,json=allOrNone,proto3" json:"all_or_none,omitempty"`
+	Commission        int64                  `protobuf:"varint,18,opt,name=commission,proto3" json:"commission,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *OrderDetail) Reset() {
+	*x = OrderDetail{}
+	mi := &file_trading_trading_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OrderDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OrderDetail) ProtoMessage() {}
+
+func (x *OrderDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OrderDetail.ProtoReflect.Descriptor instead.
+func (*OrderDetail) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *OrderDetail) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *OrderDetail) GetOrderType() string {
+	if x != nil {
+		return x.OrderType
+	}
+	return ""
+}
+
+func (x *OrderDetail) GetDirection() string {
+	if x != nil {
+		return x.Direction
+	}
+	return ""
+}
+
+func (x *OrderDetail) GetQuantity() int64 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetContractSize() int64 {
+	if x != nil {
+		return x.ContractSize
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetPricePerUnit() int64 {
+	if x != nil {
+		return x.PricePerUnit
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetRemainingPortions() int64 {
+	if x != nil {
+		return x.RemainingPortions
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetAssetLabel() string {
+	if x != nil {
+		return x.AssetLabel
+	}
+	return ""
+}
+
+func (x *OrderDetail) GetPlacerName() string {
+	if x != nil {
+		return x.PlacerName
+	}
+	return ""
+}
+
+func (x *OrderDetail) GetPlacerEmployeeId() int64 {
+	if x != nil {
+		return x.PlacerEmployeeId
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetPlacerClientId() int64 {
+	if x != nil {
+		return x.PlacerClientId
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetPastSettlement() bool {
+	if x != nil {
+		return x.PastSettlement
+	}
+	return false
+}
+
+func (x *OrderDetail) GetApprovedBy() int64 {
+	if x != nil {
+		return x.ApprovedBy
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetCreatedAtUnix() int64 {
+	if x != nil {
+		return x.CreatedAtUnix
+	}
+	return 0
+}
+
+func (x *OrderDetail) GetMargin() bool {
+	if x != nil {
+		return x.Margin
+	}
+	return false
+}
+
+func (x *OrderDetail) GetAllOrNone() bool {
+	if x != nil {
+		return x.AllOrNone
+	}
+	return false
+}
+
+func (x *OrderDetail) GetCommission() int64 {
+	if x != nil {
+		return x.Commission
+	}
+	return 0
+}
+
+// Supervisor-only. status: "" or "all" returns every order, otherwise one of
+// "pending|approved|declined|done|cancelled". agent_id filters by the placer's
+// employee_id (0 = no filter); client-placed orders are excluded when a
+// positive agent_id is passed.
+type ListOrdersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	AgentId       int64                  `protobuf:"varint,3,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListOrdersRequest) Reset() {
+	*x = ListOrdersRequest{}
+	mi := &file_trading_trading_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOrdersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOrdersRequest) ProtoMessage() {}
+
+func (x *ListOrdersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOrdersRequest.ProtoReflect.Descriptor instead.
+func (*ListOrdersRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ListOrdersRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+func (x *ListOrdersRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListOrdersRequest) GetAgentId() int64 {
+	if x != nil {
+		return x.AgentId
+	}
+	return 0
+}
+
+type ListOrdersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Orders        []*OrderDetail         `protobuf:"bytes,1,rep,name=orders,proto3" json:"orders,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListOrdersResponse) Reset() {
+	*x = ListOrdersResponse{}
+	mi := &file_trading_trading_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListOrdersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOrdersResponse) ProtoMessage() {}
+
+func (x *ListOrdersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOrdersResponse.ProtoReflect.Descriptor instead.
+func (*ListOrdersResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ListOrdersResponse) GetOrders() []*OrderDetail {
+	if x != nil {
+		return x.Orders
+	}
+	return nil
+}
+
+type ApproveOrderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrderId       int64                  `protobuf:"varint,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,2,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApproveOrderRequest) Reset() {
+	*x = ApproveOrderRequest{}
+	mi := &file_trading_trading_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApproveOrderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApproveOrderRequest) ProtoMessage() {}
+
+func (x *ApproveOrderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApproveOrderRequest.ProtoReflect.Descriptor instead.
+func (*ApproveOrderRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *ApproveOrderRequest) GetOrderId() int64 {
+	if x != nil {
+		return x.OrderId
+	}
+	return 0
+}
+
+func (x *ApproveOrderRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type ApproveOrderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Order         *OrderDetail           `protobuf:"bytes,1,opt,name=order,proto3" json:"order,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApproveOrderResponse) Reset() {
+	*x = ApproveOrderResponse{}
+	mi := &file_trading_trading_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApproveOrderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApproveOrderResponse) ProtoMessage() {}
+
+func (x *ApproveOrderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApproveOrderResponse.ProtoReflect.Descriptor instead.
+func (*ApproveOrderResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *ApproveOrderResponse) GetOrder() *OrderDetail {
+	if x != nil {
+		return x.Order
+	}
+	return nil
+}
+
+type DeclineOrderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrderId       int64                  `protobuf:"varint,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
+	CallerEmail   string                 `protobuf:"bytes,2,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeclineOrderRequest) Reset() {
+	*x = DeclineOrderRequest{}
+	mi := &file_trading_trading_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeclineOrderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeclineOrderRequest) ProtoMessage() {}
+
+func (x *DeclineOrderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeclineOrderRequest.ProtoReflect.Descriptor instead.
+func (*DeclineOrderRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *DeclineOrderRequest) GetOrderId() int64 {
+	if x != nil {
+		return x.OrderId
+	}
+	return 0
+}
+
+func (x *DeclineOrderRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type DeclineOrderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Order         *OrderDetail           `protobuf:"bytes,1,opt,name=order,proto3" json:"order,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeclineOrderResponse) Reset() {
+	*x = DeclineOrderResponse{}
+	mi := &file_trading_trading_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeclineOrderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeclineOrderResponse) ProtoMessage() {}
+
+func (x *DeclineOrderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeclineOrderResponse.ProtoReflect.Descriptor instead.
+func (*DeclineOrderResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *DeclineOrderResponse) GetOrder() *OrderDetail {
+	if x != nil {
+		return x.Order
+	}
+	return nil
+}
+
+// CancelOrder accepts either the order's owner or a supervisor. The caller
+// identity comes from the `user-email` gRPC metadata header (same as
+// CreateOrder) so the server can distinguish client owner vs. employee owner
+// vs. supervisor without an extra DB round trip on the gateway.
+type CancelOrderRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrderId       int64                  `protobuf:"varint,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelOrderRequest) Reset() {
+	*x = CancelOrderRequest{}
+	mi := &file_trading_trading_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelOrderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelOrderRequest) ProtoMessage() {}
+
+func (x *CancelOrderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelOrderRequest.ProtoReflect.Descriptor instead.
+func (*CancelOrderRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *CancelOrderRequest) GetOrderId() int64 {
+	if x != nil {
+		return x.OrderId
+	}
+	return 0
+}
+
+type CancelOrderResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Order         *OrderDetail           `protobuf:"bytes,1,opt,name=order,proto3" json:"order,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelOrderResponse) Reset() {
+	*x = CancelOrderResponse{}
+	mi := &file_trading_trading_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelOrderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelOrderResponse) ProtoMessage() {}
+
+func (x *CancelOrderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelOrderResponse.ProtoReflect.Descriptor instead.
+func (*CancelOrderResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *CancelOrderResponse) GetOrder() *OrderDetail {
+	if x != nil {
+		return x.Order
+	}
+	return nil
+}
+
 var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
@@ -2054,7 +2632,53 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x06margin\x18\v \x01(\bR\x06margin\"H\n" +
 	"\x13CreateOrderResponse\x12\x19\n" +
 	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status2\xfe\x05\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"\xec\x04\n" +
+	"\vOrderDetail\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"order_type\x18\x03 \x01(\tR\torderType\x12\x1c\n" +
+	"\tdirection\x18\x04 \x01(\tR\tdirection\x12\x1a\n" +
+	"\bquantity\x18\x05 \x01(\x03R\bquantity\x12#\n" +
+	"\rcontract_size\x18\x06 \x01(\x03R\fcontractSize\x12$\n" +
+	"\x0eprice_per_unit\x18\a \x01(\x03R\fpricePerUnit\x12-\n" +
+	"\x12remaining_portions\x18\b \x01(\x03R\x11remainingPortions\x12\x1f\n" +
+	"\vasset_label\x18\t \x01(\tR\n" +
+	"assetLabel\x12\x1f\n" +
+	"\vplacer_name\x18\n" +
+	" \x01(\tR\n" +
+	"placerName\x12,\n" +
+	"\x12placer_employee_id\x18\v \x01(\x03R\x10placerEmployeeId\x12(\n" +
+	"\x10placer_client_id\x18\f \x01(\x03R\x0eplacerClientId\x12'\n" +
+	"\x0fpast_settlement\x18\r \x01(\bR\x0epastSettlement\x12\x1f\n" +
+	"\vapproved_by\x18\x0e \x01(\x03R\n" +
+	"approvedBy\x12&\n" +
+	"\x0fcreated_at_unix\x18\x0f \x01(\x03R\rcreatedAtUnix\x12\x16\n" +
+	"\x06margin\x18\x10 \x01(\bR\x06margin\x12\x1e\n" +
+	"\vall_or_none\x18\x11 \x01(\bR\tallOrNone\x12\x1e\n" +
+	"\n" +
+	"commission\x18\x12 \x01(\x03R\n" +
+	"commission\"i\n" +
+	"\x11ListOrdersRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x19\n" +
+	"\bagent_id\x18\x03 \x01(\x03R\aagentId\"B\n" +
+	"\x12ListOrdersResponse\x12,\n" +
+	"\x06orders\x18\x01 \x03(\v2\x14.trading.OrderDetailR\x06orders\"S\n" +
+	"\x13ApproveOrderRequest\x12\x19\n" +
+	"\border_id\x18\x01 \x01(\x03R\aorderId\x12!\n" +
+	"\fcaller_email\x18\x02 \x01(\tR\vcallerEmail\"B\n" +
+	"\x14ApproveOrderResponse\x12*\n" +
+	"\x05order\x18\x01 \x01(\v2\x14.trading.OrderDetailR\x05order\"S\n" +
+	"\x13DeclineOrderRequest\x12\x19\n" +
+	"\border_id\x18\x01 \x01(\x03R\aorderId\x12!\n" +
+	"\fcaller_email\x18\x02 \x01(\tR\vcallerEmail\"B\n" +
+	"\x14DeclineOrderResponse\x12*\n" +
+	"\x05order\x18\x01 \x01(\v2\x14.trading.OrderDetailR\x05order\"/\n" +
+	"\x12CancelOrderRequest\x12\x19\n" +
+	"\border_id\x18\x01 \x01(\x03R\aorderId\"A\n" +
+	"\x13CancelOrderResponse\x12*\n" +
+	"\x05order\x18\x01 \x01(\v2\x14.trading.OrderDetailR\x05order2\xa9\b\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
@@ -2064,7 +2688,12 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x0eListForexPairs\x12\x1e.trading.ListForexPairsRequest\x1a\x1f.trading.ListForexPairsResponse\x12T\n" +
 	"\x0fListOptionDates\x12\x1f.trading.ListOptionDatesRequest\x1a .trading.ListOptionDatesResponse\x12H\n" +
 	"\vListOptions\x12\x1b.trading.ListOptionsRequest\x1a\x1c.trading.ListOptionsResponse\x12H\n" +
-	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponse\x12l\n" +
+	"\vCreateOrder\x12\x1b.trading.CreateOrderRequest\x1a\x1c.trading.CreateOrderResponse\x12E\n" +
+	"\n" +
+	"ListOrders\x12\x1a.trading.ListOrdersRequest\x1a\x1b.trading.ListOrdersResponse\x12K\n" +
+	"\fApproveOrder\x12\x1c.trading.ApproveOrderRequest\x1a\x1d.trading.ApproveOrderResponse\x12K\n" +
+	"\fDeclineOrder\x12\x1c.trading.DeclineOrderRequest\x1a\x1d.trading.DeclineOrderResponse\x12H\n" +
+	"\vCancelOrder\x12\x1b.trading.CancelOrderRequest\x1a\x1c.trading.CancelOrderResponse\x12l\n" +
 	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
@@ -2079,7 +2708,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),                        // 0: trading.Exchange
 	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
@@ -2106,6 +2735,15 @@ var file_trading_trading_proto_goTypes = []any{
 	(*ListOptionsResponse)(nil),             // 22: trading.ListOptionsResponse
 	(*CreateOrderRequest)(nil),              // 23: trading.CreateOrderRequest
 	(*CreateOrderResponse)(nil),             // 24: trading.CreateOrderResponse
+	(*OrderDetail)(nil),                     // 25: trading.OrderDetail
+	(*ListOrdersRequest)(nil),               // 26: trading.ListOrdersRequest
+	(*ListOrdersResponse)(nil),              // 27: trading.ListOrdersResponse
+	(*ApproveOrderRequest)(nil),             // 28: trading.ApproveOrderRequest
+	(*ApproveOrderResponse)(nil),            // 29: trading.ApproveOrderResponse
+	(*DeclineOrderRequest)(nil),             // 30: trading.DeclineOrderRequest
+	(*DeclineOrderResponse)(nil),            // 31: trading.DeclineOrderResponse
+	(*CancelOrderRequest)(nil),              // 32: trading.CancelOrderRequest
+	(*CancelOrderResponse)(nil),             // 33: trading.CancelOrderResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0,  // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
@@ -2118,29 +2756,41 @@ var file_trading_trading_proto_depIdxs = []int32{
 	20, // 7: trading.OptionGridRow.call:type_name -> trading.OptionContract
 	20, // 8: trading.OptionGridRow.put:type_name -> trading.OptionContract
 	21, // 9: trading.ListOptionsResponse.rows:type_name -> trading.OptionGridRow
-	3,  // 10: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
-	6,  // 11: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	8,  // 12: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
-	10, // 13: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
-	14, // 14: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
-	16, // 15: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
-	19, // 16: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
-	23, // 17: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	1,  // 18: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
-	4,  // 19: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	7,  // 20: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	9,  // 21: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
-	12, // 22: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
-	15, // 23: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
-	18, // 24: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
-	22, // 25: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
-	24, // 26: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	2,  // 27: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	19, // [19:28] is the sub-list for method output_type
-	10, // [10:19] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	25, // 10: trading.ListOrdersResponse.orders:type_name -> trading.OrderDetail
+	25, // 11: trading.ApproveOrderResponse.order:type_name -> trading.OrderDetail
+	25, // 12: trading.DeclineOrderResponse.order:type_name -> trading.OrderDetail
+	25, // 13: trading.CancelOrderResponse.order:type_name -> trading.OrderDetail
+	3,  // 14: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
+	6,  // 15: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	8,  // 16: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
+	10, // 17: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
+	14, // 18: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
+	16, // 19: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
+	19, // 20: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
+	23, // 21: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	26, // 22: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
+	28, // 23: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
+	30, // 24: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
+	32, // 25: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
+	1,  // 26: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
+	4,  // 27: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7,  // 28: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9,  // 29: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	12, // 30: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	15, // 31: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	18, // 32: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
+	22, // 33: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
+	24, // 34: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	27, // 35: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
+	29, // 36: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
+	31, // 37: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
+	33, // 38: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
+	2,  // 39: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	27, // [27:40] is the sub-list for method output_type
+	14, // [14:27] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_trading_trading_proto_init() }
@@ -2154,7 +2804,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -27,6 +27,10 @@ const (
 	TradingService_ListOptionDates_FullMethodName         = "/trading.TradingService/ListOptionDates"
 	TradingService_ListOptions_FullMethodName             = "/trading.TradingService/ListOptions"
 	TradingService_CreateOrder_FullMethodName             = "/trading.TradingService/CreateOrder"
+	TradingService_ListOrders_FullMethodName              = "/trading.TradingService/ListOrders"
+	TradingService_ApproveOrder_FullMethodName            = "/trading.TradingService/ApproveOrder"
+	TradingService_DeclineOrder_FullMethodName            = "/trading.TradingService/DeclineOrder"
+	TradingService_CancelOrder_FullMethodName             = "/trading.TradingService/CancelOrder"
 	TradingService_SetExchangeOpenOverride_FullMethodName = "/trading.TradingService/SetExchangeOpenOverride"
 )
 
@@ -42,6 +46,10 @@ type TradingServiceClient interface {
 	ListOptionDates(ctx context.Context, in *ListOptionDatesRequest, opts ...grpc.CallOption) (*ListOptionDatesResponse, error)
 	ListOptions(ctx context.Context, in *ListOptionsRequest, opts ...grpc.CallOption) (*ListOptionsResponse, error)
 	CreateOrder(ctx context.Context, in *CreateOrderRequest, opts ...grpc.CallOption) (*CreateOrderResponse, error)
+	ListOrders(ctx context.Context, in *ListOrdersRequest, opts ...grpc.CallOption) (*ListOrdersResponse, error)
+	ApproveOrder(ctx context.Context, in *ApproveOrderRequest, opts ...grpc.CallOption) (*ApproveOrderResponse, error)
+	DeclineOrder(ctx context.Context, in *DeclineOrderRequest, opts ...grpc.CallOption) (*DeclineOrderResponse, error)
+	CancelOrder(ctx context.Context, in *CancelOrderRequest, opts ...grpc.CallOption) (*CancelOrderResponse, error)
 	SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error)
 }
 
@@ -133,6 +141,46 @@ func (c *tradingServiceClient) CreateOrder(ctx context.Context, in *CreateOrderR
 	return out, nil
 }
 
+func (c *tradingServiceClient) ListOrders(ctx context.Context, in *ListOrdersRequest, opts ...grpc.CallOption) (*ListOrdersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListOrdersResponse)
+	err := c.cc.Invoke(ctx, TradingService_ListOrders_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) ApproveOrder(ctx context.Context, in *ApproveOrderRequest, opts ...grpc.CallOption) (*ApproveOrderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ApproveOrderResponse)
+	err := c.cc.Invoke(ctx, TradingService_ApproveOrder_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) DeclineOrder(ctx context.Context, in *DeclineOrderRequest, opts ...grpc.CallOption) (*DeclineOrderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeclineOrderResponse)
+	err := c.cc.Invoke(ctx, TradingService_DeclineOrder_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) CancelOrder(ctx context.Context, in *CancelOrderRequest, opts ...grpc.CallOption) (*CancelOrderResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CancelOrderResponse)
+	err := c.cc.Invoke(ctx, TradingService_CancelOrder_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *tradingServiceClient) SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SetExchangeOpenOverrideResponse)
@@ -155,6 +203,10 @@ type TradingServiceServer interface {
 	ListOptionDates(context.Context, *ListOptionDatesRequest) (*ListOptionDatesResponse, error)
 	ListOptions(context.Context, *ListOptionsRequest) (*ListOptionsResponse, error)
 	CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error)
+	ListOrders(context.Context, *ListOrdersRequest) (*ListOrdersResponse, error)
+	ApproveOrder(context.Context, *ApproveOrderRequest) (*ApproveOrderResponse, error)
+	DeclineOrder(context.Context, *DeclineOrderRequest) (*DeclineOrderResponse, error)
+	CancelOrder(context.Context, *CancelOrderRequest) (*CancelOrderResponse, error)
 	SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
@@ -189,6 +241,18 @@ func (UnimplementedTradingServiceServer) ListOptions(context.Context, *ListOptio
 }
 func (UnimplementedTradingServiceServer) CreateOrder(context.Context, *CreateOrderRequest) (*CreateOrderResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateOrder not implemented")
+}
+func (UnimplementedTradingServiceServer) ListOrders(context.Context, *ListOrdersRequest) (*ListOrdersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListOrders not implemented")
+}
+func (UnimplementedTradingServiceServer) ApproveOrder(context.Context, *ApproveOrderRequest) (*ApproveOrderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ApproveOrder not implemented")
+}
+func (UnimplementedTradingServiceServer) DeclineOrder(context.Context, *DeclineOrderRequest) (*DeclineOrderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeclineOrder not implemented")
+}
+func (UnimplementedTradingServiceServer) CancelOrder(context.Context, *CancelOrderRequest) (*CancelOrderResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelOrder not implemented")
 }
 func (UnimplementedTradingServiceServer) SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetExchangeOpenOverride not implemented")
@@ -358,6 +422,78 @@ func _TradingService_CreateOrder_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_ListOrders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListOrdersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ListOrders(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ListOrders_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ListOrders(ctx, req.(*ListOrdersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_ApproveOrder_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ApproveOrderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ApproveOrder(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ApproveOrder_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ApproveOrder(ctx, req.(*ApproveOrderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_DeclineOrder_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeclineOrderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).DeclineOrder(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_DeclineOrder_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).DeclineOrder(ctx, req.(*DeclineOrderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_CancelOrder_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelOrderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).CancelOrder(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_CancelOrder_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).CancelOrder(ctx, req.(*CancelOrderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _TradingService_SetExchangeOpenOverride_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SetExchangeOpenOverrideRequest)
 	if err := dec(in); err != nil {
@@ -414,6 +550,22 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateOrder",
 			Handler:    _TradingService_CreateOrder_Handler,
+		},
+		{
+			MethodName: "ListOrders",
+			Handler:    _TradingService_ListOrders_Handler,
+		},
+		{
+			MethodName: "ApproveOrder",
+			Handler:    _TradingService_ApproveOrder_Handler,
+		},
+		{
+			MethodName: "DeclineOrder",
+			Handler:    _TradingService_DeclineOrder_Handler,
+		},
+		{
+			MethodName: "CancelOrder",
+			Handler:    _TradingService_CancelOrder_Handler,
 		},
 		{
 			MethodName: "SetExchangeOpenOverride",

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -39,6 +39,8 @@ func writeGRPCError(c *gin.Context, err error) {
 		})
 	case codes.PermissionDenied:
 		c.String(http.StatusForbidden, st.Message())
+	case codes.FailedPrecondition:
+		c.String(http.StatusConflict, st.Message())
 	case TotpAleadyEnabledCode:
 		c.String(http.StatusConflict, st.Message())
 	default:

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -143,9 +143,16 @@ func SetupApi(router *gin.Engine, server *Server) {
 		exchange.POST("/convert", auth, secured("role:client"), server.ConvertMoney)
 	}
 
-	orders := api.Group("/orders", auth, secured("role:client|employee"))
+	orders := api.Group("/orders", auth)
 	{
-		orders.POST("", server.CreateOrder)
+		orders.POST("", secured("role:client|employee"), server.CreateOrder)
+		// Supervisor orders portal (spec pp.57–58 / #204). list+approve+decline
+		// are supervisor-only; cancel is open to placers and supervisors, with
+		// the owner-vs-permission check done inside the trading RPC.
+		orders.GET("", secured("supervisor"), server.ListOrders)
+		orders.POST("/:id/approve", secured("supervisor"), server.ApproveOrder)
+		orders.POST("/:id/decline", secured("supervisor"), server.DeclineOrder)
+		orders.POST("/:id/cancel", secured("role:client|employee"), server.CancelOrder)
 	}
 
 	// Trading read API (issue #196). Clients and employees share the same

--- a/internal/gateway/orders.go
+++ b/internal/gateway/orders.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"time"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
@@ -59,4 +60,135 @@ func (s *Server) CreateOrder(c *gin.Context) {
 		"order_id": resp.OrderId,
 		"status":   resp.Status,
 	})
+}
+
+// orderDetailToJSON renders the supervisor portal's order row (spec p.57).
+// Shape mirrors the proto's OrderDetail so frontend fields stay in lockstep.
+func orderDetailToJSON(o *tradingpb.OrderDetail) gin.H {
+	return gin.H{
+		"id":                 o.Id,
+		"status":             o.Status,
+		"order_type":         o.OrderType,
+		"direction":          o.Direction,
+		"quantity":           o.Quantity,
+		"contract_size":      o.ContractSize,
+		"price_per_unit":     o.PricePerUnit,
+		"remaining_portions": o.RemainingPortions,
+		"asset_label":        o.AssetLabel,
+		"agent":              o.PlacerName,
+		"placer_employee_id": o.PlacerEmployeeId,
+		"placer_client_id":   o.PlacerClientId,
+		"past_settlement":    o.PastSettlement,
+		"approved_by":        o.ApprovedBy,
+		"created_at_unix":    o.CreatedAtUnix,
+		"margin":             o.Margin,
+		"all_or_none":        o.AllOrNone,
+		"commission":         o.Commission,
+	}
+}
+
+// ListOrders surfaces the supervisor's orders portal feed. Both filters are
+// optional: `status` accepts all|pending|approved|declined|done|cancelled,
+// `agent` accepts an employee id to scope down to a single actuary.
+func (s *Server) ListOrders(c *gin.Context) {
+	statusFilter := c.Query("status")
+	agentStr := c.Query("agent")
+	var agentID int64
+	if agentStr != "" {
+		v, err := strconv.ParseInt(agentStr, 10, 64)
+		if err != nil || v < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "agent must be a non-negative integer"})
+			return
+		}
+		agentID = v
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListOrders(ctx, &tradingpb.ListOrdersRequest{
+		CallerEmail: c.GetString("email"),
+		Status:      statusFilter,
+		AgentId:     agentID,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(resp.Orders))
+	for _, o := range resp.Orders {
+		out = append(out, orderDetailToJSON(o))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// orderIDFromPath parses the `:id` path segment into a positive int64. Shared
+// between approve/decline/cancel so the 400 message is consistent.
+func orderIDFromPath(c *gin.Context) (int64, bool) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "order id must be a positive integer"})
+		return 0, false
+	}
+	return id, true
+}
+
+func (s *Server) ApproveOrder(c *gin.Context) {
+	id, ok := orderIDFromPath(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	resp, err := s.TradingClient.ApproveOrder(ctx, &tradingpb.ApproveOrderRequest{
+		OrderId:     id,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, orderDetailToJSON(resp.Order))
+}
+
+func (s *Server) DeclineOrder(c *gin.Context) {
+	id, ok := orderIDFromPath(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	resp, err := s.TradingClient.DeclineOrder(ctx, &tradingpb.DeclineOrderRequest{
+		OrderId:     id,
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, orderDetailToJSON(resp.Order))
+}
+
+// CancelOrder sends the caller's email via gRPC metadata (mirroring
+// CreateOrder) so the trading server can distinguish client-owner vs.
+// employee-owner vs. supervisor without an extra caller_email field.
+func (s *Server) CancelOrder(c *gin.Context) {
+	id, ok := orderIDFromPath(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+	resp, err := s.TradingClient.CancelOrder(ctx, &tradingpb.CancelOrderRequest{
+		OrderId: id,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, orderDetailToJSON(resp.Order))
 }

--- a/internal/trading/models.go
+++ b/internal/trading/models.go
@@ -36,10 +36,11 @@ const (
 type OrderStatus string
 
 const (
-	StatusPending  OrderStatus = "pending"
-	StatusApproved OrderStatus = "approved"
-	StatusDeclined OrderStatus = "declined"
-	StatusDone     OrderStatus = "done"
+	StatusPending   OrderStatus = "pending"
+	StatusApproved  OrderStatus = "approved"
+	StatusDeclined  OrderStatus = "declined"
+	StatusDone      OrderStatus = "done"
+	StatusCancelled OrderStatus = "cancelled"
 )
 
 type Exchange struct {

--- a/internal/trading/orders_portal.go
+++ b/internal/trading/orders_portal.go
@@ -1,0 +1,646 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// requirePending rejects any order whose current status isn't "pending",
+// enforcing the "single-shot" rule on approve/decline (spec p.57: a repeat
+// call must return FailedPrecondition).
+func requirePending(s OrderStatus) error {
+	if s != StatusPending {
+		return status.Errorf(codes.FailedPrecondition, "order is %s, not pending", s)
+	}
+	return nil
+}
+
+// requireCancellable accepts pending and approved orders and rejects every
+// terminal state (done / declined / already-cancelled). Used by CancelOrder
+// so repeat cancels on the same row surface as FailedPrecondition.
+func requireCancellable(s OrderStatus) error {
+	switch s {
+	case StatusPending, StatusApproved:
+		return nil
+	}
+	return status.Errorf(codes.FailedPrecondition, "order is %s; only pending/approved can be cancelled", s)
+}
+
+// parseListStatus accepts the supervisor portal's status filter (spec p.57).
+// Empty or "all" means no filter; anything else must be a valid OrderStatus.
+// Returning an empty string tells the caller to skip the WHERE clause.
+func parseListStatus(s string) (OrderStatus, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "all":
+		return "", nil
+	case "pending":
+		return StatusPending, nil
+	case "approved":
+		return StatusApproved, nil
+	case "declined":
+		return StatusDeclined, nil
+	case "done":
+		return StatusDone, nil
+	case "cancelled", "canceled":
+		return StatusCancelled, nil
+	}
+	return "", status.Errorf(codes.InvalidArgument, "invalid status filter %q", s)
+}
+
+// orderSettlementDate re-resolves the underlying's settlement date for an
+// existing order row. Stocks and forex have no expiry; futures carry one on
+// the futures row, options carry one directly. Used by approve to enforce
+// spec p.57: "orders whose underlying is past settlement allow only decline".
+func orderSettlementDate(tx *gorm.DB, o *Order) (*time.Time, error) {
+	switch {
+	case o.OptionID != nil:
+		var opt Option
+		if err := tx.Select("settlement_date").First(&opt, *o.OptionID).Error; err != nil {
+			return nil, err
+		}
+		sd := opt.SettlementDate
+		return &sd, nil
+	case o.ListingID != nil:
+		var listing Listing
+		if err := tx.Select("future_id").First(&listing, *o.ListingID).Error; err != nil {
+			return nil, err
+		}
+		if listing.FutureID == nil {
+			return nil, nil
+		}
+		var fut Future
+		if err := tx.Select("settlement_date").First(&fut, *listing.FutureID).Error; err != nil {
+			return nil, err
+		}
+		sd := fut.SettlementDate
+		return &sd, nil
+	}
+	return nil, nil
+}
+
+// assetLabelForOrder produces the human-readable ticker shown in the portal
+// table. Listings resolve through their stock/future row; options and forex
+// carry a ticker directly.
+func assetLabelForOrder(tx *gorm.DB, o *Order) (string, error) {
+	switch {
+	case o.ListingID != nil:
+		var row struct {
+			Ticker string
+		}
+		err := tx.Raw(`
+			SELECT COALESCE(s.ticker, f.ticker, '') AS ticker
+			FROM listings l
+			LEFT JOIN stocks  s ON s.id = l.stock_id
+			LEFT JOIN futures f ON f.id = l.future_id
+			WHERE l.id = ?
+		`, *o.ListingID).Scan(&row).Error
+		if err != nil {
+			return "", err
+		}
+		return row.Ticker, nil
+	case o.OptionID != nil:
+		var opt Option
+		if err := tx.Select("ticker").First(&opt, *o.OptionID).Error; err != nil {
+			return "", err
+		}
+		return opt.Ticker, nil
+	case o.ForexPairID != nil:
+		var fx ForexPair
+		if err := tx.Select("ticker").First(&fx, *o.ForexPairID).Error; err != nil {
+			return "", err
+		}
+		return fx.Ticker, nil
+	}
+	return "", nil
+}
+
+// placerInfo is the denormalized identity/label for an order's placer. Name
+// is "first last" regardless of whether the placer is an employee or a
+// client, so the portal renders a single "agent" column (spec p.57).
+type placerInfo struct {
+	Name       string
+	EmployeeID int64
+	ClientID   int64
+}
+
+// loadPlacerInfo joins the order_placers row through to either employees or
+// clients to pull a display name. Exactly one of employee_id / client_id is
+// set on the placer row (schema CHECK), so the left joins collapse to
+// whichever side is populated.
+func loadPlacerInfo(tx *gorm.DB, placerID int64) (placerInfo, error) {
+	var row struct {
+		EmployeeID *int64 `gorm:"column:employee_id"`
+		ClientID   *int64 `gorm:"column:client_id"`
+		EmpFirst   string `gorm:"column:emp_first"`
+		EmpLast    string `gorm:"column:emp_last"`
+		CliFirst   string `gorm:"column:cli_first"`
+		CliLast    string `gorm:"column:cli_last"`
+	}
+	err := tx.Raw(`
+		SELECT p.employee_id, p.client_id,
+		       e.first_name AS emp_first, e.last_name AS emp_last,
+		       c.first_name AS cli_first, c.last_name AS cli_last
+		FROM order_placers p
+		LEFT JOIN employees e ON e.id = p.employee_id
+		LEFT JOIN clients   c ON c.id = p.client_id
+		WHERE p.id = ?
+	`, placerID).Scan(&row).Error
+	if err != nil {
+		return placerInfo{}, err
+	}
+	info := placerInfo{}
+	if row.EmployeeID != nil {
+		info.EmployeeID = *row.EmployeeID
+		info.Name = strings.TrimSpace(row.EmpFirst + " " + row.EmpLast)
+	}
+	if row.ClientID != nil {
+		info.ClientID = *row.ClientID
+		info.Name = strings.TrimSpace(row.CliFirst + " " + row.CliLast)
+	}
+	return info, nil
+}
+
+// buildOrderDetail assembles the portal row for a single order. Called from
+// ListOrders (in a loop) and from the approve/decline/cancel responses.
+func (s *Server) buildOrderDetail(tx *gorm.DB, o *Order, now time.Time) (*tradingpb.OrderDetail, error) {
+	label, err := assetLabelForOrder(tx, o)
+	if err != nil {
+		return nil, err
+	}
+	placer, err := loadPlacerInfo(tx, o.PlacerID)
+	if err != nil {
+		return nil, err
+	}
+	sd, err := orderSettlementDate(tx, o)
+	if err != nil {
+		return nil, err
+	}
+	detail := &tradingpb.OrderDetail{
+		Id:                o.ID,
+		Status:            string(o.Status),
+		OrderType:         string(o.OrderType),
+		Direction:         string(o.Direction),
+		Quantity:          o.Quantity,
+		ContractSize:      o.ContractSize,
+		PricePerUnit:      o.PricePerUnit,
+		RemainingPortions: o.RemainingPortions,
+		AssetLabel:        label,
+		PlacerName:        placer.Name,
+		PlacerEmployeeId:  placer.EmployeeID,
+		PlacerClientId:    placer.ClientID,
+		PastSettlement:    isPastSettlement(sd, now),
+		CreatedAtUnix:     o.CreatedAt.Unix(),
+		Margin:            o.Margin,
+		AllOrNone:         o.AllOrNone,
+		Commission:        o.Commission,
+	}
+	if o.ApprovedBy != nil {
+		detail.ApprovedBy = *o.ApprovedBy
+	}
+	return detail, nil
+}
+
+// ListOrders returns the supervisor's orders portal view (spec pp.57–58).
+// Supervisor-only — the gateway gates with `secured("supervisor")` and we
+// re-check here. agent_id filters on the placer's employee_id; passing a
+// positive id naturally excludes client-placed orders since the join needs
+// a non-null employee_id.
+func (s *Server) ListOrders(_ context.Context, req *tradingpb.ListOrdersRequest) (*tradingpb.ListOrdersResponse, error) {
+	if !callerIsSupervisor(s.db, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "supervisor permission required")
+	}
+
+	filter, err := parseListStatus(req.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	q := s.db.Model(&Order{}).Joins("JOIN order_placers p ON p.id = orders.placer_id")
+	if filter != "" {
+		q = q.Where("orders.status = ?", string(filter))
+	}
+	if req.AgentId > 0 {
+		q = q.Where("p.employee_id = ?", req.AgentId)
+	}
+	q = q.Order("orders.created_at DESC")
+
+	var orders []Order
+	if err := q.Find(&orders).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	now := time.Now()
+	out := make([]*tradingpb.OrderDetail, 0, len(orders))
+	for i := range orders {
+		d, err := s.buildOrderDetail(s.db, &orders[i], now)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "%v", err)
+		}
+		out = append(out, d)
+	}
+	return &tradingpb.ListOrdersResponse{Orders: out}, nil
+}
+
+// ApproveOrder transitions a pending order to approved. Single-shot: any
+// non-pending status (including a prior approve) returns FailedPrecondition.
+// If the underlying is past settlement the approve is refused — the
+// supervisor can only decline such orders (spec p.57). approved_by is set to
+// the supervisor's employee id; the agent's used_limit is consumed at this
+// point so subsequent orders see the updated headroom.
+func (s *Server) ApproveOrder(_ context.Context, req *tradingpb.ApproveOrderRequest) (*tradingpb.ApproveOrderResponse, error) {
+	if req.OrderId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "order_id required")
+	}
+	supID, err := supervisorEmployeeID(s.db, req.CallerEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	var detail *tradingpb.OrderDetail
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		order, err := lockOrder(tx, req.OrderId)
+		if err != nil {
+			return err
+		}
+		if err := requirePending(order.Status); err != nil {
+			return err
+		}
+		sd, err := orderSettlementDate(tx, order)
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		if isPastSettlement(sd, time.Now()) {
+			return status.Error(codes.FailedPrecondition, "underlying is past settlement; decline only")
+		}
+
+		if err := tx.Model(order).Updates(map[string]any{
+			"status":      string(StatusApproved),
+			"approved_by": supID,
+		}).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		order.Status = StatusApproved
+		order.ApprovedBy = &supID
+
+		if err := consumeAgentLimitOnApproval(tx, order, s.bank); err != nil {
+			return err
+		}
+
+		d, err := s.buildOrderDetail(tx, order, time.Now())
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		detail = d
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.ApproveOrderResponse{Order: detail}, nil
+}
+
+// DeclineOrder transitions a pending order to declined. Single-shot: any
+// non-pending status returns FailedPrecondition. Commission isn't refunded
+// here — the orders table doesn't carry the debit account_number, so a
+// refund has no target; spec pp.57–58 don't mandate one. Left for the
+// execution engine (#205) to wire once per-fill accounting lands.
+func (s *Server) DeclineOrder(_ context.Context, req *tradingpb.DeclineOrderRequest) (*tradingpb.DeclineOrderResponse, error) {
+	if req.OrderId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "order_id required")
+	}
+	if _, err := supervisorEmployeeID(s.db, req.CallerEmail); err != nil {
+		return nil, err
+	}
+
+	var detail *tradingpb.OrderDetail
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		order, err := lockOrder(tx, req.OrderId)
+		if err != nil {
+			return err
+		}
+		if err := requirePending(order.Status); err != nil {
+			return err
+		}
+
+		if err := tx.Model(order).Update("status", string(StatusDeclined)).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		order.Status = StatusDeclined
+
+		d, err := s.buildOrderDetail(tx, order, time.Now())
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		detail = d
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.DeclineOrderResponse{Order: detail}, nil
+}
+
+// CancelOrder withdraws the remaining, unfilled portion of an order. The
+// caller must either be the placer (owner) or carry supervisor /
+// trading_cancel permissions (spec p.58). Pending and approved orders can be
+// cancelled; done, declined, and already-cancelled ones return
+// FailedPrecondition.
+func (s *Server) CancelOrder(ctx context.Context, req *tradingpb.CancelOrderRequest) (*tradingpb.CancelOrderResponse, error) {
+	if req.OrderId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "order_id required")
+	}
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var detail *tradingpb.OrderDetail
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		order, err := lockOrder(tx, req.OrderId)
+		if err != nil {
+			return err
+		}
+		if err := requireCancellable(order.Status); err != nil {
+			return err
+		}
+		if err := authorizeCancel(tx, order, caller); err != nil {
+			return err
+		}
+
+		if err := tx.Model(order).Updates(map[string]any{
+			"status":             string(StatusCancelled),
+			"remaining_portions": 0,
+		}).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		order.Status = StatusCancelled
+		order.RemainingPortions = 0
+
+		d, err := s.buildOrderDetail(tx, order, time.Now())
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		detail = d
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.CancelOrderResponse{Order: detail}, nil
+}
+
+// authorizeCancel enforces the spec's "owner or supervisor" rule, with an
+// extra carveout for employees holding the seeded trading_cancel permission.
+// Owners are matched on the placer row so clients can only cancel rows they
+// actually placed; employees who own the order are also allowed through the
+// ownership path (no perm needed) to mirror how CreateOrder's placer semantics
+// work for agent-placed orders.
+func authorizeCancel(tx *gorm.DB, order *Order, caller *bank.CallerIdentity) error {
+	var placer OrderPlacer
+	if err := tx.First(&placer, order.PlacerID).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+
+	if caller.IsClient && placer.ClientID != nil && *placer.ClientID == caller.ClientID {
+		return nil
+	}
+	if caller.IsEmployee {
+		if callerIsSupervisor(tx, caller.Email) {
+			return nil
+		}
+		if callerHasTradingCancel(tx, caller.Email) {
+			return nil
+		}
+		if placer.EmployeeID != nil && callerEmployeeID(tx, caller.Email) == *placer.EmployeeID {
+			return nil
+		}
+	}
+	return status.Error(codes.PermissionDenied, "only the placer or a supervisor may cancel this order")
+}
+
+// callerHasTradingCancel checks for the `trading_cancel` permission (admin
+// bypasses). Same shape as callerHasMarginPermission — trading stays in the
+// bank process so it queries employee_permissions directly.
+func callerHasTradingCancel(db *gorm.DB, email string) bool {
+	if strings.TrimSpace(email) == "" {
+		return false
+	}
+	var count int64
+	err := db.Table("employees").
+		Joins("JOIN employee_permissions ep ON ep.employee_id = employees.id").
+		Joins("JOIN permissions p ON p.id = ep.permission_id").
+		Where("employees.email = ? AND p.name IN (?)", email, []string{"admin", "trading_cancel"}).
+		Count(&count).Error
+	if err != nil {
+		return false
+	}
+	return count > 0
+}
+
+// callerEmployeeID returns the employee's primary key for the given email,
+// or 0 if the lookup fails (matches authorizeCancel's "fall through" shape —
+// a miss means the caller doesn't own the placer row).
+func callerEmployeeID(db *gorm.DB, email string) int64 {
+	if strings.TrimSpace(email) == "" {
+		return 0
+	}
+	var id int64
+	err := db.Table("employees").Select("id").Where("email = ?", email).Take(&id).Error
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+// supervisorEmployeeID verifies the caller carries supervisor/admin and
+// returns their employee id in one shot. Used by approve to populate
+// approved_by and by decline to gate the call. PermissionDenied is the only
+// caller-visible error; NotFound on the email bubbles up as the same
+// permission error to avoid leaking whether the email exists.
+func supervisorEmployeeID(db *gorm.DB, email string) (int64, error) {
+	if strings.TrimSpace(email) == "" {
+		return 0, status.Error(codes.PermissionDenied, "supervisor permission required")
+	}
+	var row struct {
+		ID int64
+	}
+	err := db.Table("employees").
+		Select("employees.id").
+		Joins("JOIN employee_permissions ep ON ep.employee_id = employees.id").
+		Joins("JOIN permissions p ON p.id = ep.permission_id").
+		Where("employees.email = ? AND p.name IN (?)", email, []string{"admin", "supervisor"}).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, status.Error(codes.PermissionDenied, "supervisor permission required")
+		}
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return row.ID, nil
+}
+
+// consumeAgentLimitOnApproval mirrors the self-approve path in CreateOrder: if
+// the placer is an agent (not supervisor/client), their used_limit grows by
+// the order's approximate RSD notional. Done here rather than at placement
+// because pending orders deliberately skip the increment (spec p.39 — limit
+// consumed only once the order is live).
+func consumeAgentLimitOnApproval(tx *gorm.DB, order *Order, bankSrv *bank.Server) error {
+	var placer OrderPlacer
+	if err := tx.First(&placer, order.PlacerID).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	if placer.EmployeeID == nil {
+		return nil
+	}
+
+	var emp struct {
+		Email string
+	}
+	if err := tx.Table("employees").Select("email").Where("id = ?", *placer.EmployeeID).Take(&emp).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	_, role, _, err := resolveEmployeeRole(tx, emp.Email)
+	if err != nil {
+		return err
+	}
+	if role != roleAgent {
+		return nil
+	}
+
+	currency, err := orderInstrumentCurrency(tx, order)
+	if err != nil {
+		return err
+	}
+	// Market orders carry price_per_unit=0 on the row (execution re-reads the
+	// quote at fill time) so the notional must come from the current market
+	// price, not the order row. Non-market orders store the user-provided
+	// limit/stop price and can use it directly.
+	pricePerUnit := order.PricePerUnit
+	if order.OrderType == OrderMarket && pricePerUnit == 0 {
+		pricePerUnit, err = orderMarketPrice(tx, order)
+		if err != nil {
+			return err
+		}
+	}
+	approxNative := order.ContractSize * pricePerUnit * order.Quantity
+	var approxRSD int64
+	if currency == "RSD" {
+		approxRSD = approxNative
+	} else {
+		rate, err := bankSrv.GetExchangeRateToRSD(currency)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", currency, err)
+		}
+		approxRSD = int64(float64(approxNative) * rate)
+	}
+
+	return tx.Table("employees").
+		Where("id = ?", *placer.EmployeeID).
+		Update("used_limit", gorm.Expr("used_limit + ?", approxRSD)).Error
+}
+
+// orderMarketPrice re-reads the current quote for a market order whose row
+// stores price_per_unit=0. Listings use the listing price, options use the
+// premium, forex uses the usual ExchangeRate*100 convention (matching
+// resolveInstrument at placement).
+func orderMarketPrice(tx *gorm.DB, o *Order) (int64, error) {
+	switch {
+	case o.ListingID != nil:
+		var l Listing
+		if err := tx.Select("price").First(&l, *o.ListingID).Error; err != nil {
+			return 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		return l.Price, nil
+	case o.OptionID != nil:
+		var opt Option
+		if err := tx.Select("premium").First(&opt, *o.OptionID).Error; err != nil {
+			return 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		return opt.Premium, nil
+	case o.ForexPairID != nil:
+		var fx ForexPair
+		if err := tx.Select("exchange_rate").First(&fx, *o.ForexPairID).Error; err != nil {
+			return 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		return int64(fx.ExchangeRate * 100), nil
+	}
+	return 0, status.Error(codes.Internal, "order has no underlying reference")
+}
+
+// orderInstrumentCurrency recovers the currency originally used for commission
+// / approval math. Listings inherit exchange currency; options follow the
+// underlying's listing; forex uses its quote currency. Kept separate from
+// resolveInstrument to avoid re-loading market prices we don't need here.
+func orderInstrumentCurrency(tx *gorm.DB, o *Order) (string, error) {
+	switch {
+	case o.ListingID != nil:
+		var row struct {
+			Currency string
+		}
+		err := tx.Raw(`
+			SELECT e.currency FROM listings l
+			JOIN exchanges e ON e.id = l.exchange_id
+			WHERE l.id = ?
+		`, *o.ListingID).Scan(&row).Error
+		if err != nil {
+			return "", err
+		}
+		return row.Currency, nil
+	case o.OptionID != nil:
+		var row struct {
+			Currency string
+		}
+		err := tx.Raw(`
+			SELECT e.currency FROM options o
+			JOIN listings l  ON l.stock_id = o.stock_id
+			JOIN exchanges e ON e.id = l.exchange_id
+			WHERE o.id = ?
+			LIMIT 1
+		`, *o.OptionID).Scan(&row).Error
+		if err != nil {
+			return "", err
+		}
+		return row.Currency, nil
+	case o.ForexPairID != nil:
+		var fx ForexPair
+		if err := tx.Select("quote_currency").First(&fx, *o.ForexPairID).Error; err != nil {
+			return "", err
+		}
+		return fx.QuoteCurrency, nil
+	}
+	return "", status.Error(codes.Internal, "order has no underlying reference")
+}
+
+// lockOrder loads an order row FOR UPDATE so concurrent approve/decline/cancel
+// calls serialize through Postgres row locks. NotFound becomes a gRPC error
+// directly; other failures bubble up as Internal through the transaction
+// wrapper.
+func lockOrder(tx *gorm.DB, id int64) (*Order, error) {
+	var o Order
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&o, id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "order not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &o, nil
+}

--- a/internal/trading/orders_portal_test.go
+++ b/internal/trading/orders_portal_test.go
@@ -1,0 +1,112 @@
+package trading
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRequirePending(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      OrderStatus
+		wantErr bool
+	}{
+		{"pending passes", StatusPending, false},
+		{"approved rejects", StatusApproved, true},
+		{"declined rejects", StatusDeclined, true},
+		{"done rejects", StatusDone, true},
+		{"cancelled rejects", StatusCancelled, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := requirePending(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if status.Code(err) != codes.FailedPrecondition {
+					t.Errorf("code = %s, want FailedPrecondition", status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireCancellable(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      OrderStatus
+		wantErr bool
+	}{
+		{"pending cancellable", StatusPending, false},
+		{"approved cancellable", StatusApproved, false},
+		{"declined rejects", StatusDeclined, true},
+		{"done rejects", StatusDone, true},
+		{"cancelled rejects", StatusCancelled, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := requireCancellable(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if status.Code(err) != codes.FailedPrecondition {
+					t.Errorf("code = %s, want FailedPrecondition", status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseListStatus(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    OrderStatus
+		wantErr bool
+	}{
+		{"", "", false},
+		{"all", "", false},
+		{"ALL", "", false},
+		{"  all  ", "", false},
+		{"pending", StatusPending, false},
+		{"approved", StatusApproved, false},
+		{"declined", StatusDeclined, false},
+		{"done", StatusDone, false},
+		{"cancelled", StatusCancelled, false},
+		{"canceled", StatusCancelled, false},
+		{"Pending", StatusPending, false},
+		{"bogus", "", true},
+		{"pend", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseListStatus(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", c.in)
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Errorf("code = %s, want InvalidArgument", status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -13,6 +13,10 @@ service TradingService {
   rpc ListOptionDates(ListOptionDatesRequest) returns (ListOptionDatesResponse);
   rpc ListOptions(ListOptionsRequest) returns (ListOptionsResponse);
   rpc CreateOrder(CreateOrderRequest) returns (CreateOrderResponse);
+  rpc ListOrders(ListOrdersRequest) returns (ListOrdersResponse);
+  rpc ApproveOrder(ApproveOrderRequest) returns (ApproveOrderResponse);
+  rpc DeclineOrder(DeclineOrderRequest) returns (DeclineOrderResponse);
+  rpc CancelOrder(CancelOrderRequest) returns (CancelOrderResponse);
   rpc SetExchangeOpenOverride(SetExchangeOpenOverrideRequest) returns (SetExchangeOpenOverrideResponse);
 }
 
@@ -241,4 +245,75 @@ message CreateOrderRequest {
 message CreateOrderResponse {
   int64 order_id = 1;
   string status = 2;
+}
+
+// OrderDetail is the row shape used by the supervisor orders portal (spec
+// pp.57–58). asset_label is a human-readable instrument identifier: the
+// listing's ticker for stocks/futures, the option or forex-pair ticker
+// otherwise. placer_name is derived from the placer row (employee or client).
+// past_settlement signals "approve blocked, decline only" at the UI layer —
+// the RPC re-checks server-side.
+message OrderDetail {
+  int64 id = 1;
+  string status = 2;
+  string order_type = 3;
+  string direction = 4;
+  int64 quantity = 5;
+  int64 contract_size = 6;
+  int64 price_per_unit = 7;
+  int64 remaining_portions = 8;
+  string asset_label = 9;
+  string placer_name = 10;
+  int64 placer_employee_id = 11;
+  int64 placer_client_id = 12;
+  bool past_settlement = 13;
+  int64 approved_by = 14;
+  int64 created_at_unix = 15;
+  bool margin = 16;
+  bool all_or_none = 17;
+  int64 commission = 18;
+}
+
+// Supervisor-only. status: "" or "all" returns every order, otherwise one of
+// "pending|approved|declined|done|cancelled". agent_id filters by the placer's
+// employee_id (0 = no filter); client-placed orders are excluded when a
+// positive agent_id is passed.
+message ListOrdersRequest {
+  string caller_email = 1;
+  string status = 2;
+  int64 agent_id = 3;
+}
+
+message ListOrdersResponse {
+  repeated OrderDetail orders = 1;
+}
+
+message ApproveOrderRequest {
+  int64 order_id = 1;
+  string caller_email = 2;
+}
+
+message ApproveOrderResponse {
+  OrderDetail order = 1;
+}
+
+message DeclineOrderRequest {
+  int64 order_id = 1;
+  string caller_email = 2;
+}
+
+message DeclineOrderResponse {
+  OrderDetail order = 1;
+}
+
+// CancelOrder accepts either the order's owner or a supervisor. The caller
+// identity comes from the `user-email` gRPC metadata header (same as
+// CreateOrder) so the server can distinguish client owner vs. employee owner
+// vs. supervisor without an extra DB round trip on the gateway.
+message CancelOrderRequest {
+  int64 order_id = 1;
+}
+
+message CancelOrderResponse {
+  OrderDetail order = 1;
 }

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -397,7 +397,11 @@ CREATE TABLE IF NOT EXISTS order_placers (
 
 CREATE TYPE order_type AS ENUM ('market', 'limit', 'stop', 'stop_limit');
 CREATE TYPE order_direction AS ENUM ('buy', 'sell');
-CREATE TYPE order_status AS ENUM ('pending', 'approved', 'declined', 'done');
+-- 'cancelled' distinguishes supervisor/owner withdrawals from supervisor-declined
+-- orders: declined is for pending orders that never went live (and get a
+-- commission refund); cancelled is for orders that were approved but are being
+-- withdrawn against their remaining unfilled portion (spec pp.57–58, #204).
+CREATE TYPE order_status AS ENUM ('pending', 'approved', 'declined', 'done', 'cancelled');
 
 CREATE TABLE IF NOT EXISTS orders (
     id                  BIGSERIAL       PRIMARY KEY,

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -12,7 +12,8 @@ VALUES
     ('manage_cards'),
     ('agent'),
     ('supervisor'),
-    ('margin_trading')
+    ('margin_trading'),
+    ('trading_cancel')
 ON CONFLICT (name) DO NOTHING;
 
 -- default admin (password: "Admin123!")
@@ -101,7 +102,7 @@ ON CONFLICT (email) DO NOTHING;
 INSERT INTO employee_permissions (employee_id, permission_id)
 SELECT e.id, p.id
 FROM employees e, permissions p
-WHERE e.email = 'agent@banka.raf' AND p.name IN ('agent', 'trade_stocks', 'view_stocks')
+WHERE e.email = 'agent@banka.raf' AND p.name IN ('agent', 'trade_stocks', 'view_stocks', 'trading_cancel')
 ON CONFLICT DO NOTHING;
 
 -- trading supervisor (password: "Test1234!") — has `supervisor` perm, no trading limit
@@ -122,7 +123,7 @@ ON CONFLICT (email) DO NOTHING;
 INSERT INTO employee_permissions (employee_id, permission_id)
 SELECT e.id, p.id
 FROM employees e, permissions p
-WHERE e.email = 'supervisor@banka.raf' AND p.name IN ('supervisor', 'trade_stocks', 'view_stocks', 'margin_trading')
+WHERE e.email = 'supervisor@banka.raf' AND p.name IN ('supervisor', 'trade_stocks', 'view_stocks', 'margin_trading', 'trading_cancel')
 ON CONFLICT DO NOTHING;
 
 -- test client (password: "Test1234!")


### PR DESCRIPTION
## Summary
- Adds the spec pp.57–58 endpoints: `GET /api/orders` (supervisor-only, filters by status + agent), `POST /api/orders/:id/{approve,decline,cancel}`.
- Single-shot approve/decline guarded by status + row-locking; past-settlement orders refuse approve (decline-only) per spec.
- Cancel accepts owner, supervisor, or `trading_cancel`-holding employee; sets `status=cancelled` and zeros `remaining_portions`.
- New `cancelled` order_status enum value and `trading_cancel` permission (seeded on agent + supervisor fixtures).
- Gateway maps gRPC FailedPrecondition → HTTP 409 so single-shot violations surface as Conflict.
- Approve propagates the placer-agent's `used_limit` (CreateOrder only did this for the self-approve path).

Closes #204.

## Notes
- Commission refund on decline/cancel intentionally skipped — the orders row doesn't carry the debit account number. Spec doesn't mandate a refund; will be folded into #205 where per-fill accounting lands.
- Market orders store `price_per_unit=0` on the row; the approve path re-reads the live quote to size the agent-limit debit.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\`
- [ ] Manual: place an agent order that goes pending, approve via supervisor, confirm \`approved_by\` set and \`used_limit\` grew.
- [ ] Manual: decline a pending order, repeat → expect 409.
- [ ] Manual: client cancels their own order; non-owner employee without \`trading_cancel\` → expect 403.
- [ ] Manual: approve an order whose future underlying has settled → expect 409 "decline only".

🤖 Generated with [Claude Code](https://claude.com/claude-code)