### PR TITLE
feat(trading): capital-gains model + state company seed (#208)

### DIFF
--- a/internal/trading/capital_gains.go
+++ b/internal/trading/capital_gains.go
@@ -1,0 +1,113 @@
+package trading
+
+import (
+	"math"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// Capital-gains tax (#208, spec pp.63–64). Only stock sales are taxed in
+// this iteration — futures/forex/options have their own lifecycles the spec
+// doesn't cover under "porez na kapitalnu dobit", and exercising an option
+// (#207) already pays out at intrinsic, not at a realized-sale event.
+const (
+	// capitalGainsTaxPermille is 15% expressed as integer permille so the
+	// math sits with the rest of commission.go's permille arithmetic and
+	// avoids float rounding on the dinar side.
+	capitalGainsTaxPermille int64 = 150
+)
+
+// CapitalGain is one tax-owing row per sell-fill that realized positive dobit
+// against the holding's blended avg_cost. RealizedProfit is in the booking
+// account's currency; TaxDue is the 15% cut converted to RSD at the sale-day
+// rate (spec Napomena 2 on p.63: država ima samo RSD račun, so the receipt
+// currency has to be RSD regardless of where the gain was realized).
+//
+// PaidAt stays NULL until the monthly tax-collection cron (#209) debits the
+// account and transfers to the state company; that flow is the next issue —
+// this file only writes rows.
+type CapitalGain struct {
+	ID             int64      `gorm:"column:id;primaryKey"`
+	SellerPlacerID int64      `gorm:"column:seller_placer_id;not null"`
+	AccountID      int64      `gorm:"column:account_id;not null"`
+	OrderFillID    *int64     `gorm:"column:order_fill_id"`
+	RealizedProfit int64      `gorm:"column:realized_profit;not null"`
+	TaxDue         int64      `gorm:"column:tax_due;not null"`
+	Period         string     `gorm:"column:period;type:char(7);not null"`
+	PaidAt         *time.Time `gorm:"column:paid_at"`
+	CreatedAt      time.Time  `gorm:"column:created_at;not null;autoCreateTime"`
+}
+
+func (CapitalGain) TableName() string { return "capital_gains" }
+
+// capitalGainsPeriod formats `now` as the monthly bucket the tax spec uses
+// (YYYY-MM). Kept separate so tests can pin it without a Server dependency.
+func capitalGainsPeriod(now time.Time) string {
+	return now.Format("2006-01")
+}
+
+// computeCapitalGainsTax returns the tax owed on a single sell-fill, both in
+// the booking account's currency and converted to RSD. rateAccRSD is the
+// RSD-per-unit rate for the account currency at sale-day; callers pass 1.0
+// when the account is already in RSD. A zero or negative profit returns
+// (0, 0) — no dobit, no tax (spec p.62 "u slučaju gubitka").
+//
+// Rounding is up for tax_acc_ccy so rounding never under-taxes the placer;
+// the RSD conversion then uses bankers' rounding via math.Round so a foreign
+// dobit doesn't drift away from its RSD equivalent over time.
+func computeCapitalGainsTax(profitAccCcy int64, rateAccRSD float64) (int64, int64) {
+	if profitAccCcy <= 0 {
+		return 0, 0
+	}
+	taxAcc := (profitAccCcy*capitalGainsTaxPermille + 999) / 1000
+	taxRSD := int64(math.Round(float64(taxAcc) * rateAccRSD))
+	return taxAcc, taxRSD
+}
+
+// recordCapitalGain writes a capital_gains row for a stock sell-fill when the
+// sale realized positive dobit against the holding's pre-deduction avg_cost.
+// Non-stock holdings and loss fills are no-ops.
+//
+// proceedsAccCcy is the gross sale proceeds in the booking account's currency
+// (settle.accAmount from executor.go); snapshot is the holding as it stood
+// before deductHoldingOnSell ran, so avg_cost and account_id reflect the
+// moment of sale rather than any post-deduction re-averaging.
+func recordCapitalGain(
+	tx *gorm.DB,
+	snapshot *Holding,
+	orderFillID int64,
+	chunk int64,
+	proceedsAccCcy int64,
+	rateAccRSD float64,
+	now time.Time,
+) error {
+	if snapshot == nil || snapshot.StockID == nil {
+		return nil
+	}
+	if chunk <= 0 {
+		return nil
+	}
+	costBasis := snapshot.AvgCost * chunk
+	profit := proceedsAccCcy - costBasis
+	if profit <= 0 {
+		return nil
+	}
+
+	_, taxRSD := computeCapitalGainsTax(profit, rateAccRSD)
+	fillID := orderFillID
+	row := CapitalGain{
+		SellerPlacerID: snapshot.PlacerID,
+		AccountID:      snapshot.AccountID,
+		OrderFillID:    &fillID,
+		RealizedProfit: profit,
+		TaxDue:         taxRSD,
+		Period:         capitalGainsPeriod(now),
+	}
+	if err := tx.Create(&row).Error; err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+	return nil
+}

--- a/internal/trading/capital_gains_test.go
+++ b/internal/trading/capital_gains_test.go
@@ -1,0 +1,52 @@
+package trading
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCapitalGainsTaxFormula pins the spec p.63 example ("100 RSD buy, 250
+// RSD sell → 150 RSD dobit → 22.5 RSD porez") plus the cross-currency and
+// loss cases. Rounding is intentionally up on the account-currency tax side
+// so rounding never under-taxes the placer.
+func TestCapitalGainsTaxFormula(t *testing.T) {
+	cases := []struct {
+		name       string
+		profit     int64
+		rateAccRSD float64
+		wantAcc    int64
+		wantRSD    int64
+	}{
+		{"spec example RSD", 15000, 1.0, 2250, 2250},
+		{"loss zero", -500, 1.0, 0, 0},
+		{"zero profit skipped", 0, 1.0, 0, 0},
+		{"rounds up on account", 7, 1.0, 2, 2}, // 7 * 0.15 = 1.05 → rounds up to 2
+		{"EUR @ 117.15", 10000, 117.15, 1500, 175725},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			acc, rsd := computeCapitalGainsTax(c.profit, c.rateAccRSD)
+			if acc != c.wantAcc {
+				t.Errorf("acc tax: got %d, want %d", acc, c.wantAcc)
+			}
+			if rsd != c.wantRSD {
+				t.Errorf("RSD tax: got %d, want %d", rsd, c.wantRSD)
+			}
+		})
+	}
+}
+
+// TestCapitalGainsPeriodMonthly confirms the period key collapses any moment
+// in the month to a stable YYYY-MM bucket — the next-issue collection cron
+// joins on this column, so a drift from UTC/local or a different separator
+// would split the same month into two pay-outs.
+func TestCapitalGainsPeriodMonthly(t *testing.T) {
+	mid := time.Date(2026, 3, 14, 15, 9, 26, 0, time.UTC)
+	if got := capitalGainsPeriod(mid); got != "2026-03" {
+		t.Errorf("got %q, want 2026-03", got)
+	}
+	endOfMonth := time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)
+	if got := capitalGainsPeriod(endOfMonth); got != "2026-12" {
+		t.Errorf("got %q, want 2026-12", got)
+	}
+}

--- a/internal/trading/executor.go
+++ b/internal/trading/executor.go
@@ -279,6 +279,7 @@ func (s *Server) executeFill(o *Order, now time.Time) (time.Time, error) {
 		if err != nil {
 			return err
 		}
+		var soldFromSnapshot *Holding
 		if locked.Direction == DirectionBuy {
 			accountID, err := holdingAccountID(tx, locked.AccountNumber)
 			if err != nil {
@@ -289,7 +290,8 @@ func (s *Server) executeFill(o *Order, now time.Time) (time.Time, error) {
 				return err
 			}
 		} else {
-			if err := deductHoldingOnSell(tx, locked.PlacerID, assetCol, assetID, chunk, now); err != nil {
+			soldFromSnapshot, err = deductHoldingOnSell(tx, locked.PlacerID, assetCol, assetID, chunk, now)
+			if err != nil {
 				return err
 			}
 		}
@@ -302,6 +304,24 @@ func (s *Server) executeFill(o *Order, now time.Time) (time.Time, error) {
 		}
 		if err := tx.Create(&fill).Error; err != nil {
 			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		// Capital-gains tax (#208): stock sell-fills with positive dobit owe
+		// 15% (RSD). recordCapitalGain is a no-op on non-stock snapshots and
+		// loss fills, so it's safe to call unconditionally on the sell path.
+		// RSD accounts skip the rate lookup — the conversion is the identity.
+		if locked.Direction == DirectionSell && soldFromSnapshot != nil {
+			rateAccRSD := 1.0
+			if acc.Currency != "RSD" {
+				r, err := s.bank.GetExchangeRateToRSD(acc.Currency)
+				if err != nil {
+					return status.Errorf(codes.Internal, "%v", err)
+				}
+				rateAccRSD = r
+			}
+			if err := recordCapitalGain(tx, soldFromSnapshot, fill.ID, chunk, settle.accAmount, rateAccRSD, now); err != nil {
+				return err
+			}
 		}
 
 		newVolume, err := upsertDailyVolume(tx, *locked.ListingID, now, chunk, listing)

--- a/internal/trading/holdings.go
+++ b/internal/trading/holdings.go
@@ -107,9 +107,13 @@ func upsertHoldingOnBuy(tx *gorm.DB, placerID int64, accountID int64, assetCol s
 // public_amount tracks the OTC-discoverable share count and must never exceed
 // amount; if a sell drops amount below the current public_amount, the public
 // counter is clamped down so the invariant holds.
-func deductHoldingOnSell(tx *gorm.DB, placerID int64, assetCol string, assetID int64, chunk int64, now time.Time) error {
+//
+// The returned Holding is the pre-deduction snapshot — avg_cost and
+// account_id at the moment of sale, which capital_gains.go needs to compute
+// the tax row (#208). nil is returned only alongside a non-nil error.
+func deductHoldingOnSell(tx *gorm.DB, placerID int64, assetCol string, assetID int64, chunk int64, now time.Time) (*Holding, error) {
 	if chunk <= 0 {
-		return nil
+		return nil, nil
 	}
 
 	var h Holding
@@ -117,13 +121,13 @@ func deductHoldingOnSell(tx *gorm.DB, placerID int64, assetCol string, assetID i
 		Where("placer_id = ? AND "+assetCol+" = ?", placerID, assetID).
 		First(&h).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return status.Error(codes.FailedPrecondition, "no holding for sell-side fill")
+		return nil, status.Error(codes.FailedPrecondition, "no holding for sell-side fill")
 	}
 	if err != nil {
-		return status.Errorf(codes.Internal, "%v", err)
+		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 	if h.Amount < chunk {
-		return status.Error(codes.FailedPrecondition, "insufficient holding for sell-side fill")
+		return nil, status.Error(codes.FailedPrecondition, "insufficient holding for sell-side fill")
 	}
 
 	newAmount := h.Amount - chunk
@@ -135,9 +139,9 @@ func deductHoldingOnSell(tx *gorm.DB, placerID int64, assetCol string, assetID i
 		updates["public_amount"] = newAmount
 	}
 	if err := tx.Model(&Holding{}).Where("id = ?", h.ID).Updates(updates).Error; err != nil {
-		return status.Errorf(codes.Internal, "%v", err)
+		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
-	return nil
+	return &h, nil
 }
 
 // findOrCreatePlacer returns the order_placers.id for the given identity,

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -492,6 +492,30 @@ CREATE TABLE IF NOT EXISTS order_fills (
 );
 CREATE INDEX IF NOT EXISTS idx_order_fills_order ON order_fills(order_id);
 
+-- Capital-gains tax tracking (#208, spec pp.63–64). One row per sell-fill that
+-- realizes positive dobit on a stock; loss fills are skipped because there's
+-- nothing to tax (spec p.62 "u slučaju gubitka"). realized_profit is in the
+-- booking account's currency (avg_cost vs sell proceeds both live there);
+-- tax_due is 15% of that, converted to RSD at the sale-day rate because the
+-- state company has only an RSD account (Napomena 2 on p.63). paid_at stays
+-- NULL until the monthly collection cron (#209) debits the placer.
+CREATE TABLE IF NOT EXISTS capital_gains (
+    id                  BIGSERIAL       PRIMARY KEY,
+    seller_placer_id    BIGINT          NOT NULL REFERENCES order_placers(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    account_id          BIGINT          NOT NULL REFERENCES accounts(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    order_fill_id       BIGINT          REFERENCES order_fills(id) ON UPDATE CASCADE ON DELETE SET NULL,
+    realized_profit     BIGINT          NOT NULL CHECK (realized_profit > 0),
+    tax_due             BIGINT          NOT NULL CHECK (tax_due >= 0),
+    period              CHAR(7)         NOT NULL,
+    paid_at             TIMESTAMP,
+    created_at          TIMESTAMP       NOT NULL DEFAULT NOW()
+);
+-- The cron scans by (period, unpaid) — partial index keeps it selective as
+-- paid rows accumulate.
+CREATE INDEX IF NOT EXISTS idx_capital_gains_period_unpaid
+    ON capital_gains(period, seller_placer_id)
+    WHERE paid_at IS NULL;
+
 -- Notify Redis when employee permissions change
 CREATE OR REPLACE FUNCTION notify_permission_change() RETURNS trigger AS $$
 DECLARE

--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -868,6 +868,56 @@ CROSS JOIN generate_series(1, 30) AS gs(n)
 ON CONFLICT (listing_id, date) DO NOTHING;
 
 -------------------------------------------------------------------------------
+-- State as a company (spec p.38 "naša država = firma", #208). Acts as the
+-- destination for capital-gains tax transfers. tax_code = 1 is the stable
+-- magic value lookups can key off; one RSD current account per the spec
+-- ("država ima samo RSD račun", p.63 Napomena 2).
+-------------------------------------------------------------------------------
+INSERT INTO clients (
+    first_name, last_name, date_of_birth, gender, email,
+    phone_number, address, password, salt_password
+)
+VALUES (
+    'Republika', 'Srbija', '1900-01-01', 'M', 'drzava@republika.rs',
+    '+381600000002', 'Nemanjina 11',
+    '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA,
+    '\x00000000000000000000000000000000'::BYTEA
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO activity_codes (code, sector, branch)
+VALUES ('84.11', 'Public administration', 'General public administration')
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO companies (registered_id, name, tax_code, activity_code_id, address, owner_id)
+SELECT 84110001, 'Republika Srbija', 1, ac.id, 'Nemanjina 11', c.id
+FROM activity_codes ac, clients c
+WHERE ac.code = '84.11' AND c.email = 'drzava@republika.rs'
+ON CONFLICT (registered_id) DO NOTHING;
+
+INSERT INTO accounts (number, name, owner, company_id, balance, created_by, valid_until, currency, active, owner_type, account_type, maintainance_cost, daily_limit, monthly_limit, daily_expenditure, monthly_expenditure)
+SELECT
+    '333000100000099910' AS number,
+    'Republika Srbija - RSD' AS name,
+    c.id AS owner,
+    co.id AS company_id,
+    0 AS balance,
+    e.id AS created_by,
+    '2099-12-31' AS valid_until,
+    'RSD' AS currency,
+    TRUE AS active,
+    'business'::owner_type AS owner_type,
+    'checking'::account_type AS account_type,
+    0 AS maintainance_cost,
+    NULL AS daily_limit,
+    NULL AS monthly_limit,
+    0 AS daily_expenditure,
+    0 AS monthly_expenditure
+FROM clients c, companies co, employees e
+WHERE c.email = 'drzava@republika.rs' AND co.tax_code = 1 AND e.email = :'admin_email'
+ON CONFLICT (number) DO NOTHING;
+
+-------------------------------------------------------------------------------
 -- Options: Black-Scholes fallback (spec p.45) — 11 strikes per stock at 10%
 -- steps around spot, CALL + PUT for each, with 6-day and 30-day expiries.
 -- IV=1 (placeholder until BS pricing is wired up); premium is a simple


### PR DESCRIPTION
## Summary
- Adds `capital_gains` table: one row per stock sell-fill that realizes positive dobit against the holding's pre-deduction `avg_cost`. `realized_profit` sits in the booking account's currency; `tax_due` is 15% converted to RSD at the sale-day rate (spec p.63 Napomena 2 — država ima samo RSD račun). `paid_at` stays NULL until the collection cron lands (next issue, #209).
- Seeds `Republika Srbija` as a company with `tax_code = 1` and a single RSD current account (`333000100000099910`), per spec p.38 "naša država = firma". This is the tax-transfer destination.
- Executor wiring: `deductHoldingOnSell` now returns the pre-deduction holding snapshot so the sell branch can feed cost basis + booking account into `recordCapitalGain`. No-op on non-stock assets and loss fills, so it's safe on every sell-fill.

Closes #208.

## Test plan
- [x] `go test ./internal/trading/...` passes (new formula + period tests cover spec p.63 example and RSD conversion).
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `make schema && make seed` against a fresh Postgres: schema applies, state company row + RSD account created.
- [ ] Manual smoke: place a buy order, let it fill, then place a sell order — verify a `capital_gains` row lands with the expected profit and RSD tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)