### PR TITLE
feat(trading): market-order execution engine

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -61,6 +61,8 @@ func main() {
 	defer stopScheduler()
 
 	tradingService := internalTrading.NewServer(gorm_db, bankService)
+	stopExecutor := tradingService.StartExecutor()
+	defer stopExecutor()
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/internal/trading/executor.go
+++ b/internal/trading/executor.go
@@ -1,0 +1,419 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"math"
+	"math/rand"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// Market-order execution engine (#205). Per spec pp. 51, 57–58 the engine
+// fills approved market orders in randomly sized chunks at randomly spaced
+// intervals, with the interval scaled by the listing's daily volume. The
+// implementation is a single ticker goroutine rather than per-order
+// goroutines so cancellation/shutdown stays simple and state (next-fill
+// time per order) lives in one map. In-memory state is intentional:
+// restart re-rolls delays, which is acceptable at sim fidelity.
+const (
+	executorTickInterval = 1 * time.Second
+	// executorDefaultDelaySeconds is used when today's listing volume is
+	// still 0 and the spec formula (24*60 * remaining / Volume) would
+	// divide by zero. Picked short enough that the first fill happens
+	// quickly, after which volume becomes non-zero and the formula takes
+	// over on its own.
+	executorDefaultDelaySeconds int64 = 30
+	// afterHoursDelayBonus matches the spec's "add 30 min" rule on top of
+	// the computed interval for orders flagged as after-hours (p.58).
+	afterHoursDelayBonus = 30 * time.Minute
+	// executorFailureBackoff keeps a persistently failing order from
+	// hot-looping on the tick queue without dropping it permanently.
+	executorFailureBackoff = 30 * time.Second
+)
+
+// StartExecutor launches the market-order execution worker. Mirrors the
+// cancel-func pattern used by bank.StartScheduler so main.go treats both
+// the same way.
+func (s *Server) StartExecutor() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.runExecutor(ctx)
+	return cancel
+}
+
+func (s *Server) runExecutor(ctx context.Context) {
+	nextFillAt := map[int64]time.Time{}
+	ticker := time.NewTicker(executorTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			s.executorTick(now, nextFillAt)
+		}
+	}
+}
+
+// executorTick scans the approved market-order pool and fires any whose
+// scheduled fill time has elapsed. Listings only for now: options and forex
+// have no ask/bid + listing_daily_price_info.volume, so they need their own
+// engine and are out of scope for #205.
+func (s *Server) executorTick(now time.Time, nextFillAt map[int64]time.Time) {
+	var orders []Order
+	err := s.db.Where(
+		"status = ? AND is_done = ? AND order_type = ? AND listing_id IS NOT NULL",
+		StatusApproved, false, OrderMarket,
+	).Find(&orders).Error
+	if err != nil {
+		log.Printf("[Executor] ERROR loading orders: %v", err)
+		return
+	}
+
+	alive := make(map[int64]struct{}, len(orders))
+	for _, o := range orders {
+		alive[o.ID] = struct{}{}
+	}
+	for id := range nextFillAt {
+		if _, ok := alive[id]; !ok {
+			delete(nextFillAt, id)
+		}
+	}
+
+	for i := range orders {
+		o := &orders[i]
+		due, scheduled := nextFillAt[o.ID]
+		if !scheduled {
+			// New order seen this tick: schedule immediately so the first
+			// fill happens next tick instead of waiting on a delay
+			// computed against zero progress.
+			nextFillAt[o.ID] = now
+			continue
+		}
+		if now.Before(due) {
+			continue
+		}
+		next, err := s.executeFill(o, now)
+		if err != nil {
+			log.Printf("[Executor] order %d fill failed: %v", o.ID, err)
+			nextFillAt[o.ID] = now.Add(executorFailureBackoff)
+			continue
+		}
+		if next.IsZero() {
+			delete(nextFillAt, o.ID)
+			continue
+		}
+		nextFillAt[o.ID] = next
+	}
+}
+
+// executeFill fills one chunk in a transaction. Returns the scheduled time
+// for the next chunk; the zero time signals "order is complete, drop it".
+func (s *Server) executeFill(o *Order, now time.Time) (time.Time, error) {
+	var next time.Time
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		// Re-lock + re-check: a concurrent cancel or prior fill on the same
+		// order might have moved the row out from under this tick.
+		locked, err := lockOrder(tx, o.ID)
+		if err != nil {
+			return err
+		}
+		if locked.Status != StatusApproved || locked.IsDone || locked.RemainingPortions <= 0 {
+			next = time.Time{}
+			return nil
+		}
+		if locked.OrderType != OrderMarket || locked.ListingID == nil {
+			next = time.Time{}
+			return nil
+		}
+
+		var listing Listing
+		if err := tx.First(&listing, *locked.ListingID).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		var exch Exchange
+		if err := tx.First(&exch, listing.ExchangeID).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		// Clock check: the delay may have fired while the exchange is
+		// closed (e.g. order was scheduled late in the session and slept
+		// past close). Postpone one tick rather than filling against a
+		// stale quote.
+		if !IsOpen(exch, now) {
+			next = now.Add(executorTickInterval)
+			return nil
+		}
+
+		fillPPU := fillPricePerUnit(locked.Direction, listing)
+		if fillPPU <= 0 {
+			next = now.Add(executorTickInterval)
+			return nil
+		}
+		chunk := randomChunk(locked.RemainingPortions)
+		chunkCostInstr := chunk * locked.ContractSize * fillPPU
+
+		acc, err := s.bank.GetAccountByNumber(locked.AccountNumber)
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		instrCurrency := exch.Currency
+		settle, err := s.planSettlement(acc.Currency, instrCurrency, chunkCostInstr, locked.Direction)
+		if err != nil {
+			return err
+		}
+
+		if err := applySettlement(tx, locked.Direction, locked.AccountNumber, acc.Currency, instrCurrency, settle); err != nil {
+			return err
+		}
+
+		fill := OrderFill{
+			OrderID:      locked.ID,
+			Portions:     chunk,
+			PricePerUnit: fillPPU,
+			FxRate:       settle.fxRate,
+		}
+		if err := tx.Create(&fill).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		newVolume, err := upsertDailyVolume(tx, *locked.ListingID, now, chunk, listing)
+		if err != nil {
+			return err
+		}
+
+		newRemaining := locked.RemainingPortions - chunk
+		updates := map[string]any{
+			"remaining_portions": newRemaining,
+			"last_modification":  now,
+		}
+		if newRemaining <= 0 {
+			updates["is_done"] = true
+			updates["status"] = string(StatusDone)
+		}
+		if err := tx.Model(locked).Updates(updates).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		if newRemaining <= 0 {
+			next = time.Time{}
+			return nil
+		}
+		next = now.Add(nextDelay(newRemaining, newVolume, locked.AfterHours))
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	return next, nil
+}
+
+// fillPricePerUnit returns the per-unit price the chunk should fill at:
+// ask for a buy (placer pays the asking price), bid for a sell (placer gets
+// the bid). Multiplied by contract_size downstream for the chunk total.
+func fillPricePerUnit(d OrderDirection, l Listing) int64 {
+	if d == DirectionBuy {
+		return l.AskPrice
+	}
+	return l.BidPrice
+}
+
+// randomChunk picks the portion count for this fill: Random(1, remaining).
+// Always at least 1 so progress is guaranteed when called on an order with
+// work left.
+func randomChunk(remaining int64) int64 {
+	if remaining <= 1 {
+		return remaining
+	}
+	return rand.Int63n(remaining) + 1
+}
+
+// nextDelay implements the spec formula: Random(0, 24*60 / (Volume /
+// remaining)) seconds, with an after-hours bonus of 30 min. Volume==0 is a
+// first-of-day edge case (no daily row yet) — we fall back to a short
+// default so the first fill lands promptly and builds volume for later
+// ticks to key off.
+func nextDelay(remaining, volume int64, afterHours bool) time.Duration {
+	var maxSec int64
+	if volume <= 0 || remaining <= 0 {
+		maxSec = executorDefaultDelaySeconds
+	} else {
+		maxSec = 1440 * remaining / volume
+		if maxSec <= 0 {
+			maxSec = 1
+		}
+	}
+	d := time.Duration(rand.Int63n(maxSec+1)) * time.Second
+	if afterHours {
+		d += afterHoursDelayBonus
+	}
+	return d
+}
+
+// settlement captures a single chunk's money movement across currencies.
+// feeInstrument is the chunk cost in the instrument's currency; accAmount
+// is its equivalent in the placer account's currency (equal to
+// feeInstrument for same-currency orders). fxRate is nil for same-currency
+// and otherwise snapshots rateInstrRSD/rateAccRSD for audit.
+type settlement struct {
+	accAmount   int64
+	feeInstr    int64
+	fxRate      *float64
+	direction   OrderDirection
+	accCurrency string
+	instrCurr   string
+}
+
+// planSettlement converts the instrument-currency chunk cost into the
+// account's currency via the existing menjacnica rates-to-RSD service
+// (bank.GetExchangeRateToRSD). Rounding sides with the bank: buyers round
+// up, sellers round down, so the placer doesn't pocket a rounding penny on
+// either side. No menjacnica fee is charged at fill — the placement
+// commission already covered it (commission.go, spec pp.27, 57).
+func (s *Server) planSettlement(accCurrency, instrCurrency string, chunkCostInstr int64, dir OrderDirection) (settlement, error) {
+	out := settlement{
+		feeInstr:    chunkCostInstr,
+		direction:   dir,
+		accCurrency: accCurrency,
+		instrCurr:   instrCurrency,
+	}
+	if accCurrency == instrCurrency {
+		out.accAmount = chunkCostInstr
+		return out, nil
+	}
+	rateAccRSD, err := s.bank.GetExchangeRateToRSD(accCurrency)
+	if err != nil {
+		return settlement{}, status.Errorf(codes.Internal, "%v", err)
+	}
+	rateInstrRSD, err := s.bank.GetExchangeRateToRSD(instrCurrency)
+	if err != nil {
+		return settlement{}, status.Errorf(codes.Internal, "%v", err)
+	}
+	rate := rateInstrRSD / rateAccRSD
+	if dir == DirectionBuy {
+		out.accAmount = int64(math.Ceil(float64(chunkCostInstr) * rate))
+	} else {
+		out.accAmount = int64(math.Floor(float64(chunkCostInstr) * rate))
+	}
+	out.fxRate = &rate
+	return out, nil
+}
+
+// applySettlement moves the money for one chunk. With no real orderbook we
+// use the bank-system client (system@banka3.rs) as the standing
+// counterparty: buys debit the placer and credit the system's
+// instrument-currency account; sells do the reverse. The same per-currency
+// system accounts back commission.go's fee pool, so we don't seed a
+// dedicated trading-stub account.
+func applySettlement(tx *gorm.DB, dir OrderDirection, account, accCurrency, instrCurrency string, s settlement) error {
+	if dir == DirectionBuy {
+		if err := debitPlacer(tx, account, s.accAmount); err != nil {
+			return err
+		}
+		return creditFeeAccount(tx, instrCurrency, s.feeInstr)
+	}
+	// Sell: stub pays the placer. Debit the system account first so we
+	// surface an insufficient-funds failure before mutating the placer.
+	if err := debitSystemAccount(tx, instrCurrency, s.feeInstr); err != nil {
+		return err
+	}
+	return creditPlacer(tx, account, s.accAmount)
+}
+
+func debitPlacer(tx *gorm.DB, account string, amount int64) error {
+	if amount <= 0 {
+		return nil
+	}
+	res := tx.Exec(
+		`UPDATE accounts SET balance = balance - ? WHERE number = ? AND balance >= ?`,
+		amount, account, amount,
+	)
+	if res.Error != nil {
+		return status.Errorf(codes.Internal, "%v", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return status.Error(codes.FailedPrecondition, "insufficient funds for fill")
+	}
+	return nil
+}
+
+func creditPlacer(tx *gorm.DB, account string, amount int64) error {
+	if amount <= 0 {
+		return nil
+	}
+	res := tx.Exec(
+		`UPDATE accounts SET balance = balance + ? WHERE number = ?`,
+		amount, account,
+	)
+	if res.Error != nil {
+		return status.Errorf(codes.Internal, "%v", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return status.Error(codes.FailedPrecondition, "placer account missing")
+	}
+	return nil
+}
+
+// debitSystemAccount mirrors creditFeeAccount but in the opposite
+// direction: used by sell-side fills to pull funds out of the bank-stub
+// counterparty. Guards on balance so an under-funded stub surfaces as
+// FailedPrecondition rather than silently going negative.
+func debitSystemAccount(tx *gorm.DB, currency string, amount int64) error {
+	if amount <= 0 {
+		return nil
+	}
+	var feeAccount string
+	err := tx.Raw(
+		`SELECT a.number FROM accounts a
+		 JOIN clients c ON c.id = a.owner
+		 WHERE c.email = ? AND a.currency = ?
+		 LIMIT 1`,
+		bankSystemOwnerEmail, currency,
+	).Scan(&feeAccount).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return status.Errorf(codes.FailedPrecondition, "no bank stub account for %s", currency)
+		}
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	if feeAccount == "" {
+		return status.Errorf(codes.FailedPrecondition, "no bank stub account for %s", currency)
+	}
+	res := tx.Exec(
+		`UPDATE accounts SET balance = balance - ? WHERE number = ? AND balance >= ?`,
+		amount, feeAccount, amount,
+	)
+	if res.Error != nil {
+		return status.Errorf(codes.Internal, "%v", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return status.Errorf(codes.FailedPrecondition, "bank stub account underfunded for %s", currency)
+	}
+	return nil
+}
+
+// upsertDailyVolume bumps today's listing_daily_price_info.volume by the
+// fill size, creating today's row from the listing's current quote if it
+// doesn't exist yet. Returns the post-update volume so the executor can
+// feed it into the delay formula without an extra SELECT.
+func upsertDailyVolume(tx *gorm.DB, listingID int64, now time.Time, chunk int64, listing Listing) (int64, error) {
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	var volume int64
+	err := tx.Raw(
+		`INSERT INTO listing_daily_price_info (listing_id, date, price, ask_price, bid_price, change, volume)
+		 VALUES (?, ?, ?, ?, ?, 0, ?)
+		 ON CONFLICT (listing_id, date)
+		 DO UPDATE SET volume = listing_daily_price_info.volume + EXCLUDED.volume
+		 RETURNING volume`,
+		listingID, today, listing.Price, listing.AskPrice, listing.BidPrice, chunk,
+	).Scan(&volume).Error
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return volume, nil
+}

--- a/internal/trading/executor_test.go
+++ b/internal/trading/executor_test.go
@@ -1,0 +1,109 @@
+package trading
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFillPricePerUnit(t *testing.T) {
+	l := Listing{AskPrice: 12500, BidPrice: 12400}
+	if got := fillPricePerUnit(DirectionBuy, l); got != 12500 {
+		t.Errorf("buy: got %d, want ask 12500", got)
+	}
+	if got := fillPricePerUnit(DirectionSell, l); got != 12400 {
+		t.Errorf("sell: got %d, want bid 12400", got)
+	}
+}
+
+func TestRandomChunkBounds(t *testing.T) {
+	cases := []struct {
+		name      string
+		remaining int64
+	}{
+		{"one", 1},
+		{"small", 5},
+		{"large", 1000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for i := 0; i < 200; i++ {
+				got := randomChunk(c.remaining)
+				if got < 1 || got > c.remaining {
+					t.Fatalf("chunk %d out of [1,%d]", got, c.remaining)
+				}
+			}
+		})
+	}
+}
+
+func TestRandomChunkZero(t *testing.T) {
+	// Not reachable from the executor (it skips is_done/remaining<=0 rows),
+	// but we still want a deterministic answer: zero remaining means zero
+	// chunk, no panic from rand.Int63n(0).
+	if got := randomChunk(0); got != 0 {
+		t.Errorf("chunk on 0 remaining: got %d, want 0", got)
+	}
+}
+
+func TestNextDelayVolumeZeroUsesDefault(t *testing.T) {
+	// Volume=0 happens on the very first fill of the day. Formula would
+	// divide by zero; we fall back to executorDefaultDelaySeconds so the
+	// first fill lands promptly and seeds volume for later ticks.
+	for i := 0; i < 100; i++ {
+		d := nextDelay(10, 0, false)
+		if d < 0 || d > time.Duration(executorDefaultDelaySeconds)*time.Second {
+			t.Fatalf("delay %s outside [0, %ds]", d, executorDefaultDelaySeconds)
+		}
+	}
+}
+
+func TestNextDelayFormula(t *testing.T) {
+	// remaining=100, volume=1440 → max = 1440*100/1440 = 100 seconds.
+	max := 100 * time.Second
+	for i := 0; i < 200; i++ {
+		d := nextDelay(100, 1440, false)
+		if d < 0 || d > max {
+			t.Fatalf("delay %s outside [0, %s]", d, max)
+		}
+	}
+}
+
+func TestNextDelayAfterHoursBonus(t *testing.T) {
+	// After-hours: every computed delay gets +30 min.
+	for i := 0; i < 100; i++ {
+		d := nextDelay(100, 1440, true)
+		if d < afterHoursDelayBonus {
+			t.Fatalf("after-hours delay %s below bonus floor %s", d, afterHoursDelayBonus)
+		}
+		if d > afterHoursDelayBonus+100*time.Second {
+			t.Fatalf("after-hours delay %s above ceiling", d)
+		}
+	}
+}
+
+func TestNextDelayHighVolumeClampsToOneSecond(t *testing.T) {
+	// Volume >> remaining * 1440 → integer division yields 0. The helper
+	// bumps the max to 1s so rand.Int63n doesn't panic on zero.
+	for i := 0; i < 100; i++ {
+		d := nextDelay(1, 1_000_000_000, false)
+		if d < 0 || d > time.Second {
+			t.Fatalf("delay %s outside [0, 1s]", d)
+		}
+	}
+}
+
+func TestPlanSettlementSameCurrency(t *testing.T) {
+	// Same-currency orders leave rate unset and copy the instrument-
+	// currency cost straight through.
+	s := &Server{}
+	got, err := s.planSettlement("USD", "USD", 12500, DirectionBuy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.accAmount != 12500 || got.feeInstr != 12500 {
+		t.Errorf("accAmount=%d feeInstr=%d, want 12500/12500", got.accAmount, got.feeInstr)
+	}
+	if got.fxRate != nil {
+		t.Errorf("fxRate should be nil for same-currency, got %v", *got.fxRate)
+	}
+}

--- a/internal/trading/models.go
+++ b/internal/trading/models.go
@@ -149,6 +149,7 @@ type Order struct {
 	ListingID         *int64         `gorm:"column:listing_id"`
 	OptionID          *int64         `gorm:"column:option_id"`
 	ForexPairID       *int64         `gorm:"column:forex_pair_id"`
+	AccountNumber     string         `gorm:"column:account_number;type:varchar(20);not null"`
 	OrderType         OrderType      `gorm:"column:order_type;type:order_type;not null"`
 	Direction         OrderDirection `gorm:"column:direction;type:order_direction;not null"`
 	Status            OrderStatus    `gorm:"column:status;type:order_status;not null;default:'pending'"`
@@ -167,3 +168,18 @@ type Order struct {
 }
 
 func (Order) TableName() string { return "orders" }
+
+// OrderFill is one chunk executed against an order by the market executor
+// (#205). price_per_unit is in the instrument's currency; FxRate is set only
+// for cross-currency fills and stores the rateInstrRSD/rateAccRSD used to
+// convert the chunk cost into the placer's account currency.
+type OrderFill struct {
+	ID           int64     `gorm:"column:id;primaryKey"`
+	OrderID      int64     `gorm:"column:order_id;not null"`
+	Portions     int64     `gorm:"column:portions;not null"`
+	PricePerUnit int64     `gorm:"column:price_per_unit;not null"`
+	FxRate       *float64  `gorm:"column:fx_rate"`
+	CreatedAt    time.Time `gorm:"column:created_at;not null;autoCreateTime"`
+}
+
+func (OrderFill) TableName() string { return "order_fills" }

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -122,6 +122,14 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	// and always leave the flag false.
 	afterHours := info.Exchange != nil && IsAfterHours(*info.Exchange, now)
 
+	// Market orders cannot be placed while the exchange is closed (spec p.57
+	// / issue #189): execution has no quote to fill against. Limit/stop
+	// variants are allowed outside hours because they wait for a trigger.
+	// Forex has no exchange and is always tradable.
+	if orderType == OrderMarket && info.Exchange != nil && !IsOpen(*info.Exchange, now) {
+		return nil, status.Error(codes.FailedPrecondition, "exchange is closed; market orders cannot be placed")
+	}
+
 	// Approximate-price inputs (spec p.57). We keep PricePerUnit=0 on market
 	// orders so the execution engine (#189) re-reads the quote at fill time,
 	// but approval math still needs a concrete number — that's what
@@ -138,6 +146,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	order := Order{
 		OrderType:         orderType,
 		Direction:         direction,
+		AccountNumber:     req.AccountNumber,
 		Quantity:          req.Quantity,
 		ContractSize:      info.ContractSize,
 		PricePerUnit:      marketReferencePrice(orderType, req),

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -409,6 +409,10 @@ CREATE TABLE IF NOT EXISTS orders (
     listing_id          BIGINT          REFERENCES listings(id) ON UPDATE CASCADE ON DELETE RESTRICT,
     option_id           BIGINT          REFERENCES options(id) ON UPDATE CASCADE ON DELETE RESTRICT,
     forex_pair_id       BIGINT          REFERENCES forex_pairs(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    -- Debit target for the placer side of each fill. Kept on the row so the
+    -- execution engine can settle fills without re-reading the original
+    -- request; also lets decline/cancel refund commission if we ever wire it.
+    account_number      VARCHAR(20)     NOT NULL REFERENCES accounts(number) ON UPDATE CASCADE ON DELETE RESTRICT,
     order_type          order_type      NOT NULL,
     direction           order_direction NOT NULL,
     status              order_status    NOT NULL DEFAULT 'pending',
@@ -426,6 +430,20 @@ CREATE TABLE IF NOT EXISTS orders (
     created_at          TIMESTAMP       NOT NULL DEFAULT NOW(),
     CHECK ((listing_id IS NOT NULL)::int + (option_id IS NOT NULL)::int + (forex_pair_id IS NOT NULL)::int = 1)
 );
+
+-- Per-chunk fills written by the execution engine (#205). price_per_unit is
+-- in the instrument's currency; fx_rate is NULL for same-currency fills and
+-- otherwise stores the rateInstrRSD/rateAccRSD snapshot used to convert the
+-- chunk cost into the placer's account currency at settle time.
+CREATE TABLE IF NOT EXISTS order_fills (
+    id                  BIGSERIAL        PRIMARY KEY,
+    order_id            BIGINT           NOT NULL REFERENCES orders(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    portions            BIGINT           NOT NULL,
+    price_per_unit      BIGINT           NOT NULL,
+    fx_rate             DOUBLE PRECISION,
+    created_at          TIMESTAMP        NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_order_fills_order ON order_fills(order_id);
 
 -- Notify Redis when employee permissions change
 CREATE OR REPLACE FUNCTION notify_permission_change() RETURNS trigger AS $$


### PR DESCRIPTION
## Summary
- New `order_fills` table + `orders.account_number` FK so fills have a settlement target. `CreateOrder` rejects market orders when the exchange is closed (FailedPrecondition; `open_override` respected).
- Background executor (`internal/trading/executor.go`) on a 1s ticker with per-order in-memory schedule. Each due order fills a `Random(1, remaining)` chunk at `ask`/`bid × contract_size`, settles through the existing `system@banka3.rs` per-currency accounts as the standing counterparty (no real orderbook), upserts today's `listing_daily_price_info.volume`, and flips to `done` at zero remaining. Delay between chunks follows the spec formula `Random(0, 1440 × remaining / volume)` seconds, +30 min when `after_hours`.
- Cross-currency: converts chunk cost via `GetExchangeRateToRSD`, storing the `rateInstrRSD/rateAccRSD` snapshot on the fill row; buyer rounds up, seller rounds down so the placer doesn't pocket a rounding penny.
- Listings-only for now: options/forex don't expose `ask`/`bid` + daily-volume, so they're out of scope for #205.

Closes #189, closes #205.

## Test plan
- [x] `go test ./...` green (existing + new `executor_test.go` covering fill-price derivation, chunk bounds, delay formula incl. volume=0 fallback / after-hours bonus / high-volume clamp, same-currency settlement)
- [ ] Manual smoke: place a market buy on an open exchange listing, confirm fills accrue over time, `orders` row flips to `done`, `order_fills` rows populated, `listing_daily_price_info.volume` increments
- [ ] Manual smoke: place a market order while exchange closed → `FailedPrecondition`
- [ ] Manual smoke: cross-currency fill writes `fx_rate` and balances move as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)