### PR TITLE
Trading: portfolio (holdings, sell flow, option exercise) (#207)

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -2464,6 +2464,632 @@ func (x *CancelOrderResponse) GetOrder() *OrderDetail {
 	return nil
 }
 
+// Holding is one row in the portfolio portal (spec p.62 / #207). Exactly one
+// of stock_id / future_id / forex_pair_id / option_id is set — the asset_type
+// string ("stock"|"future"|"forex"|"option") gives the UI a single switch.
+// avg_cost is denominated in the booking account's currency; current_price
+// uses the instrument's quote currency (listing price, option premium, or
+// forex_pair.exchange_rate × 100). profit converts the current quote into the
+// account's currency before subtracting avg_cost so the displayed P/L lines
+// up with what would actually settle on a sell. public_amount is meaningful
+// only for stock holdings (OTC counter, fourth celina) and stays 0 elsewhere.
+type Holding struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Id               int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	PlacerId         int64                  `protobuf:"varint,2,opt,name=placer_id,json=placerId,proto3" json:"placer_id,omitempty"`
+	StockId          int64                  `protobuf:"varint,3,opt,name=stock_id,json=stockId,proto3" json:"stock_id,omitempty"`
+	FutureId         int64                  `protobuf:"varint,4,opt,name=future_id,json=futureId,proto3" json:"future_id,omitempty"`
+	ForexPairId      int64                  `protobuf:"varint,5,opt,name=forex_pair_id,json=forexPairId,proto3" json:"forex_pair_id,omitempty"`
+	OptionId         int64                  `protobuf:"varint,6,opt,name=option_id,json=optionId,proto3" json:"option_id,omitempty"`
+	Amount           int64                  `protobuf:"varint,7,opt,name=amount,proto3" json:"amount,omitempty"`
+	AvgCost          int64                  `protobuf:"varint,8,opt,name=avg_cost,json=avgCost,proto3" json:"avg_cost,omitempty"`
+	AccountId        int64                  `protobuf:"varint,9,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	AccountNumber    string                 `protobuf:"bytes,10,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
+	PublicAmount     int64                  `protobuf:"varint,11,opt,name=public_amount,json=publicAmount,proto3" json:"public_amount,omitempty"`
+	Ticker           string                 `protobuf:"bytes,12,opt,name=ticker,proto3" json:"ticker,omitempty"`
+	CurrentPrice     int64                  `protobuf:"varint,13,opt,name=current_price,json=currentPrice,proto3" json:"current_price,omitempty"`
+	Profit           int64                  `protobuf:"varint,14,opt,name=profit,proto3" json:"profit,omitempty"`
+	LastModifiedUnix int64                  `protobuf:"varint,15,opt,name=last_modified_unix,json=lastModifiedUnix,proto3" json:"last_modified_unix,omitempty"`
+	AssetType        string                 `protobuf:"bytes,16,opt,name=asset_type,json=assetType,proto3" json:"asset_type,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *Holding) Reset() {
+	*x = Holding{}
+	mi := &file_trading_trading_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Holding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Holding) ProtoMessage() {}
+
+func (x *Holding) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Holding.ProtoReflect.Descriptor instead.
+func (*Holding) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *Holding) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *Holding) GetPlacerId() int64 {
+	if x != nil {
+		return x.PlacerId
+	}
+	return 0
+}
+
+func (x *Holding) GetStockId() int64 {
+	if x != nil {
+		return x.StockId
+	}
+	return 0
+}
+
+func (x *Holding) GetFutureId() int64 {
+	if x != nil {
+		return x.FutureId
+	}
+	return 0
+}
+
+func (x *Holding) GetForexPairId() int64 {
+	if x != nil {
+		return x.ForexPairId
+	}
+	return 0
+}
+
+func (x *Holding) GetOptionId() int64 {
+	if x != nil {
+		return x.OptionId
+	}
+	return 0
+}
+
+func (x *Holding) GetAmount() int64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *Holding) GetAvgCost() int64 {
+	if x != nil {
+		return x.AvgCost
+	}
+	return 0
+}
+
+func (x *Holding) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *Holding) GetAccountNumber() string {
+	if x != nil {
+		return x.AccountNumber
+	}
+	return ""
+}
+
+func (x *Holding) GetPublicAmount() int64 {
+	if x != nil {
+		return x.PublicAmount
+	}
+	return 0
+}
+
+func (x *Holding) GetTicker() string {
+	if x != nil {
+		return x.Ticker
+	}
+	return ""
+}
+
+func (x *Holding) GetCurrentPrice() int64 {
+	if x != nil {
+		return x.CurrentPrice
+	}
+	return 0
+}
+
+func (x *Holding) GetProfit() int64 {
+	if x != nil {
+		return x.Profit
+	}
+	return 0
+}
+
+func (x *Holding) GetLastModifiedUnix() int64 {
+	if x != nil {
+		return x.LastModifiedUnix
+	}
+	return 0
+}
+
+func (x *Holding) GetAssetType() string {
+	if x != nil {
+		return x.AssetType
+	}
+	return ""
+}
+
+type ListHoldingsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListHoldingsRequest) Reset() {
+	*x = ListHoldingsRequest{}
+	mi := &file_trading_trading_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListHoldingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListHoldingsRequest) ProtoMessage() {}
+
+func (x *ListHoldingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListHoldingsRequest.ProtoReflect.Descriptor instead.
+func (*ListHoldingsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ListHoldingsRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type ListHoldingsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Holdings      []*Holding             `protobuf:"bytes,1,rep,name=holdings,proto3" json:"holdings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListHoldingsResponse) Reset() {
+	*x = ListHoldingsResponse{}
+	mi := &file_trading_trading_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListHoldingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListHoldingsResponse) ProtoMessage() {}
+
+func (x *ListHoldingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListHoldingsResponse.ProtoReflect.Descriptor instead.
+func (*ListHoldingsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ListHoldingsResponse) GetHoldings() []*Holding {
+	if x != nil {
+		return x.Holdings
+	}
+	return nil
+}
+
+// SellHolding is the spec's `POST /api/portfolio/sell` thin wrapper. The
+// server resolves the holding to its underlying asset and forwards a
+// CreateOrder with direction=sell, so the same execution / approval / margin
+// pipeline applies. The caller must own the holding (placer matches) — the
+// server enforces this rather than the gateway since the holding row carries
+// the authoritative placer link.
+type SellHoldingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HoldingId     int64                  `protobuf:"varint,1,opt,name=holding_id,json=holdingId,proto3" json:"holding_id,omitempty"`
+	AccountNumber string                 `protobuf:"bytes,2,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
+	OrderType     string                 `protobuf:"bytes,3,opt,name=order_type,json=orderType,proto3" json:"order_type,omitempty"`
+	Quantity      int64                  `protobuf:"varint,4,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	LimitPrice    int64                  `protobuf:"varint,5,opt,name=limit_price,json=limitPrice,proto3" json:"limit_price,omitempty"`
+	StopPrice     int64                  `protobuf:"varint,6,opt,name=stop_price,json=stopPrice,proto3" json:"stop_price,omitempty"`
+	AllOrNone     bool                   `protobuf:"varint,7,opt,name=all_or_none,json=allOrNone,proto3" json:"all_or_none,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SellHoldingRequest) Reset() {
+	*x = SellHoldingRequest{}
+	mi := &file_trading_trading_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SellHoldingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SellHoldingRequest) ProtoMessage() {}
+
+func (x *SellHoldingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SellHoldingRequest.ProtoReflect.Descriptor instead.
+func (*SellHoldingRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *SellHoldingRequest) GetHoldingId() int64 {
+	if x != nil {
+		return x.HoldingId
+	}
+	return 0
+}
+
+func (x *SellHoldingRequest) GetAccountNumber() string {
+	if x != nil {
+		return x.AccountNumber
+	}
+	return ""
+}
+
+func (x *SellHoldingRequest) GetOrderType() string {
+	if x != nil {
+		return x.OrderType
+	}
+	return ""
+}
+
+func (x *SellHoldingRequest) GetQuantity() int64 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
+func (x *SellHoldingRequest) GetLimitPrice() int64 {
+	if x != nil {
+		return x.LimitPrice
+	}
+	return 0
+}
+
+func (x *SellHoldingRequest) GetStopPrice() int64 {
+	if x != nil {
+		return x.StopPrice
+	}
+	return 0
+}
+
+func (x *SellHoldingRequest) GetAllOrNone() bool {
+	if x != nil {
+		return x.AllOrNone
+	}
+	return false
+}
+
+type SellHoldingResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrderId       int64                  `protobuf:"varint,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SellHoldingResponse) Reset() {
+	*x = SellHoldingResponse{}
+	mi := &file_trading_trading_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SellHoldingResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SellHoldingResponse) ProtoMessage() {}
+
+func (x *SellHoldingResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SellHoldingResponse.ProtoReflect.Descriptor instead.
+func (*SellHoldingResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *SellHoldingResponse) GetOrderId() int64 {
+	if x != nil {
+		return x.OrderId
+	}
+	return 0
+}
+
+func (x *SellHoldingResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+// SetHoldingPublic adjusts the public_amount counter on a stock holding. The
+// schema CHECK pins public_amount to 0 for non-stock holdings — the server
+// rejects any attempt to set it on a non-stock row with FailedPrecondition.
+// 0 ≤ public_amount ≤ amount; out-of-range values come back as
+// InvalidArgument so the portal can surface the problem inline.
+type SetHoldingPublicRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HoldingId     int64                  `protobuf:"varint,1,opt,name=holding_id,json=holdingId,proto3" json:"holding_id,omitempty"`
+	PublicAmount  int64                  `protobuf:"varint,2,opt,name=public_amount,json=publicAmount,proto3" json:"public_amount,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetHoldingPublicRequest) Reset() {
+	*x = SetHoldingPublicRequest{}
+	mi := &file_trading_trading_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetHoldingPublicRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetHoldingPublicRequest) ProtoMessage() {}
+
+func (x *SetHoldingPublicRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetHoldingPublicRequest.ProtoReflect.Descriptor instead.
+func (*SetHoldingPublicRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *SetHoldingPublicRequest) GetHoldingId() int64 {
+	if x != nil {
+		return x.HoldingId
+	}
+	return 0
+}
+
+func (x *SetHoldingPublicRequest) GetPublicAmount() int64 {
+	if x != nil {
+		return x.PublicAmount
+	}
+	return 0
+}
+
+type SetHoldingPublicResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Holding       *Holding               `protobuf:"bytes,1,opt,name=holding,proto3" json:"holding,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetHoldingPublicResponse) Reset() {
+	*x = SetHoldingPublicResponse{}
+	mi := &file_trading_trading_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetHoldingPublicResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetHoldingPublicResponse) ProtoMessage() {}
+
+func (x *SetHoldingPublicResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetHoldingPublicResponse.ProtoReflect.Descriptor instead.
+func (*SetHoldingPublicResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SetHoldingPublicResponse) GetHolding() *Holding {
+	if x != nil {
+		return x.Holding
+	}
+	return nil
+}
+
+// ExerciseOption settles an option held by the caller. Actuary-only, the
+// option must not be past settlement, and it has to be in-the-money — calls
+// fire when spot > strike, puts when strike > spot. Payout per spec p.62:
+//
+//	call: (spot - strike) * contract_size * quantity − premium * quantity
+//	put : (strike - spot) * contract_size * quantity − premium * quantity
+//
+// The premium is paid back per contract held (not just once) — the user
+// effectively recoups what they paid to acquire the position. Settlement is
+// against the account_number passed in, which must belong to the caller.
+type ExerciseOptionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OptionId      int64                  `protobuf:"varint,1,opt,name=option_id,json=optionId,proto3" json:"option_id,omitempty"`
+	AccountNumber string                 `protobuf:"bytes,2,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExerciseOptionRequest) Reset() {
+	*x = ExerciseOptionRequest{}
+	mi := &file_trading_trading_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExerciseOptionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExerciseOptionRequest) ProtoMessage() {}
+
+func (x *ExerciseOptionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExerciseOptionRequest.ProtoReflect.Descriptor instead.
+func (*ExerciseOptionRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ExerciseOptionRequest) GetOptionId() int64 {
+	if x != nil {
+		return x.OptionId
+	}
+	return 0
+}
+
+func (x *ExerciseOptionRequest) GetAccountNumber() string {
+	if x != nil {
+		return x.AccountNumber
+	}
+	return ""
+}
+
+type ExerciseOptionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Payout        int64                  `protobuf:"varint,1,opt,name=payout,proto3" json:"payout,omitempty"`
+	Quantity      int64                  `protobuf:"varint,2,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExerciseOptionResponse) Reset() {
+	*x = ExerciseOptionResponse{}
+	mi := &file_trading_trading_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExerciseOptionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExerciseOptionResponse) ProtoMessage() {}
+
+func (x *ExerciseOptionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExerciseOptionResponse.ProtoReflect.Descriptor instead.
+func (*ExerciseOptionResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *ExerciseOptionResponse) GetPayout() int64 {
+	if x != nil {
+		return x.Payout
+	}
+	return 0
+}
+
+func (x *ExerciseOptionResponse) GetQuantity() int64 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
 var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
@@ -2678,7 +3304,59 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x12CancelOrderRequest\x12\x19\n" +
 	"\border_id\x18\x01 \x01(\x03R\aorderId\"A\n" +
 	"\x13CancelOrderResponse\x12*\n" +
-	"\x05order\x18\x01 \x01(\v2\x14.trading.OrderDetailR\x05order2\xa9\b\n" +
+	"\x05order\x18\x01 \x01(\v2\x14.trading.OrderDetailR\x05order\"\xef\x03\n" +
+	"\aHolding\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1b\n" +
+	"\tplacer_id\x18\x02 \x01(\x03R\bplacerId\x12\x19\n" +
+	"\bstock_id\x18\x03 \x01(\x03R\astockId\x12\x1b\n" +
+	"\tfuture_id\x18\x04 \x01(\x03R\bfutureId\x12\"\n" +
+	"\rforex_pair_id\x18\x05 \x01(\x03R\vforexPairId\x12\x1b\n" +
+	"\toption_id\x18\x06 \x01(\x03R\boptionId\x12\x16\n" +
+	"\x06amount\x18\a \x01(\x03R\x06amount\x12\x19\n" +
+	"\bavg_cost\x18\b \x01(\x03R\aavgCost\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\t \x01(\x03R\taccountId\x12%\n" +
+	"\x0eaccount_number\x18\n" +
+	" \x01(\tR\raccountNumber\x12#\n" +
+	"\rpublic_amount\x18\v \x01(\x03R\fpublicAmount\x12\x16\n" +
+	"\x06ticker\x18\f \x01(\tR\x06ticker\x12#\n" +
+	"\rcurrent_price\x18\r \x01(\x03R\fcurrentPrice\x12\x16\n" +
+	"\x06profit\x18\x0e \x01(\x03R\x06profit\x12,\n" +
+	"\x12last_modified_unix\x18\x0f \x01(\x03R\x10lastModifiedUnix\x12\x1d\n" +
+	"\n" +
+	"asset_type\x18\x10 \x01(\tR\tassetType\"8\n" +
+	"\x13ListHoldingsRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\"D\n" +
+	"\x14ListHoldingsResponse\x12,\n" +
+	"\bholdings\x18\x01 \x03(\v2\x10.trading.HoldingR\bholdings\"\xf5\x01\n" +
+	"\x12SellHoldingRequest\x12\x1d\n" +
+	"\n" +
+	"holding_id\x18\x01 \x01(\x03R\tholdingId\x12%\n" +
+	"\x0eaccount_number\x18\x02 \x01(\tR\raccountNumber\x12\x1d\n" +
+	"\n" +
+	"order_type\x18\x03 \x01(\tR\torderType\x12\x1a\n" +
+	"\bquantity\x18\x04 \x01(\x03R\bquantity\x12\x1f\n" +
+	"\vlimit_price\x18\x05 \x01(\x03R\n" +
+	"limitPrice\x12\x1d\n" +
+	"\n" +
+	"stop_price\x18\x06 \x01(\x03R\tstopPrice\x12\x1e\n" +
+	"\vall_or_none\x18\a \x01(\bR\tallOrNone\"H\n" +
+	"\x13SellHoldingResponse\x12\x19\n" +
+	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"]\n" +
+	"\x17SetHoldingPublicRequest\x12\x1d\n" +
+	"\n" +
+	"holding_id\x18\x01 \x01(\x03R\tholdingId\x12#\n" +
+	"\rpublic_amount\x18\x02 \x01(\x03R\fpublicAmount\"F\n" +
+	"\x18SetHoldingPublicResponse\x12*\n" +
+	"\aholding\x18\x01 \x01(\v2\x10.trading.HoldingR\aholding\"[\n" +
+	"\x15ExerciseOptionRequest\x12\x1b\n" +
+	"\toption_id\x18\x01 \x01(\x03R\boptionId\x12%\n" +
+	"\x0eaccount_number\x18\x02 \x01(\tR\raccountNumber\"L\n" +
+	"\x16ExerciseOptionResponse\x12\x16\n" +
+	"\x06payout\x18\x01 \x01(\x03R\x06payout\x12\x1a\n" +
+	"\bquantity\x18\x02 \x01(\x03R\bquantity2\xec\n" +
+	"\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
@@ -2694,7 +3372,11 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\fApproveOrder\x12\x1c.trading.ApproveOrderRequest\x1a\x1d.trading.ApproveOrderResponse\x12K\n" +
 	"\fDeclineOrder\x12\x1c.trading.DeclineOrderRequest\x1a\x1d.trading.DeclineOrderResponse\x12H\n" +
 	"\vCancelOrder\x12\x1b.trading.CancelOrderRequest\x1a\x1c.trading.CancelOrderResponse\x12l\n" +
-	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
+	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponse\x12K\n" +
+	"\fListHoldings\x12\x1c.trading.ListHoldingsRequest\x1a\x1d.trading.ListHoldingsResponse\x12H\n" +
+	"\vSellHolding\x12\x1b.trading.SellHoldingRequest\x1a\x1c.trading.SellHoldingResponse\x12W\n" +
+	"\x10SetHoldingPublic\x12 .trading.SetHoldingPublicRequest\x1a!.trading.SetHoldingPublicResponse\x12Q\n" +
+	"\x0eExerciseOption\x12\x1e.trading.ExerciseOptionRequest\x1a\x1f.trading.ExerciseOptionResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
 	file_trading_trading_proto_rawDescOnce sync.Once
@@ -2708,7 +3390,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),                        // 0: trading.Exchange
 	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
@@ -2744,6 +3426,15 @@ var file_trading_trading_proto_goTypes = []any{
 	(*DeclineOrderResponse)(nil),            // 31: trading.DeclineOrderResponse
 	(*CancelOrderRequest)(nil),              // 32: trading.CancelOrderRequest
 	(*CancelOrderResponse)(nil),             // 33: trading.CancelOrderResponse
+	(*Holding)(nil),                         // 34: trading.Holding
+	(*ListHoldingsRequest)(nil),             // 35: trading.ListHoldingsRequest
+	(*ListHoldingsResponse)(nil),            // 36: trading.ListHoldingsResponse
+	(*SellHoldingRequest)(nil),              // 37: trading.SellHoldingRequest
+	(*SellHoldingResponse)(nil),             // 38: trading.SellHoldingResponse
+	(*SetHoldingPublicRequest)(nil),         // 39: trading.SetHoldingPublicRequest
+	(*SetHoldingPublicResponse)(nil),        // 40: trading.SetHoldingPublicResponse
+	(*ExerciseOptionRequest)(nil),           // 41: trading.ExerciseOptionRequest
+	(*ExerciseOptionResponse)(nil),          // 42: trading.ExerciseOptionResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0,  // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
@@ -2760,37 +3451,47 @@ var file_trading_trading_proto_depIdxs = []int32{
 	25, // 11: trading.ApproveOrderResponse.order:type_name -> trading.OrderDetail
 	25, // 12: trading.DeclineOrderResponse.order:type_name -> trading.OrderDetail
 	25, // 13: trading.CancelOrderResponse.order:type_name -> trading.OrderDetail
-	3,  // 14: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
-	6,  // 15: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	8,  // 16: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
-	10, // 17: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
-	14, // 18: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
-	16, // 19: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
-	19, // 20: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
-	23, // 21: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	26, // 22: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
-	28, // 23: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
-	30, // 24: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
-	32, // 25: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
-	1,  // 26: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
-	4,  // 27: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	7,  // 28: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	9,  // 29: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
-	12, // 30: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
-	15, // 31: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
-	18, // 32: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
-	22, // 33: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
-	24, // 34: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	27, // 35: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
-	29, // 36: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
-	31, // 37: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
-	33, // 38: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
-	2,  // 39: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	27, // [27:40] is the sub-list for method output_type
-	14, // [14:27] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	34, // 14: trading.ListHoldingsResponse.holdings:type_name -> trading.Holding
+	34, // 15: trading.SetHoldingPublicResponse.holding:type_name -> trading.Holding
+	3,  // 16: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
+	6,  // 17: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	8,  // 18: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
+	10, // 19: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
+	14, // 20: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
+	16, // 21: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
+	19, // 22: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
+	23, // 23: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	26, // 24: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
+	28, // 25: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
+	30, // 26: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
+	32, // 27: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
+	1,  // 28: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
+	35, // 29: trading.TradingService.ListHoldings:input_type -> trading.ListHoldingsRequest
+	37, // 30: trading.TradingService.SellHolding:input_type -> trading.SellHoldingRequest
+	39, // 31: trading.TradingService.SetHoldingPublic:input_type -> trading.SetHoldingPublicRequest
+	41, // 32: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
+	4,  // 33: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7,  // 34: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9,  // 35: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	12, // 36: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	15, // 37: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	18, // 38: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
+	22, // 39: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
+	24, // 40: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	27, // 41: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
+	29, // 42: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
+	31, // 43: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
+	33, // 44: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
+	2,  // 45: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	36, // 46: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
+	38, // 47: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
+	40, // 48: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
+	42, // 49: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
+	33, // [33:50] is the sub-list for method output_type
+	16, // [16:33] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_trading_trading_proto_init() }
@@ -2804,7 +3505,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -32,6 +32,10 @@ const (
 	TradingService_DeclineOrder_FullMethodName            = "/trading.TradingService/DeclineOrder"
 	TradingService_CancelOrder_FullMethodName             = "/trading.TradingService/CancelOrder"
 	TradingService_SetExchangeOpenOverride_FullMethodName = "/trading.TradingService/SetExchangeOpenOverride"
+	TradingService_ListHoldings_FullMethodName            = "/trading.TradingService/ListHoldings"
+	TradingService_SellHolding_FullMethodName             = "/trading.TradingService/SellHolding"
+	TradingService_SetHoldingPublic_FullMethodName        = "/trading.TradingService/SetHoldingPublic"
+	TradingService_ExerciseOption_FullMethodName          = "/trading.TradingService/ExerciseOption"
 )
 
 // TradingServiceClient is the client API for TradingService service.
@@ -51,6 +55,10 @@ type TradingServiceClient interface {
 	DeclineOrder(ctx context.Context, in *DeclineOrderRequest, opts ...grpc.CallOption) (*DeclineOrderResponse, error)
 	CancelOrder(ctx context.Context, in *CancelOrderRequest, opts ...grpc.CallOption) (*CancelOrderResponse, error)
 	SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error)
+	ListHoldings(ctx context.Context, in *ListHoldingsRequest, opts ...grpc.CallOption) (*ListHoldingsResponse, error)
+	SellHolding(ctx context.Context, in *SellHoldingRequest, opts ...grpc.CallOption) (*SellHoldingResponse, error)
+	SetHoldingPublic(ctx context.Context, in *SetHoldingPublicRequest, opts ...grpc.CallOption) (*SetHoldingPublicResponse, error)
+	ExerciseOption(ctx context.Context, in *ExerciseOptionRequest, opts ...grpc.CallOption) (*ExerciseOptionResponse, error)
 }
 
 type tradingServiceClient struct {
@@ -191,6 +199,46 @@ func (c *tradingServiceClient) SetExchangeOpenOverride(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *tradingServiceClient) ListHoldings(ctx context.Context, in *ListHoldingsRequest, opts ...grpc.CallOption) (*ListHoldingsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListHoldingsResponse)
+	err := c.cc.Invoke(ctx, TradingService_ListHoldings_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) SellHolding(ctx context.Context, in *SellHoldingRequest, opts ...grpc.CallOption) (*SellHoldingResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SellHoldingResponse)
+	err := c.cc.Invoke(ctx, TradingService_SellHolding_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) SetHoldingPublic(ctx context.Context, in *SetHoldingPublicRequest, opts ...grpc.CallOption) (*SetHoldingPublicResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetHoldingPublicResponse)
+	err := c.cc.Invoke(ctx, TradingService_SetHoldingPublic_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) ExerciseOption(ctx context.Context, in *ExerciseOptionRequest, opts ...grpc.CallOption) (*ExerciseOptionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExerciseOptionResponse)
+	err := c.cc.Invoke(ctx, TradingService_ExerciseOption_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TradingServiceServer is the server API for TradingService service.
 // All implementations must embed UnimplementedTradingServiceServer
 // for forward compatibility.
@@ -208,6 +256,10 @@ type TradingServiceServer interface {
 	DeclineOrder(context.Context, *DeclineOrderRequest) (*DeclineOrderResponse, error)
 	CancelOrder(context.Context, *CancelOrderRequest) (*CancelOrderResponse, error)
 	SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error)
+	ListHoldings(context.Context, *ListHoldingsRequest) (*ListHoldingsResponse, error)
+	SellHolding(context.Context, *SellHoldingRequest) (*SellHoldingResponse, error)
+	SetHoldingPublic(context.Context, *SetHoldingPublicRequest) (*SetHoldingPublicResponse, error)
+	ExerciseOption(context.Context, *ExerciseOptionRequest) (*ExerciseOptionResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
 
@@ -256,6 +308,18 @@ func (UnimplementedTradingServiceServer) CancelOrder(context.Context, *CancelOrd
 }
 func (UnimplementedTradingServiceServer) SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetExchangeOpenOverride not implemented")
+}
+func (UnimplementedTradingServiceServer) ListHoldings(context.Context, *ListHoldingsRequest) (*ListHoldingsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListHoldings not implemented")
+}
+func (UnimplementedTradingServiceServer) SellHolding(context.Context, *SellHoldingRequest) (*SellHoldingResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SellHolding not implemented")
+}
+func (UnimplementedTradingServiceServer) SetHoldingPublic(context.Context, *SetHoldingPublicRequest) (*SetHoldingPublicResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetHoldingPublic not implemented")
+}
+func (UnimplementedTradingServiceServer) ExerciseOption(context.Context, *ExerciseOptionRequest) (*ExerciseOptionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExerciseOption not implemented")
 }
 func (UnimplementedTradingServiceServer) mustEmbedUnimplementedTradingServiceServer() {}
 func (UnimplementedTradingServiceServer) testEmbeddedByValue()                        {}
@@ -512,6 +576,78 @@ func _TradingService_SetExchangeOpenOverride_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_ListHoldings_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListHoldingsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ListHoldings(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ListHoldings_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ListHoldings(ctx, req.(*ListHoldingsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_SellHolding_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SellHoldingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).SellHolding(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_SellHolding_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).SellHolding(ctx, req.(*SellHoldingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_SetHoldingPublic_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetHoldingPublicRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).SetHoldingPublic(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_SetHoldingPublic_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).SetHoldingPublic(ctx, req.(*SetHoldingPublicRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_ExerciseOption_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExerciseOptionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ExerciseOption(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ExerciseOption_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ExerciseOption(ctx, req.(*ExerciseOptionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TradingService_ServiceDesc is the grpc.ServiceDesc for TradingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -570,6 +706,22 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetExchangeOpenOverride",
 			Handler:    _TradingService_SetExchangeOpenOverride_Handler,
+		},
+		{
+			MethodName: "ListHoldings",
+			Handler:    _TradingService_ListHoldings_Handler,
+		},
+		{
+			MethodName: "SellHolding",
+			Handler:    _TradingService_SellHolding_Handler,
+		},
+		{
+			MethodName: "SetHoldingPublic",
+			Handler:    _TradingService_SetHoldingPublic_Handler,
+		},
+		{
+			MethodName: "ExerciseOption",
+			Handler:    _TradingService_ExerciseOption_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -175,6 +175,18 @@ func SetupApi(router *gin.Engine, server *Server) {
 		stockOptions.GET("/stocks/:id/options", server.ListStockOptions)
 	}
 
+	// Portfolio portal (spec p.62 / #207). Listing + sell are open to both
+	// clients and employees (everyone has a portfolio); public_amount is
+	// stock-only and the trading RPC enforces that. ExerciseOption is
+	// actuary-only at the gateway and re-checks server-side.
+	portfolio := api.Group("/portfolio", auth, secured("role:client|employee"))
+	{
+		portfolio.GET("", server.ListPortfolio)
+		portfolio.POST("/sell", server.SellHolding)
+		portfolio.PATCH("/:id/public", server.SetHoldingPublic)
+	}
+	api.POST("/options/:id/exercise", auth, secured("role:employee"), server.ExerciseOption)
+
 	// Supervisor-only toggle used to exercise the trading flow outside real
 	// market hours (see spec p.40 and issue #194). Admin bypass still applies
 	// through `secured("supervisor")`.

--- a/internal/gateway/portfolio.go
+++ b/internal/gateway/portfolio.go
@@ -1,0 +1,185 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/metadata"
+)
+
+// holdingToJSON renders the portfolio row (spec p.62). asset_type tags the
+// underlying so the UI can pick the right icon / route without reading the
+// FK fields; profit is denominated in the booking account's currency.
+func holdingToJSON(h *tradingpb.Holding) gin.H {
+	return gin.H{
+		"id":                 h.Id,
+		"placer_id":          h.PlacerId,
+		"asset_type":         h.AssetType,
+		"stock_id":           h.StockId,
+		"future_id":          h.FutureId,
+		"forex_pair_id":      h.ForexPairId,
+		"option_id":          h.OptionId,
+		"ticker":             h.Ticker,
+		"amount":             h.Amount,
+		"avg_cost":           h.AvgCost,
+		"current_price":      h.CurrentPrice,
+		"profit":             h.Profit,
+		"account_id":         h.AccountId,
+		"account_number":     h.AccountNumber,
+		"public_amount":      h.PublicAmount,
+		"last_modified_unix": h.LastModifiedUnix,
+	}
+}
+
+// ListPortfolio backs `GET /api/portfolio` (spec p.62). Open to both clients
+// and employees; the trading server scopes results by the caller's identity
+// — no caller_email needed since user-email metadata already rides on the
+// gRPC call.
+func (s *Server) ListPortfolio(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.ListHoldings(ctx, &tradingpb.ListHoldingsRequest{
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(resp.Holdings))
+	for _, h := range resp.Holdings {
+		out = append(out, holdingToJSON(h))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+type sellHoldingBody struct {
+	HoldingID     int64  `json:"holding_id" binding:"required"`
+	AccountNumber string `json:"account_number" binding:"required"`
+	OrderType     string `json:"order_type" binding:"required"`
+	Quantity      int64  `json:"quantity" binding:"required"`
+	LimitPrice    int64  `json:"limit_price"`
+	StopPrice     int64  `json:"stop_price"`
+	AllOrNone     bool   `json:"all_or_none"`
+}
+
+// SellHolding backs `POST /api/portfolio/sell`. Forwards to the trading
+// service's SellHolding wrapper, which constructs and dispatches the
+// underlying CreateOrder. user-email metadata is attached so the trading
+// server can authorize the holding owner.
+func (s *Server) SellHolding(c *gin.Context) {
+	var body sellHoldingBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.SellHolding(ctx, &tradingpb.SellHoldingRequest{
+		HoldingId:     body.HoldingID,
+		AccountNumber: body.AccountNumber,
+		OrderType:     body.OrderType,
+		Quantity:      body.Quantity,
+		LimitPrice:    body.LimitPrice,
+		StopPrice:     body.StopPrice,
+		AllOrNone:     body.AllOrNone,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{
+		"order_id": resp.OrderId,
+		"status":   resp.Status,
+	})
+}
+
+type setHoldingPublicBody struct {
+	PublicAmount int64 `json:"public_amount"`
+}
+
+// SetHoldingPublic backs `PATCH /api/portfolio/:id/public`. Owner-only; the
+// trading server rejects non-stock holdings with FailedPrecondition (the
+// schema CHECK pins public_amount=0 there) and out-of-range values with
+// InvalidArgument.
+func (s *Server) SetHoldingPublic(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "holding id must be a positive integer"})
+		return
+	}
+	var body setHoldingPublicBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.SetHoldingPublic(ctx, &tradingpb.SetHoldingPublicRequest{
+		HoldingId:    id,
+		PublicAmount: body.PublicAmount,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, holdingToJSON(resp.Holding))
+}
+
+type exerciseOptionBody struct {
+	AccountNumber string `json:"account_number" binding:"required"`
+}
+
+// ExerciseOption backs `POST /api/options/:id/exercise`. Actuary-only
+// (employees only at the gateway, the trading server re-checks). The path
+// id is the option contract id, account_number is the credit destination —
+// must belong to the caller (verified by AuthorizeAccountAccess inside the
+// trading RPC).
+func (s *Server) ExerciseOption(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "option id must be a positive integer"})
+		return
+	}
+	var body exerciseOptionBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.ExerciseOption(ctx, &tradingpb.ExerciseOptionRequest{
+		OptionId:      id,
+		AccountNumber: body.AccountNumber,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"payout":   resp.Payout,
+		"quantity": resp.Quantity,
+	})
+}

--- a/internal/trading/executor.go
+++ b/internal/trading/executor.go
@@ -269,6 +269,31 @@ func (s *Server) executeFill(o *Order, now time.Time) (time.Time, error) {
 			return err
 		}
 
+		// Holding bookkeeping (#207): buy-fills upsert into the placer's
+		// position with a quantity-weighted avg_cost; sell-fills deduct and
+		// fail (FailedPrecondition → tick-level backoff) when the seller is
+		// short. The check happens after applySettlement so a refused sell
+		// rolls the money movement back too — the deferred error path the
+		// gorm Transaction wrapper already provides.
+		assetCol, assetID, err := holdingAssetKey(tx, locked)
+		if err != nil {
+			return err
+		}
+		if locked.Direction == DirectionBuy {
+			accountID, err := holdingAccountID(tx, locked.AccountNumber)
+			if err != nil {
+				return err
+			}
+			perContractAccCost := settle.accAmount / chunk
+			if err := upsertHoldingOnBuy(tx, locked.PlacerID, accountID, assetCol, assetID, chunk, perContractAccCost, now); err != nil {
+				return err
+			}
+		} else {
+			if err := deductHoldingOnSell(tx, locked.PlacerID, assetCol, assetID, chunk, now); err != nil {
+				return err
+			}
+		}
+
 		fill := OrderFill{
 			OrderID:      locked.ID,
 			Portions:     chunk,

--- a/internal/trading/holdings.go
+++ b/internal/trading/holdings.go
@@ -1,0 +1,214 @@
+package trading
+
+import (
+	"errors"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// holdingAssetKey resolves an order's asset reference to the single FK that
+// belongs on a holding row. Listings are resolved through to whichever of
+// stock_id / future_id is non-null on the listing — the holding tracks the
+// underlying security, not the listing pairing. Options and forex map
+// directly. Returns a column name and value usable in WHERE / INSERT clauses.
+func holdingAssetKey(tx *gorm.DB, o *Order) (string, int64, error) {
+	switch {
+	case o.OptionID != nil:
+		return "option_id", *o.OptionID, nil
+	case o.ForexPairID != nil:
+		return "forex_pair_id", *o.ForexPairID, nil
+	case o.ListingID != nil:
+		var l Listing
+		if err := tx.Select("stock_id, future_id").First(&l, *o.ListingID).Error; err != nil {
+			return "", 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		if l.StockID != nil {
+			return "stock_id", *l.StockID, nil
+		}
+		if l.FutureID != nil {
+			return "future_id", *l.FutureID, nil
+		}
+		return "", 0, status.Error(codes.Internal, "listing has no underlying")
+	}
+	return "", 0, status.Error(codes.Internal, "order has no asset reference")
+}
+
+// upsertHoldingOnBuy applies a buy-fill to the placer's position. New rows
+// land with avg_cost = unitCostAccountCcy; existing rows roll the cost into
+// a quantity-weighted average so the tax basis stays accurate across many
+// fills at different prices. AccountID is rewritten to the buying account
+// each time — sell proceeds always follow the most recent buy.
+//
+// unitCostAccountCcy is the per-unit price denominated in the booking
+// account's currency (already FX-converted by the caller); chunk is the
+// number of units this fill adds.
+func upsertHoldingOnBuy(tx *gorm.DB, placerID int64, accountID int64, assetCol string, assetID int64, chunk, unitCostAccountCcy int64, now time.Time) error {
+	if chunk <= 0 {
+		return nil
+	}
+
+	var h Holding
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("placer_id = ? AND "+assetCol+" = ?", placerID, assetID).
+		First(&h).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		row := map[string]any{
+			"placer_id":     placerID,
+			assetCol:        assetID,
+			"account_id":    accountID,
+			"amount":        chunk,
+			"avg_cost":      unitCostAccountCcy,
+			"public_amount": 0,
+			"last_modified": now,
+		}
+		if err := tx.Table("holdings").Create(row).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+
+	newAmount := h.Amount + chunk
+	// Weighted average: stays at unitCost when the previous holding was empty
+	// (avg_cost on a zero-amount holding is meaningless), otherwise blends.
+	var newAvg int64
+	if h.Amount <= 0 {
+		newAvg = unitCostAccountCcy
+	} else {
+		newAvg = (h.AvgCost*h.Amount + unitCostAccountCcy*chunk) / newAmount
+	}
+
+	updates := map[string]any{
+		"amount":        newAmount,
+		"avg_cost":      newAvg,
+		"account_id":    accountID,
+		"last_modified": now,
+	}
+	if err := tx.Model(&Holding{}).Where("id = ?", h.ID).Updates(updates).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	return nil
+}
+
+// deductHoldingOnSell pulls `chunk` units out of the placer's holding for the
+// asset. Locks the row FOR UPDATE so concurrent fills on the same holding
+// serialize. Returns FailedPrecondition when the position is missing or
+// insufficient — the executor backs off and retries on the next tick, which
+// is the same contract market/limit fills already use for failed settlements.
+//
+// public_amount tracks the OTC-discoverable share count and must never exceed
+// amount; if a sell drops amount below the current public_amount, the public
+// counter is clamped down so the invariant holds.
+func deductHoldingOnSell(tx *gorm.DB, placerID int64, assetCol string, assetID int64, chunk int64, now time.Time) error {
+	if chunk <= 0 {
+		return nil
+	}
+
+	var h Holding
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("placer_id = ? AND "+assetCol+" = ?", placerID, assetID).
+		First(&h).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return status.Error(codes.FailedPrecondition, "no holding for sell-side fill")
+	}
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	if h.Amount < chunk {
+		return status.Error(codes.FailedPrecondition, "insufficient holding for sell-side fill")
+	}
+
+	newAmount := h.Amount - chunk
+	updates := map[string]any{
+		"amount":        newAmount,
+		"last_modified": now,
+	}
+	if h.PublicAmount > newAmount {
+		updates["public_amount"] = newAmount
+	}
+	if err := tx.Model(&Holding{}).Where("id = ?", h.ID).Updates(updates).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	return nil
+}
+
+// findOrCreatePlacer returns the order_placers.id for the given identity,
+// creating the row on first use. Holdings (#207) are keyed by placer_id, so
+// the row has to be stable across orders for the same person — the partial
+// unique indexes on (client_id) / (employee_id) make that safe.
+//
+// Exactly one of clientID / employeeID must be non-nil; the schema CHECK
+// constraint enforces this on the row, the precondition lets us short-circuit
+// before hitting the DB.
+func findOrCreatePlacer(tx *gorm.DB, clientID, employeeID *int64) (int64, error) {
+	if (clientID == nil) == (employeeID == nil) {
+		return 0, status.Error(codes.Internal, "placer must reference exactly one of client / employee")
+	}
+
+	var existing int64
+	q := tx.Table("order_placers").Select("id")
+	if clientID != nil {
+		q = q.Where("client_id = ?", *clientID)
+	} else {
+		q = q.Where("employee_id = ?", *employeeID)
+	}
+	err := q.Take(&existing).Error
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	placer := OrderPlacer{ClientID: clientID, EmployeeID: employeeID}
+	if err := tx.Create(&placer).Error; err != nil {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return placer.ID, nil
+}
+
+// resolvePlacerForCaller returns the placer row for the caller, creating it
+// if needed. Used by RPCs that have to look up holdings (#207) for callers
+// who haven't placed any orders yet — without this, ListHoldings on a fresh
+// client would 404 even though "no orders" is a perfectly valid state.
+func resolvePlacerForCaller(tx *gorm.DB, caller *bank.CallerIdentity) (int64, error) {
+	if caller.IsClient {
+		id := caller.ClientID
+		return findOrCreatePlacer(tx, &id, nil)
+	}
+	if caller.IsEmployee {
+		var empID int64
+		err := tx.Table("employees").Select("id").Where("email = ?", caller.Email).Take(&empID).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return 0, status.Error(codes.NotFound, "employee not found")
+			}
+			return 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		return findOrCreatePlacer(tx, nil, &empID)
+	}
+	return 0, status.Error(codes.PermissionDenied, "caller is neither client nor employee")
+}
+
+// holdingAccountID looks up the placer's accounts.id for an account number.
+// Used by the executor on buy-fills to record the booking account on the
+// holding row (orders carry the number, holdings keep the id for tax joins).
+func holdingAccountID(tx *gorm.DB, accountNumber string) (int64, error) {
+	var id int64
+	err := tx.Table("accounts").Select("id").Where("number = ?", accountNumber).Take(&id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, status.Error(codes.NotFound, "account not found")
+		}
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return id, nil
+}

--- a/internal/trading/holdings_test.go
+++ b/internal/trading/holdings_test.go
@@ -1,0 +1,135 @@
+package trading
+
+import (
+	"testing"
+)
+
+func TestHoldingAssetType(t *testing.T) {
+	stock := int64(1)
+	future := int64(2)
+	forex := int64(3)
+	option := int64(4)
+	cases := []struct {
+		name string
+		h    *Holding
+		want string
+	}{
+		{"stock", &Holding{StockID: &stock}, "stock"},
+		{"future", &Holding{FutureID: &future}, "future"},
+		{"forex", &Holding{ForexPairID: &forex}, "forex"},
+		{"option", &Holding{OptionID: &option}, "option"},
+		{"empty", &Holding{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := holdingAssetType(c.h); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestWeightedAvgCostFormula pins down the buy-fill weighting math used by
+// upsertHoldingOnBuy. Two fills at different prices should land at the
+// quantity-weighted mean — tax basis stays accurate across many partial
+// fills, so a future spec change to the formula breaks this test loudly.
+func TestWeightedAvgCostFormula(t *testing.T) {
+	cases := []struct {
+		name        string
+		oldAmt      int64
+		oldAvg      int64
+		chunk       int64
+		newPrice    int64
+		expectedAvg int64
+	}{
+		{"first fill seeds avg", 0, 0, 10, 12500, 12500},
+		{"same price keeps avg", 5, 12500, 5, 12500, 12500},
+		{"higher price pulls up", 10, 10000, 10, 14000, 12000},
+		{"smaller fill weights less", 9, 10000, 1, 20000, 11000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got int64
+			if c.oldAmt <= 0 {
+				got = c.newPrice
+			} else {
+				got = (c.oldAvg*c.oldAmt + c.newPrice*c.chunk) / (c.oldAmt + c.chunk)
+			}
+			if got != c.expectedAvg {
+				t.Errorf("got %d, want %d", got, c.expectedAvg)
+			}
+		})
+	}
+}
+
+// TestExercisePayoutFormula pins the spec p.62 payout math used by
+// ExerciseOption — call: spot − strike, put: strike − spot, both then have
+// the premium per contract subtracted before being scaled by held quantity.
+// The test stays at formula-level because the RPC drives a transactional DB
+// path; the math itself is the part that has to track the spec exactly.
+func TestExercisePayoutFormula(t *testing.T) {
+	cases := []struct {
+		name       string
+		side       OptionType
+		spot       int64
+		strike     int64
+		premium    int64
+		quantity   int64
+		wantInstr  int64 // payout in instrument currency, before FX
+		shouldFire bool  // true iff intrinsic > 0 (passes ITM gate)
+	}{
+		{"call ITM", OptionCall, 15000, 12000, 500, 2, (15000 - 12000 - 500) * 2, true},
+		{"call ATM rejects", OptionCall, 12000, 12000, 500, 1, 0, false},
+		{"call OTM rejects", OptionCall, 11000, 12000, 500, 1, 0, false},
+		{"put ITM", OptionPut, 9000, 12000, 500, 3, (12000 - 9000 - 500) * 3, true},
+		{"put OTM rejects", OptionPut, 13000, 12000, 500, 1, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var intrinsic int64
+			switch c.side {
+			case OptionCall:
+				intrinsic = c.spot - c.strike
+			case OptionPut:
+				intrinsic = c.strike - c.spot
+			}
+			if (intrinsic > 0) != c.shouldFire {
+				t.Fatalf("ITM gate mismatch: intrinsic=%d, shouldFire=%v", intrinsic, c.shouldFire)
+			}
+			if !c.shouldFire {
+				return
+			}
+			got := (intrinsic - c.premium) * c.quantity
+			if got != c.wantInstr {
+				t.Errorf("got %d, want %d", got, c.wantInstr)
+			}
+		})
+	}
+}
+
+// TestPublicAmountValidation pins the 0 ≤ public_amount ≤ amount invariant
+// the SetHoldingPublic RPC enforces. Out-of-range inputs surface as
+// InvalidArgument so the portal can render an inline error; non-stock holdings
+// hit a separate FailedPrecondition path the RPC checks earlier.
+func TestPublicAmountValidation(t *testing.T) {
+	cases := []struct {
+		name   string
+		amount int64
+		public int64
+		wantOK bool
+	}{
+		{"zero is fine", 100, 0, true},
+		{"equal to amount is fine", 100, 100, true},
+		{"under amount is fine", 100, 50, true},
+		{"over amount rejected", 100, 101, false},
+		{"negative rejected", 100, -1, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ok := c.public >= 0 && c.public <= c.amount
+			if ok != c.wantOK {
+				t.Errorf("got %v, want %v", ok, c.wantOK)
+			}
+		})
+	}
+}

--- a/internal/trading/models.go
+++ b/internal/trading/models.go
@@ -185,3 +185,32 @@ type OrderFill struct {
 }
 
 func (OrderFill) TableName() string { return "order_fills" }
+
+// Holding is the per-placer asset position written by the execution engine
+// (#207). Polymorphic across the four asset kinds: exactly one of StockID,
+// FutureID, ForexPairID, OptionID is set on every row (DB CHECK).
+//
+// AvgCost is denominated in the booking account's currency, which keeps the
+// tax-tracking story self-contained: profit on a sell is simply
+// (current_price_in_account_ccy - avg_cost) * amount, no per-row FX history
+// required. AccountID is the destination for sell proceeds and is updated to
+// the most-recent buy's account on each upsert.
+//
+// PublicAmount applies to stock holdings only and seeds the OTC counter (the
+// actual OTC flow lives in the fourth celina); a CHECK constraint pins it to
+// 0 for non-stock holdings.
+type Holding struct {
+	ID           int64     `gorm:"column:id;primaryKey"`
+	PlacerID     int64     `gorm:"column:placer_id;not null"`
+	StockID      *int64    `gorm:"column:stock_id"`
+	FutureID     *int64    `gorm:"column:future_id"`
+	ForexPairID  *int64    `gorm:"column:forex_pair_id"`
+	OptionID     *int64    `gorm:"column:option_id"`
+	AccountID    int64     `gorm:"column:account_id;not null"`
+	Amount       int64     `gorm:"column:amount;not null;default:0"`
+	AvgCost      int64     `gorm:"column:avg_cost;not null;default:0"`
+	PublicAmount int64     `gorm:"column:public_amount;not null;default:0"`
+	LastModified time.Time `gorm:"column:last_modified;not null;autoUpdateTime"`
+}
+
+func (Holding) TableName() string { return "holdings" }

--- a/internal/trading/portfolio.go
+++ b/internal/trading/portfolio.go
@@ -1,0 +1,544 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// holdingAssetType maps the holding's polymorphic FK to the short type tag
+// the portal renders ("stock", "future", "forex", "option"). Exactly one of
+// the FKs is set on every row (DB CHECK), so the order of the cases doesn't
+// matter — at most one matches.
+func holdingAssetType(h *Holding) string {
+	switch {
+	case h.StockID != nil:
+		return "stock"
+	case h.FutureID != nil:
+		return "future"
+	case h.ForexPairID != nil:
+		return "forex"
+	case h.OptionID != nil:
+		return "option"
+	}
+	return ""
+}
+
+// holdingTickerAndPrice resolves the asset's display ticker and current quote
+// in the instrument's native currency. Listings inherit ticker from their
+// underlying stock/future row; options carry one directly; forex pairs use
+// the BASE/QUOTE ticker. The current price uses the same conventions as
+// resolveInstrument (listing.price for stocks/futures, option.premium for
+// options, exchange_rate*100 for forex) so portfolio P/L tracks the same
+// quote the order placement page shows.
+func (s *Server) holdingTickerAndPrice(tx *gorm.DB, h *Holding) (string, int64, string, error) {
+	switch {
+	case h.StockID != nil:
+		var st Stock
+		if err := tx.Select("ticker").First(&st, *h.StockID).Error; err != nil {
+			return "", 0, "", err
+		}
+		var l Listing
+		if err := tx.Where("stock_id = ?", *h.StockID).First(&l).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return st.Ticker, 0, "", nil
+			}
+			return "", 0, "", err
+		}
+		var ex Exchange
+		if err := tx.Select("currency").First(&ex, l.ExchangeID).Error; err != nil {
+			return "", 0, "", err
+		}
+		return st.Ticker, l.Price, ex.Currency, nil
+	case h.FutureID != nil:
+		var ft Future
+		if err := tx.Select("ticker").First(&ft, *h.FutureID).Error; err != nil {
+			return "", 0, "", err
+		}
+		var l Listing
+		if err := tx.Where("future_id = ?", *h.FutureID).First(&l).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ft.Ticker, 0, "", nil
+			}
+			return "", 0, "", err
+		}
+		var ex Exchange
+		if err := tx.Select("currency").First(&ex, l.ExchangeID).Error; err != nil {
+			return "", 0, "", err
+		}
+		return ft.Ticker, l.Price, ex.Currency, nil
+	case h.OptionID != nil:
+		var opt Option
+		if err := tx.Select("ticker, stock_id, premium").First(&opt, *h.OptionID).Error; err != nil {
+			return "", 0, "", err
+		}
+		var l Listing
+		if err := tx.Where("stock_id = ?", opt.StockID).First(&l).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return opt.Ticker, opt.Premium, "", nil
+			}
+			return "", 0, "", err
+		}
+		var ex Exchange
+		if err := tx.Select("currency").First(&ex, l.ExchangeID).Error; err != nil {
+			return "", 0, "", err
+		}
+		return opt.Ticker, opt.Premium, ex.Currency, nil
+	case h.ForexPairID != nil:
+		var fx ForexPair
+		if err := tx.First(&fx, *h.ForexPairID).Error; err != nil {
+			return "", 0, "", err
+		}
+		return fx.Ticker, int64(fx.ExchangeRate * 100), fx.QuoteCurrency, nil
+	}
+	return "", 0, "", status.Error(codes.Internal, "holding has no asset reference")
+}
+
+// convertToAccountCcy converts an amount in `from` to the account's currency
+// via the bank's RSD-anchored rate table. Same-currency calls short-circuit
+// and never hit the DB. Used for portfolio profit display so the ledger lines
+// up with what would actually settle on a sell.
+func (s *Server) convertToAccountCcy(amount int64, from, accCurrency string) (int64, error) {
+	if from == "" || from == accCurrency {
+		return amount, nil
+	}
+	rateAcc, err := s.bank.GetExchangeRateToRSD(accCurrency)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	rateFrom, err := s.bank.GetExchangeRateToRSD(from)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return int64(math.Round(float64(amount) * rateFrom / rateAcc)), nil
+}
+
+// holdingToProto fills in the display-only fields (ticker, current_price,
+// profit, asset_type) on top of the stored row. Profit is rendered in the
+// holding's account currency: avg_cost is already there, current_price gets
+// FX-converted before the subtraction. Holdings whose asset has no listing
+// surface a 0 price rather than failing — the portal still wants to show the
+// position so the user can sell it (or wait for a listing).
+func (s *Server) holdingToProto(tx *gorm.DB, h *Holding) (*tradingpb.Holding, error) {
+	ticker, price, instrCcy, err := s.holdingTickerAndPrice(tx, h)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	var accNumber, accCcy string
+	{
+		var row struct {
+			Number   string
+			Currency string
+		}
+		if err := tx.Table("accounts").Select("number, currency").Where("id = ?", h.AccountID).Take(&row).Error; err != nil {
+			return nil, status.Errorf(codes.Internal, "%v", err)
+		}
+		accNumber = row.Number
+		accCcy = row.Currency
+	}
+	priceInAcc, err := s.convertToAccountCcy(price, instrCcy, accCcy)
+	if err != nil {
+		return nil, err
+	}
+	profit := (priceInAcc - h.AvgCost) * h.Amount
+
+	out := &tradingpb.Holding{
+		Id:               h.ID,
+		PlacerId:         h.PlacerID,
+		Amount:           h.Amount,
+		AvgCost:          h.AvgCost,
+		AccountId:        h.AccountID,
+		AccountNumber:    accNumber,
+		PublicAmount:     h.PublicAmount,
+		Ticker:           ticker,
+		CurrentPrice:     price,
+		Profit:           profit,
+		LastModifiedUnix: h.LastModified.Unix(),
+		AssetType:        holdingAssetType(h),
+	}
+	if h.StockID != nil {
+		out.StockId = *h.StockID
+	}
+	if h.FutureID != nil {
+		out.FutureId = *h.FutureID
+	}
+	if h.ForexPairID != nil {
+		out.ForexPairId = *h.ForexPairID
+	}
+	if h.OptionID != nil {
+		out.OptionId = *h.OptionID
+	}
+	return out, nil
+}
+
+// ListHoldings returns every holding owned by the caller — clients see their
+// own, employees see whatever they've placed orders for. A caller with no
+// placer row yet (no orders ever placed) gets an empty list rather than a
+// 404; the placer row is created lazily so subsequent holdings calls dedupe.
+func (s *Server) ListHoldings(ctx context.Context, _ *tradingpb.ListHoldingsRequest) (*tradingpb.ListHoldingsResponse, error) {
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*tradingpb.Holding
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		placerID, err := resolvePlacerForCaller(tx, caller)
+		if err != nil {
+			return err
+		}
+		var holdings []Holding
+		if err := tx.Where("placer_id = ?", placerID).Order("last_modified DESC").Find(&holdings).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		out = make([]*tradingpb.Holding, 0, len(holdings))
+		for i := range holdings {
+			p, err := s.holdingToProto(tx, &holdings[i])
+			if err != nil {
+				return err
+			}
+			out = append(out, p)
+		}
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.ListHoldingsResponse{Holdings: out}, nil
+}
+
+// SellHolding is the spec's `POST /api/portfolio/sell` thin wrapper. Resolves
+// the holding to its underlying asset, verifies ownership, and forwards a
+// CreateOrder with direction=sell so the same approval / execution / margin
+// pipeline applies. Quantity is clamped at validation time so a user can't
+// place a sell larger than what they hold; the executor's per-fill check
+// stays as the final safety net.
+func (s *Server) SellHolding(ctx context.Context, req *tradingpb.SellHoldingRequest) (*tradingpb.SellHoldingResponse, error) {
+	if req.HoldingId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "holding_id required")
+	}
+	if req.Quantity <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "quantity must be positive")
+	}
+	if strings.TrimSpace(req.AccountNumber) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_number required")
+	}
+	if req.OrderType == "" {
+		return nil, status.Error(codes.InvalidArgument, "order_type required")
+	}
+
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var h Holding
+	if err := s.db.First(&h, req.HoldingId).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "holding not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if err := s.authorizeHoldingOwner(s.db, &h, caller); err != nil {
+		return nil, err
+	}
+	if req.Quantity > h.Amount {
+		return nil, status.Error(codes.FailedPrecondition, "quantity exceeds held amount")
+	}
+
+	createReq := &tradingpb.CreateOrderRequest{
+		AccountNumber: req.AccountNumber,
+		OrderType:     req.OrderType,
+		Direction:     "sell",
+		Quantity:      req.Quantity,
+		LimitPrice:    req.LimitPrice,
+		StopPrice:     req.StopPrice,
+		AllOrNone:     req.AllOrNone,
+	}
+	switch {
+	case h.StockID != nil, h.FutureID != nil:
+		listingID, err := listingIDForHolding(s.db, &h)
+		if err != nil {
+			return nil, err
+		}
+		createReq.ListingId = listingID
+	case h.OptionID != nil:
+		createReq.OptionId = *h.OptionID
+	case h.ForexPairID != nil:
+		createReq.ForexPairId = *h.ForexPairID
+	}
+
+	resp, err := s.CreateOrder(ctx, createReq)
+	if err != nil {
+		return nil, err
+	}
+	return &tradingpb.SellHoldingResponse{OrderId: resp.OrderId, Status: resp.Status}, nil
+}
+
+// listingIDForHolding finds the listing row for a stock or future holding so
+// the wrapped CreateOrder call can populate listing_id (orders never reference
+// stocks/futures directly — that's the listing's job). Returns FailedPrecondition
+// when the underlying has no listing on any exchange.
+func listingIDForHolding(db *gorm.DB, h *Holding) (int64, error) {
+	var col string
+	var val int64
+	switch {
+	case h.StockID != nil:
+		col, val = "stock_id", *h.StockID
+	case h.FutureID != nil:
+		col, val = "future_id", *h.FutureID
+	default:
+		return 0, status.Error(codes.Internal, "listingIDForHolding called on non-listing asset")
+	}
+	var id int64
+	err := db.Table("listings").Select("id").Where(col+" = ?", val).Take(&id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, status.Error(codes.FailedPrecondition, "no listing for this asset")
+		}
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return id, nil
+}
+
+// authorizeHoldingOwner enforces "the caller owns this holding". Holdings are
+// scoped to the placer row, which is keyed per identity (client or employee)
+// — so the check reduces to comparing the caller's identity against the
+// placer the holding points at.
+func (s *Server) authorizeHoldingOwner(db *gorm.DB, h *Holding, caller *bank.CallerIdentity) error {
+	var placer OrderPlacer
+	if err := db.First(&placer, h.PlacerID).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	if caller.IsClient && placer.ClientID != nil && *placer.ClientID == caller.ClientID {
+		return nil
+	}
+	if caller.IsEmployee && placer.EmployeeID != nil {
+		var empID int64
+		if err := db.Table("employees").Select("id").Where("email = ?", caller.Email).Take(&empID).Error; err == nil && empID == *placer.EmployeeID {
+			return nil
+		}
+	}
+	return status.Error(codes.PermissionDenied, "caller does not own this holding")
+}
+
+// SetHoldingPublic adjusts the OTC-discoverable share count on a stock
+// holding. Validation fans out into three buckets so the frontend can wire
+// each to a different inline error: NotFound for a stale id, PermissionDenied
+// for a wrong-owner attempt, FailedPrecondition for a non-stock asset (the
+// schema CHECK enforces 0 there), and InvalidArgument for an out-of-range
+// public_amount (must satisfy 0 ≤ public_amount ≤ amount).
+func (s *Server) SetHoldingPublic(ctx context.Context, req *tradingpb.SetHoldingPublicRequest) (*tradingpb.SetHoldingPublicResponse, error) {
+	if req.HoldingId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "holding_id required")
+	}
+	if req.PublicAmount < 0 {
+		return nil, status.Error(codes.InvalidArgument, "public_amount must be >= 0")
+	}
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var detail *tradingpb.Holding
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		var h Holding
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&h, req.HoldingId).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return status.Error(codes.NotFound, "holding not found")
+			}
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		if err := s.authorizeHoldingOwner(tx, &h, caller); err != nil {
+			return err
+		}
+		if h.StockID == nil {
+			return status.Error(codes.FailedPrecondition, "public_amount applies to stock holdings only")
+		}
+		if req.PublicAmount > h.Amount {
+			return status.Error(codes.InvalidArgument, "public_amount cannot exceed amount")
+		}
+
+		if err := tx.Model(&Holding{}).Where("id = ?", h.ID).Updates(map[string]any{
+			"public_amount": req.PublicAmount,
+			"last_modified": time.Now(),
+		}).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		h.PublicAmount = req.PublicAmount
+		h.LastModified = time.Now()
+
+		p, err := s.holdingToProto(tx, &h)
+		if err != nil {
+			return err
+		}
+		detail = p
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.SetHoldingPublicResponse{Holding: detail}, nil
+}
+
+// ExerciseOption settles a held option against the spot price (spec p.62).
+// Actuary-only, the option must not be past its settlement date, and it has
+// to be in-the-money. Payout is paid out of the bank-stub system account in
+// the option's underlying currency, then converted to the chosen account's
+// currency on credit — same FX path the executor uses for cross-currency
+// fills. The holding is fully consumed by exercise (all units settle at once
+// per spec — partial exercise isn't surfaced).
+func (s *Server) ExerciseOption(ctx context.Context, req *tradingpb.ExerciseOptionRequest) (*tradingpb.ExerciseOptionResponse, error) {
+	if req.OptionId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "option_id required")
+	}
+	if strings.TrimSpace(req.AccountNumber) == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_number required")
+	}
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caller.IsClient {
+		return nil, status.Error(codes.PermissionDenied, "options are available to employees only")
+	}
+
+	acc, err := s.bank.GetAccountByNumber(req.AccountNumber)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if err := s.bank.AuthorizeAccountAccess(ctx, acc); err != nil {
+		return nil, err
+	}
+
+	var payout, qty int64
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		var opt Option
+		if err := tx.First(&opt, req.OptionId).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return status.Error(codes.NotFound, "option not found")
+			}
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		now := time.Now()
+		if isPastSettlement(&opt.SettlementDate, now) {
+			return status.Error(codes.FailedPrecondition, "option past settlement")
+		}
+
+		// Spot price comes from the underlying stock's listing — same source
+		// the options grid uses for `shared_price`. No listing means no spot,
+		// so we can't decide ITM/OTM and refuse the exercise.
+		var listing Listing
+		if err := tx.Where("stock_id = ?", opt.StockID).First(&listing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return status.Error(codes.FailedPrecondition, "underlying stock has no listing")
+			}
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		spot := listing.Price
+		var ex Exchange
+		if err := tx.First(&ex, listing.ExchangeID).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		placerID, err := resolvePlacerForCaller(tx, caller)
+		if err != nil {
+			return err
+		}
+		var h Holding
+		err = tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("placer_id = ? AND option_id = ?", placerID, opt.ID).
+			First(&h).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return status.Error(codes.FailedPrecondition, "option not held by caller")
+		}
+		if err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+		if h.Amount <= 0 {
+			return status.Error(codes.FailedPrecondition, "option not held by caller")
+		}
+
+		// Spec p.62: payout per contract is intrinsic value × contract_size,
+		// minus the premium the holder paid up front. This codebase keeps
+		// options at contract_size 1 (resolveInstrument) so the formula
+		// collapses to (intrinsic − premium) × quantity. Premium is debited
+		// per-contract because that's how it was paid at acquisition.
+		var intrinsic int64
+		switch opt.OptionType {
+		case OptionCall:
+			intrinsic = spot - opt.StrikePrice
+		case OptionPut:
+			intrinsic = opt.StrikePrice - spot
+		default:
+			return status.Error(codes.Internal, "unknown option type")
+		}
+		if intrinsic <= 0 {
+			return status.Error(codes.FailedPrecondition, "option is out of the money")
+		}
+		payoutInstr := (intrinsic - opt.Premium) * h.Amount
+		if payoutInstr <= 0 {
+			return status.Error(codes.FailedPrecondition, "option payout would be non-positive after premium")
+		}
+
+		// Cross-currency credit: convert the instrument-currency payout into
+		// the account's currency using the same RSD-anchored rates as the
+		// executor. Sell-side rounding (floor) so the bank doesn't pay an
+		// extra penny on conversion.
+		creditAcc := payoutInstr
+		if acc.Currency != ex.Currency {
+			rateAcc, err := s.bank.GetExchangeRateToRSD(acc.Currency)
+			if err != nil {
+				return status.Errorf(codes.Internal, "%v", err)
+			}
+			rateInstr, err := s.bank.GetExchangeRateToRSD(ex.Currency)
+			if err != nil {
+				return status.Errorf(codes.Internal, "%v", err)
+			}
+			creditAcc = int64(math.Floor(float64(payoutInstr) * rateInstr / rateAcc))
+		}
+
+		if err := debitSystemAccount(tx, ex.Currency, payoutInstr); err != nil {
+			return err
+		}
+		if err := creditPlacer(tx, req.AccountNumber, creditAcc); err != nil {
+			return err
+		}
+
+		// Holding is fully consumed by exercise — partial exercise isn't a
+		// concept the spec exposes. Delete rather than zero out so the
+		// portfolio listing doesn't keep showing a stale 0-amount row.
+		if err := tx.Where("id = ?", h.ID).Delete(&Holding{}).Error; err != nil {
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		payout = creditAcc
+		qty = h.Amount
+		return nil
+	})
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.ExerciseOptionResponse{Payout: payout, Quantity: qty}, nil
+}

--- a/internal/trading/server.go
+++ b/internal/trading/server.go
@@ -171,14 +171,15 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	}
 
 	if err := s.db.Transaction(func(tx *gorm.DB) error {
-		placer := OrderPlacer{}
 		role := roleClient
 		var limits agentLimits
 		var employeeID int64
+		var clientPlacer *int64
+		var employeePlacer *int64
 
 		if caller.IsClient {
 			id := caller.ClientID
-			placer.ClientID = &id
+			clientPlacer = &id
 		} else if caller.IsEmployee {
 			if caller.Email == "" {
 				return status.Error(codes.Internal, "employee email missing from caller")
@@ -190,7 +191,7 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			employeeID = empID
 			role = r
 			limits = lim
-			placer.EmployeeID = &empID
+			employeePlacer = &empID
 		} else {
 			return status.Error(codes.PermissionDenied, "caller is neither client nor employee")
 		}
@@ -217,10 +218,11 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 			}
 		}
 
-		if err := tx.Create(&placer).Error; err != nil {
+		placerID, err := findOrCreatePlacer(tx, clientPlacer, employeePlacer)
+		if err != nil {
 			return err
 		}
-		order.PlacerID = placer.ID
+		order.PlacerID = placerID
 		if err := tx.Create(&order).Error; err != nil {
 			return err
 		}

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -18,6 +18,10 @@ service TradingService {
   rpc DeclineOrder(DeclineOrderRequest) returns (DeclineOrderResponse);
   rpc CancelOrder(CancelOrderRequest) returns (CancelOrderResponse);
   rpc SetExchangeOpenOverride(SetExchangeOpenOverrideRequest) returns (SetExchangeOpenOverrideResponse);
+  rpc ListHoldings(ListHoldingsRequest) returns (ListHoldingsResponse);
+  rpc SellHolding(SellHoldingRequest) returns (SellHoldingResponse);
+  rpc SetHoldingPublic(SetHoldingPublicRequest) returns (SetHoldingPublicResponse);
+  rpc ExerciseOption(ExerciseOptionRequest) returns (ExerciseOptionResponse);
 }
 
 message Exchange {
@@ -316,4 +320,93 @@ message CancelOrderRequest {
 
 message CancelOrderResponse {
   OrderDetail order = 1;
+}
+
+// Holding is one row in the portfolio portal (spec p.62 / #207). Exactly one
+// of stock_id / future_id / forex_pair_id / option_id is set — the asset_type
+// string ("stock"|"future"|"forex"|"option") gives the UI a single switch.
+// avg_cost is denominated in the booking account's currency; current_price
+// uses the instrument's quote currency (listing price, option premium, or
+// forex_pair.exchange_rate × 100). profit converts the current quote into the
+// account's currency before subtracting avg_cost so the displayed P/L lines
+// up with what would actually settle on a sell. public_amount is meaningful
+// only for stock holdings (OTC counter, fourth celina) and stays 0 elsewhere.
+message Holding {
+  int64 id = 1;
+  int64 placer_id = 2;
+  int64 stock_id = 3;
+  int64 future_id = 4;
+  int64 forex_pair_id = 5;
+  int64 option_id = 6;
+  int64 amount = 7;
+  int64 avg_cost = 8;
+  int64 account_id = 9;
+  string account_number = 10;
+  int64 public_amount = 11;
+  string ticker = 12;
+  int64 current_price = 13;
+  int64 profit = 14;
+  int64 last_modified_unix = 15;
+  string asset_type = 16;
+}
+
+message ListHoldingsRequest {
+  string caller_email = 1;
+}
+
+message ListHoldingsResponse {
+  repeated Holding holdings = 1;
+}
+
+// SellHolding is the spec's `POST /api/portfolio/sell` thin wrapper. The
+// server resolves the holding to its underlying asset and forwards a
+// CreateOrder with direction=sell, so the same execution / approval / margin
+// pipeline applies. The caller must own the holding (placer matches) — the
+// server enforces this rather than the gateway since the holding row carries
+// the authoritative placer link.
+message SellHoldingRequest {
+  int64 holding_id = 1;
+  string account_number = 2;
+  string order_type = 3;
+  int64 quantity = 4;
+  int64 limit_price = 5;
+  int64 stop_price = 6;
+  bool all_or_none = 7;
+}
+
+message SellHoldingResponse {
+  int64 order_id = 1;
+  string status = 2;
+}
+
+// SetHoldingPublic adjusts the public_amount counter on a stock holding. The
+// schema CHECK pins public_amount to 0 for non-stock holdings — the server
+// rejects any attempt to set it on a non-stock row with FailedPrecondition.
+// 0 ≤ public_amount ≤ amount; out-of-range values come back as
+// InvalidArgument so the portal can surface the problem inline.
+message SetHoldingPublicRequest {
+  int64 holding_id = 1;
+  int64 public_amount = 2;
+}
+
+message SetHoldingPublicResponse {
+  Holding holding = 1;
+}
+
+// ExerciseOption settles an option held by the caller. Actuary-only, the
+// option must not be past settlement, and it has to be in-the-money — calls
+// fire when spot > strike, puts when strike > spot. Payout per spec p.62:
+//   call: (spot - strike) * contract_size * quantity − premium * quantity
+//   put : (strike - spot) * contract_size * quantity − premium * quantity
+// The premium is paid back per contract held (not just once) — the user
+// effectively recoups what they paid to acquire the position. Settlement is
+// against the account_number passed in, which must belong to the caller.
+message ExerciseOptionRequest {
+  int64 option_id = 1;
+  string account_number = 2;
+}
+
+message ExerciseOptionResponse {
+  int64 payout = 1;
+  int64 quantity = 2;
 }

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -395,6 +395,12 @@ CREATE TABLE IF NOT EXISTS order_placers (
     CHECK ((client_id IS NOT NULL)::int + (employee_id IS NOT NULL)::int = 1)
 );
 
+-- One placer row per client / employee identity. Holdings (#207) are keyed on
+-- placer_id, so the row has to outlive any single order — the partial indexes
+-- enforce this without breaking the polymorphic NULL pattern.
+CREATE UNIQUE INDEX IF NOT EXISTS order_placers_client_uniq   ON order_placers(client_id)   WHERE client_id   IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS order_placers_employee_uniq ON order_placers(employee_id) WHERE employee_id IS NOT NULL;
+
 CREATE TYPE order_type AS ENUM ('market', 'limit', 'stop', 'stop_limit');
 CREATE TYPE order_direction AS ENUM ('buy', 'sell');
 -- 'cancelled' distinguishes supervisor/owner withdrawals from supervisor-declined
@@ -439,6 +445,38 @@ CREATE TABLE IF NOT EXISTS orders (
     created_at          TIMESTAMP       NOT NULL DEFAULT NOW(),
     CHECK ((listing_id IS NOT NULL)::int + (option_id IS NOT NULL)::int + (forex_pair_id IS NOT NULL)::int = 1)
 );
+
+-- Portfolio holdings (#207, spec p.62). Polymorphic over the four asset
+-- kinds — stock / future / forex_pair / option — same exactly-one pattern
+-- as orders.asset. Keyed by (placer_id, asset) so a buy-fill upserts the
+-- existing row instead of creating duplicates; account_id records where
+-- subsequent sell proceeds should land (relevant for tax). public_amount
+-- is the OTC-discoverable share count (stocks only); the OTC flow itself
+-- ships in the fourth celina, this column is just the counter.
+CREATE TABLE IF NOT EXISTS holdings (
+    id              BIGSERIAL       PRIMARY KEY,
+    placer_id       BIGINT          NOT NULL REFERENCES order_placers(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    stock_id        BIGINT          REFERENCES stocks(id)       ON UPDATE CASCADE ON DELETE CASCADE,
+    future_id       BIGINT          REFERENCES futures(id)      ON UPDATE CASCADE ON DELETE CASCADE,
+    forex_pair_id   BIGINT          REFERENCES forex_pairs(id)  ON UPDATE CASCADE ON DELETE CASCADE,
+    option_id       BIGINT          REFERENCES options(id)      ON UPDATE CASCADE ON DELETE CASCADE,
+    account_id      BIGINT          NOT NULL REFERENCES accounts(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    amount          BIGINT          NOT NULL DEFAULT 0 CHECK (amount >= 0),
+    avg_cost        BIGINT          NOT NULL DEFAULT 0 CHECK (avg_cost >= 0),
+    public_amount   BIGINT          NOT NULL DEFAULT 0 CHECK (public_amount >= 0),
+    last_modified   TIMESTAMP       NOT NULL DEFAULT NOW(),
+    CHECK ((stock_id IS NOT NULL)::int + (future_id IS NOT NULL)::int + (forex_pair_id IS NOT NULL)::int + (option_id IS NOT NULL)::int = 1),
+    -- public_amount is meaningful only for stocks; everywhere else it stays 0.
+    CHECK (stock_id IS NOT NULL OR public_amount = 0)
+);
+
+-- One holding per (placer, asset). Partial unique indexes keep the polymorphic
+-- shape working with NULLs (default Postgres NULLS DISTINCT would otherwise
+-- let two stock_id-NULL rows coexist on the same future_id).
+CREATE UNIQUE INDEX IF NOT EXISTS holdings_placer_stock_uniq  ON holdings(placer_id, stock_id)      WHERE stock_id      IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS holdings_placer_future_uniq ON holdings(placer_id, future_id)     WHERE future_id     IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS holdings_placer_forex_uniq  ON holdings(placer_id, forex_pair_id) WHERE forex_pair_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS holdings_placer_option_uniq ON holdings(placer_id, option_id)     WHERE option_id     IS NOT NULL;
 
 -- Per-chunk fills written by the execution engine (#205). price_per_unit is
 -- in the instrument's currency; fx_rate is NULL for same-currency fills and


### PR DESCRIPTION
## Summary
- New `holdings` table polymorphic over stock/future/forex/option, keyed by (placer_id, asset). Buy-fills upsert with quantity-weighted `avg_cost`; sell-fills lock and decrement, refusing on FailedPrecondition when the seller is short (the executor's per-tick backoff handles the retry).
- Order placers are now deduped per identity (partial unique indexes on `client_id` / `employee_id`) so holding rows can outlive any single order.
- Portfolio portal RPCs/routes:
  - `GET  /api/portfolio` — every holding the caller owns, with ticker, current price, profit (avg_cost stored in account currency, current quote FX-converted before subtraction), last_modified.
  - `POST /api/portfolio/sell` — thin wrapper that resolves the holding to its asset and forwards a `CreateOrder` with `direction=sell`. Quantity is bounded by held amount up front; the executor still re-checks at fill time.
  - `PATCH /api/portfolio/:id/public` — owner-only, stock-only, `0 ≤ public_amount ≤ amount`. Schema CHECK pins it to 0 for non-stock holdings.
  - `POST /api/options/:id/exercise` — actuary-only. Refuses past-settlement, OTM, or non-positive-after-premium. Payout per spec p.62: `(intrinsic − premium) × quantity`, FX-converted into the account currency, debited from the bank-stub account in the underlying's currency.

Closes #207.

## Test plan
- [x] `go test ./...`
- [x] `make lint` — 0 issues
- [x] Schema applies to a fresh `postgres:18-alpine`
- [ ] Manual: place a buy market order → observe holding upsert; place a sell exceeding holdings → fill stalls with FailedPrecondition; PATCH public_amount > amount → 400; exercise OTM call → 412; exercise ITM put → payout credited

🤖 Generated with [Claude Code](https://claude.com/claude-code)