### PR TITLE
feat(trading): monthly tax cron + supervisor tax portal endpoints

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -3090,6 +3090,341 @@ func (x *ExerciseOptionResponse) GetQuantity() int64 {
 	return 0
 }
 
+// Supervisor-only manual trigger for the monthly capital-gains tax sweep
+// (spec p.63 "Supervizori mogu ručno pokrenuti ovu operaciju putem portala").
+// month is YYYY-MM; passing an empty string sweeps every still-unpaid row
+// regardless of period — useful for back-fills.
+type RunCapitalGainsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	Month         string                 `protobuf:"bytes,2,opt,name=month,proto3" json:"month,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunCapitalGainsRequest) Reset() {
+	*x = RunCapitalGainsRequest{}
+	mi := &file_trading_trading_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunCapitalGainsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunCapitalGainsRequest) ProtoMessage() {}
+
+func (x *RunCapitalGainsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunCapitalGainsRequest.ProtoReflect.Descriptor instead.
+func (*RunCapitalGainsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *RunCapitalGainsRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+func (x *RunCapitalGainsRequest) GetMonth() string {
+	if x != nil {
+		return x.Month
+	}
+	return ""
+}
+
+type RunCapitalGainsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Period        string                 `protobuf:"bytes,1,opt,name=period,proto3" json:"period,omitempty"`
+	AccountsPaid  int32                  `protobuf:"varint,2,opt,name=accounts_paid,json=accountsPaid,proto3" json:"accounts_paid,omitempty"`
+	RowsPaid      int32                  `protobuf:"varint,3,opt,name=rows_paid,json=rowsPaid,proto3" json:"rows_paid,omitempty"`
+	Insufficient  int32                  `protobuf:"varint,4,opt,name=insufficient,proto3" json:"insufficient,omitempty"`
+	TotalDebtRsd  int64                  `protobuf:"varint,5,opt,name=total_debt_rsd,json=totalDebtRsd,proto3" json:"total_debt_rsd,omitempty"`
+	CollectedRsd  int64                  `protobuf:"varint,6,opt,name=collected_rsd,json=collectedRsd,proto3" json:"collected_rsd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunCapitalGainsResponse) Reset() {
+	*x = RunCapitalGainsResponse{}
+	mi := &file_trading_trading_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunCapitalGainsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunCapitalGainsResponse) ProtoMessage() {}
+
+func (x *RunCapitalGainsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunCapitalGainsResponse.ProtoReflect.Descriptor instead.
+func (*RunCapitalGainsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *RunCapitalGainsResponse) GetPeriod() string {
+	if x != nil {
+		return x.Period
+	}
+	return ""
+}
+
+func (x *RunCapitalGainsResponse) GetAccountsPaid() int32 {
+	if x != nil {
+		return x.AccountsPaid
+	}
+	return 0
+}
+
+func (x *RunCapitalGainsResponse) GetRowsPaid() int32 {
+	if x != nil {
+		return x.RowsPaid
+	}
+	return 0
+}
+
+func (x *RunCapitalGainsResponse) GetInsufficient() int32 {
+	if x != nil {
+		return x.Insufficient
+	}
+	return 0
+}
+
+func (x *RunCapitalGainsResponse) GetTotalDebtRsd() int64 {
+	if x != nil {
+		return x.TotalDebtRsd
+	}
+	return 0
+}
+
+func (x *RunCapitalGainsResponse) GetCollectedRsd() int64 {
+	if x != nil {
+		return x.CollectedRsd
+	}
+	return 0
+}
+
+// TaxDebtor is one user's current unpaid RSD tax debt summed across all of
+// their accounts (spec p.63: "Dugovanja korisnika prikazana su u RSD"). team
+// is "client" or "actuary". Users without any capital-gains rows are not
+// listed — the portal scopes itself to participants in the trading flow.
+type TaxDebtor struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	FirstName     string                 `protobuf:"bytes,2,opt,name=first_name,json=firstName,proto3" json:"first_name,omitempty"`
+	LastName      string                 `protobuf:"bytes,3,opt,name=last_name,json=lastName,proto3" json:"last_name,omitempty"`
+	Team          string                 `protobuf:"bytes,4,opt,name=team,proto3" json:"team,omitempty"`
+	UnpaidRsd     int64                  `protobuf:"varint,5,opt,name=unpaid_rsd,json=unpaidRsd,proto3" json:"unpaid_rsd,omitempty"`
+	PaidRsd       int64                  `protobuf:"varint,6,opt,name=paid_rsd,json=paidRsd,proto3" json:"paid_rsd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaxDebtor) Reset() {
+	*x = TaxDebtor{}
+	mi := &file_trading_trading_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaxDebtor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaxDebtor) ProtoMessage() {}
+
+func (x *TaxDebtor) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaxDebtor.ProtoReflect.Descriptor instead.
+func (*TaxDebtor) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *TaxDebtor) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *TaxDebtor) GetFirstName() string {
+	if x != nil {
+		return x.FirstName
+	}
+	return ""
+}
+
+func (x *TaxDebtor) GetLastName() string {
+	if x != nil {
+		return x.LastName
+	}
+	return ""
+}
+
+func (x *TaxDebtor) GetTeam() string {
+	if x != nil {
+		return x.Team
+	}
+	return ""
+}
+
+func (x *TaxDebtor) GetUnpaidRsd() int64 {
+	if x != nil {
+		return x.UnpaidRsd
+	}
+	return 0
+}
+
+func (x *TaxDebtor) GetPaidRsd() int64 {
+	if x != nil {
+		return x.PaidRsd
+	}
+	return 0
+}
+
+// Filters mirror the spec's two portal filters: team (klijent/aktuar) and
+// name (case-insensitive substring on first or last name). Empty values
+// disable the corresponding filter.
+type ListTaxDebtsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	Team          string                 `protobuf:"bytes,2,opt,name=team,proto3" json:"team,omitempty"`
+	Name          string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTaxDebtsRequest) Reset() {
+	*x = ListTaxDebtsRequest{}
+	mi := &file_trading_trading_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTaxDebtsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTaxDebtsRequest) ProtoMessage() {}
+
+func (x *ListTaxDebtsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTaxDebtsRequest.ProtoReflect.Descriptor instead.
+func (*ListTaxDebtsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ListTaxDebtsRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+func (x *ListTaxDebtsRequest) GetTeam() string {
+	if x != nil {
+		return x.Team
+	}
+	return ""
+}
+
+func (x *ListTaxDebtsRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type ListTaxDebtsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Debtors       []*TaxDebtor           `protobuf:"bytes,1,rep,name=debtors,proto3" json:"debtors,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTaxDebtsResponse) Reset() {
+	*x = ListTaxDebtsResponse{}
+	mi := &file_trading_trading_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTaxDebtsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTaxDebtsResponse) ProtoMessage() {}
+
+func (x *ListTaxDebtsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTaxDebtsResponse.ProtoReflect.Descriptor instead.
+func (*ListTaxDebtsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ListTaxDebtsResponse) GetDebtors() []*TaxDebtor {
+	if x != nil {
+		return x.Debtors
+	}
+	return nil
+}
+
 var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
@@ -3355,8 +3690,32 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x0eaccount_number\x18\x02 \x01(\tR\raccountNumber\"L\n" +
 	"\x16ExerciseOptionResponse\x12\x16\n" +
 	"\x06payout\x18\x01 \x01(\x03R\x06payout\x12\x1a\n" +
-	"\bquantity\x18\x02 \x01(\x03R\bquantity2\xec\n" +
+	"\bquantity\x18\x02 \x01(\x03R\bquantity\"Q\n" +
+	"\x16RunCapitalGainsRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\x12\x14\n" +
+	"\x05month\x18\x02 \x01(\tR\x05month\"\xe2\x01\n" +
+	"\x17RunCapitalGainsResponse\x12\x16\n" +
+	"\x06period\x18\x01 \x01(\tR\x06period\x12#\n" +
+	"\raccounts_paid\x18\x02 \x01(\x05R\faccountsPaid\x12\x1b\n" +
+	"\trows_paid\x18\x03 \x01(\x05R\browsPaid\x12\"\n" +
+	"\finsufficient\x18\x04 \x01(\x05R\finsufficient\x12$\n" +
+	"\x0etotal_debt_rsd\x18\x05 \x01(\x03R\ftotalDebtRsd\x12#\n" +
+	"\rcollected_rsd\x18\x06 \x01(\x03R\fcollectedRsd\"\xae\x01\n" +
+	"\tTaxDebtor\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12\x1d\n" +
 	"\n" +
+	"first_name\x18\x02 \x01(\tR\tfirstName\x12\x1b\n" +
+	"\tlast_name\x18\x03 \x01(\tR\blastName\x12\x12\n" +
+	"\x04team\x18\x04 \x01(\tR\x04team\x12\x1d\n" +
+	"\n" +
+	"unpaid_rsd\x18\x05 \x01(\x03R\tunpaidRsd\x12\x19\n" +
+	"\bpaid_rsd\x18\x06 \x01(\x03R\apaidRsd\"`\n" +
+	"\x13ListTaxDebtsRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\x12\x12\n" +
+	"\x04team\x18\x02 \x01(\tR\x04team\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"D\n" +
+	"\x14ListTaxDebtsResponse\x12,\n" +
+	"\adebtors\x18\x01 \x03(\v2\x12.trading.TaxDebtorR\adebtors2\x8f\f\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
@@ -3376,7 +3735,9 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\fListHoldings\x12\x1c.trading.ListHoldingsRequest\x1a\x1d.trading.ListHoldingsResponse\x12H\n" +
 	"\vSellHolding\x12\x1b.trading.SellHoldingRequest\x1a\x1c.trading.SellHoldingResponse\x12W\n" +
 	"\x10SetHoldingPublic\x12 .trading.SetHoldingPublicRequest\x1a!.trading.SetHoldingPublicResponse\x12Q\n" +
-	"\x0eExerciseOption\x12\x1e.trading.ExerciseOptionRequest\x1a\x1f.trading.ExerciseOptionResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
+	"\x0eExerciseOption\x12\x1e.trading.ExerciseOptionRequest\x1a\x1f.trading.ExerciseOptionResponse\x12T\n" +
+	"\x0fRunCapitalGains\x12\x1f.trading.RunCapitalGainsRequest\x1a .trading.RunCapitalGainsResponse\x12K\n" +
+	"\fListTaxDebts\x12\x1c.trading.ListTaxDebtsRequest\x1a\x1d.trading.ListTaxDebtsResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
 	file_trading_trading_proto_rawDescOnce sync.Once
@@ -3390,7 +3751,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),                        // 0: trading.Exchange
 	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
@@ -3435,6 +3796,11 @@ var file_trading_trading_proto_goTypes = []any{
 	(*SetHoldingPublicResponse)(nil),        // 40: trading.SetHoldingPublicResponse
 	(*ExerciseOptionRequest)(nil),           // 41: trading.ExerciseOptionRequest
 	(*ExerciseOptionResponse)(nil),          // 42: trading.ExerciseOptionResponse
+	(*RunCapitalGainsRequest)(nil),          // 43: trading.RunCapitalGainsRequest
+	(*RunCapitalGainsResponse)(nil),         // 44: trading.RunCapitalGainsResponse
+	(*TaxDebtor)(nil),                       // 45: trading.TaxDebtor
+	(*ListTaxDebtsRequest)(nil),             // 46: trading.ListTaxDebtsRequest
+	(*ListTaxDebtsResponse)(nil),            // 47: trading.ListTaxDebtsResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0,  // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
@@ -3453,45 +3819,50 @@ var file_trading_trading_proto_depIdxs = []int32{
 	25, // 13: trading.CancelOrderResponse.order:type_name -> trading.OrderDetail
 	34, // 14: trading.ListHoldingsResponse.holdings:type_name -> trading.Holding
 	34, // 15: trading.SetHoldingPublicResponse.holding:type_name -> trading.Holding
-	3,  // 16: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
-	6,  // 17: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	8,  // 18: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
-	10, // 19: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
-	14, // 20: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
-	16, // 21: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
-	19, // 22: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
-	23, // 23: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	26, // 24: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
-	28, // 25: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
-	30, // 26: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
-	32, // 27: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
-	1,  // 28: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
-	35, // 29: trading.TradingService.ListHoldings:input_type -> trading.ListHoldingsRequest
-	37, // 30: trading.TradingService.SellHolding:input_type -> trading.SellHoldingRequest
-	39, // 31: trading.TradingService.SetHoldingPublic:input_type -> trading.SetHoldingPublicRequest
-	41, // 32: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
-	4,  // 33: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	7,  // 34: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	9,  // 35: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
-	12, // 36: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
-	15, // 37: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
-	18, // 38: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
-	22, // 39: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
-	24, // 40: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	27, // 41: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
-	29, // 42: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
-	31, // 43: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
-	33, // 44: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
-	2,  // 45: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	36, // 46: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
-	38, // 47: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
-	40, // 48: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
-	42, // 49: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
-	33, // [33:50] is the sub-list for method output_type
-	16, // [16:33] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	45, // 16: trading.ListTaxDebtsResponse.debtors:type_name -> trading.TaxDebtor
+	3,  // 17: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
+	6,  // 18: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	8,  // 19: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
+	10, // 20: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
+	14, // 21: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
+	16, // 22: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
+	19, // 23: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
+	23, // 24: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	26, // 25: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
+	28, // 26: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
+	30, // 27: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
+	32, // 28: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
+	1,  // 29: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
+	35, // 30: trading.TradingService.ListHoldings:input_type -> trading.ListHoldingsRequest
+	37, // 31: trading.TradingService.SellHolding:input_type -> trading.SellHoldingRequest
+	39, // 32: trading.TradingService.SetHoldingPublic:input_type -> trading.SetHoldingPublicRequest
+	41, // 33: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
+	43, // 34: trading.TradingService.RunCapitalGains:input_type -> trading.RunCapitalGainsRequest
+	46, // 35: trading.TradingService.ListTaxDebts:input_type -> trading.ListTaxDebtsRequest
+	4,  // 36: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7,  // 37: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9,  // 38: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	12, // 39: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	15, // 40: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	18, // 41: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
+	22, // 42: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
+	24, // 43: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	27, // 44: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
+	29, // 45: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
+	31, // 46: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
+	33, // 47: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
+	2,  // 48: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	36, // 49: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
+	38, // 50: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
+	40, // 51: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
+	42, // 52: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
+	44, // 53: trading.TradingService.RunCapitalGains:output_type -> trading.RunCapitalGainsResponse
+	47, // 54: trading.TradingService.ListTaxDebts:output_type -> trading.ListTaxDebtsResponse
+	36, // [36:55] is the sub-list for method output_type
+	17, // [17:36] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_trading_trading_proto_init() }
@@ -3505,7 +3876,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   43,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -36,6 +36,8 @@ const (
 	TradingService_SellHolding_FullMethodName             = "/trading.TradingService/SellHolding"
 	TradingService_SetHoldingPublic_FullMethodName        = "/trading.TradingService/SetHoldingPublic"
 	TradingService_ExerciseOption_FullMethodName          = "/trading.TradingService/ExerciseOption"
+	TradingService_RunCapitalGains_FullMethodName         = "/trading.TradingService/RunCapitalGains"
+	TradingService_ListTaxDebts_FullMethodName            = "/trading.TradingService/ListTaxDebts"
 )
 
 // TradingServiceClient is the client API for TradingService service.
@@ -59,6 +61,8 @@ type TradingServiceClient interface {
 	SellHolding(ctx context.Context, in *SellHoldingRequest, opts ...grpc.CallOption) (*SellHoldingResponse, error)
 	SetHoldingPublic(ctx context.Context, in *SetHoldingPublicRequest, opts ...grpc.CallOption) (*SetHoldingPublicResponse, error)
 	ExerciseOption(ctx context.Context, in *ExerciseOptionRequest, opts ...grpc.CallOption) (*ExerciseOptionResponse, error)
+	RunCapitalGains(ctx context.Context, in *RunCapitalGainsRequest, opts ...grpc.CallOption) (*RunCapitalGainsResponse, error)
+	ListTaxDebts(ctx context.Context, in *ListTaxDebtsRequest, opts ...grpc.CallOption) (*ListTaxDebtsResponse, error)
 }
 
 type tradingServiceClient struct {
@@ -239,6 +243,26 @@ func (c *tradingServiceClient) ExerciseOption(ctx context.Context, in *ExerciseO
 	return out, nil
 }
 
+func (c *tradingServiceClient) RunCapitalGains(ctx context.Context, in *RunCapitalGainsRequest, opts ...grpc.CallOption) (*RunCapitalGainsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunCapitalGainsResponse)
+	err := c.cc.Invoke(ctx, TradingService_RunCapitalGains_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) ListTaxDebts(ctx context.Context, in *ListTaxDebtsRequest, opts ...grpc.CallOption) (*ListTaxDebtsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTaxDebtsResponse)
+	err := c.cc.Invoke(ctx, TradingService_ListTaxDebts_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TradingServiceServer is the server API for TradingService service.
 // All implementations must embed UnimplementedTradingServiceServer
 // for forward compatibility.
@@ -260,6 +284,8 @@ type TradingServiceServer interface {
 	SellHolding(context.Context, *SellHoldingRequest) (*SellHoldingResponse, error)
 	SetHoldingPublic(context.Context, *SetHoldingPublicRequest) (*SetHoldingPublicResponse, error)
 	ExerciseOption(context.Context, *ExerciseOptionRequest) (*ExerciseOptionResponse, error)
+	RunCapitalGains(context.Context, *RunCapitalGainsRequest) (*RunCapitalGainsResponse, error)
+	ListTaxDebts(context.Context, *ListTaxDebtsRequest) (*ListTaxDebtsResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
 
@@ -320,6 +346,12 @@ func (UnimplementedTradingServiceServer) SetHoldingPublic(context.Context, *SetH
 }
 func (UnimplementedTradingServiceServer) ExerciseOption(context.Context, *ExerciseOptionRequest) (*ExerciseOptionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ExerciseOption not implemented")
+}
+func (UnimplementedTradingServiceServer) RunCapitalGains(context.Context, *RunCapitalGainsRequest) (*RunCapitalGainsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunCapitalGains not implemented")
+}
+func (UnimplementedTradingServiceServer) ListTaxDebts(context.Context, *ListTaxDebtsRequest) (*ListTaxDebtsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTaxDebts not implemented")
 }
 func (UnimplementedTradingServiceServer) mustEmbedUnimplementedTradingServiceServer() {}
 func (UnimplementedTradingServiceServer) testEmbeddedByValue()                        {}
@@ -648,6 +680,42 @@ func _TradingService_ExerciseOption_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_RunCapitalGains_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunCapitalGainsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).RunCapitalGains(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_RunCapitalGains_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).RunCapitalGains(ctx, req.(*RunCapitalGainsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_ListTaxDebts_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTaxDebtsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).ListTaxDebts(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_ListTaxDebts_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).ListTaxDebts(ctx, req.(*ListTaxDebtsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TradingService_ServiceDesc is the grpc.ServiceDesc for TradingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -722,6 +790,14 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ExerciseOption",
 			Handler:    _TradingService_ExerciseOption_Handler,
+		},
+		{
+			MethodName: "RunCapitalGains",
+			Handler:    _TradingService_RunCapitalGains_Handler,
+		},
+		{
+			MethodName: "ListTaxDebts",
+			Handler:    _TradingService_ListTaxDebts_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/bank/cron.go
+++ b/internal/bank/cron.go
@@ -18,12 +18,21 @@ func (s *Server) StartScheduler() func() {
 	go s.runOnSchedule(ctx, 6, always, s.RunDailyInstallmentCollection)
 	// Spec p.39: zero each agent's used_limit at end of day so the next day starts fresh.
 	go s.runOnScheduleAt(ctx, 23, 59, always, s.RunDailyUsedLimitReset)
+	// Spec p.63: capital-gains tax sweeps at the end of the calendar month.
+	// Scheduled at 23:50 on the last day so it fires before the day-end
+	// limit-reset at 23:59 (no overlap, deterministic ordering).
+	go s.runOnScheduleAt(ctx, 23, 50, isLastOfMonth, s.RunMonthlyCapitalGainsCollection)
 
 	return cancel
 }
 
 func always(time.Time) bool           { return true }
 func isFirstOfMonth(t time.Time) bool { return t.Day() == 1 }
+
+// isLastOfMonth returns true when t is the calendar last day of its month —
+// "tomorrow is the 1st". Robust against month length (28/29/30/31) without
+// hard-coding day numbers.
+func isLastOfMonth(t time.Time) bool { return t.AddDate(0, 0, 1).Day() == 1 }
 
 // poor man's cron - wakes up at the target hour, runs fn if filter says yes
 func (s *Server) runOnSchedule(ctx context.Context, hour int, filter func(time.Time) bool, fn func()) {

--- a/internal/bank/tax.go
+++ b/internal/bank/tax.go
@@ -1,0 +1,230 @@
+package bank
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// CapitalGainsCollectionResult summarizes one tax-collection run. AccountsPaid
+// is the number of (account_id) buckets fully debited; RowsPaid is the count
+// of capital_gains rows marked paid; Insufficient counts buckets we couldn't
+// debit because the account didn't have the funds — those rows stay unpaid
+// for the next collection (spec p.63 doesn't mandate a forced overdraft, and
+// the existing loan-collection cron uses the same "skip and leave unpaid"
+// shape).
+type CapitalGainsCollectionResult struct {
+	Period       string
+	AccountsPaid int
+	RowsPaid     int
+	Insufficient int
+	TotalDebtRSD int64
+	CollectedRSD int64
+}
+
+// CollectCapitalGains debits each placer's account for their unpaid
+// capital_gains tax and credits the state's RSD account. Used by the monthly
+// cron and by the supervisor "Pokreni obračun" button (spec p.63: "Supervizori
+// mogu ručno pokrenuti ovu operaciju putem portala").
+//
+// Pass period="" to sweep every still-unpaid row regardless of period — useful
+// for back-fills where the cron missed a month. A specific YYYY-MM filters to
+// that calendar month only.
+//
+// Each account's debit + credit + paid-at update runs in its own transaction
+// so an underfunded placer doesn't block collection from everyone else.
+func (s *Server) CollectCapitalGains(period string) (CapitalGainsCollectionResult, error) {
+	res := CapitalGainsCollectionResult{Period: period}
+	if s.db_gorm == nil {
+		return res, status.Error(codes.Internal, "gorm db not initialized")
+	}
+
+	stateAccount, err := lookupStateRSDAccount(s.db_gorm)
+	if err != nil {
+		return res, err
+	}
+
+	type bucket struct {
+		AccountID int64
+		Total     int64
+	}
+	var buckets []bucket
+	q := s.db_gorm.Table("capital_gains").
+		Select("account_id, SUM(tax_due) AS total").
+		Where("paid_at IS NULL")
+	if period != "" {
+		q = q.Where("period = ?", period)
+	}
+	if err := q.Group("account_id").Having("SUM(tax_due) > 0").Scan(&buckets).Error; err != nil {
+		return res, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	for _, b := range buckets {
+		res.TotalDebtRSD += b.Total
+		paid, rows, err := s.collectOneAccount(stateAccount, b.AccountID, b.Total, period)
+		if err != nil {
+			log.Printf("[Cron] capital-gains collect account=%d: %v", b.AccountID, err)
+			continue
+		}
+		if !paid {
+			res.Insufficient++
+			continue
+		}
+		res.AccountsPaid++
+		res.RowsPaid += rows
+		res.CollectedRSD += b.Total
+	}
+	return res, nil
+}
+
+// stateRSDAccount is the destination for tax transfers. Identified by
+// companies.tax_code=1 (the state company seeded in seed.sql), with the
+// currency pinned to RSD per Napomena 2 on spec p.63.
+type stateRSDAccount struct {
+	ID     int64
+	Number string
+}
+
+func lookupStateRSDAccount(db *gorm.DB) (stateRSDAccount, error) {
+	var out stateRSDAccount
+	err := db.Raw(`
+		SELECT a.id, a.number FROM accounts a
+		JOIN companies co ON co.id = a.company_id
+		WHERE co.tax_code = 1 AND a.currency = 'RSD' AND a.active
+		ORDER BY a.id ASC
+		LIMIT 1
+	`).Scan(&out).Error
+	if err != nil {
+		return out, status.Errorf(codes.Internal, "%v", err)
+	}
+	if out.ID == 0 {
+		return out, status.Error(codes.FailedPrecondition, "state RSD account missing (tax_code=1)")
+	}
+	return out, nil
+}
+
+// collectOneAccount debits a single placer account for its unpaid tax total
+// and credits the state account. Returns (paid, rowsPaid). paid=false signals
+// insufficient funds — the rows stay unpaid for the next run.
+func (s *Server) collectOneAccount(state stateRSDAccount, accountID, totalRSD int64, period string) (bool, int, error) {
+	if totalRSD <= 0 {
+		return true, 0, nil
+	}
+
+	var paid bool
+	var rowsPaid int
+	err := s.db_gorm.Transaction(func(tx *gorm.DB) error {
+		// Lock the source account to serialize the debit against any concurrent
+		// trading/loan flow. Same FOR UPDATE pattern as elsewhere in the bank
+		// package — without it a parallel transaction could read a stale
+		// balance and over-/under-debit.
+		var acc Account
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&acc, accountID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return status.Error(codes.NotFound, "source account missing")
+			}
+			return status.Errorf(codes.Internal, "%v", err)
+		}
+
+		debitAmount, err := convertRSDToAccountCcy(tx, acc.Currency, totalRSD)
+		if err != nil {
+			return err
+		}
+
+		// Atomic debit gated on balance: a 0-row update means the placer
+		// can't cover the tax this run. We let the cron skip them rather
+		// than overdrafting (spec p.63 is silent on overdrafts and our
+		// loan-collection cron makes the same call).
+		debitRes := tx.Exec(
+			`UPDATE accounts SET balance = balance - ? WHERE id = ? AND balance >= ?`,
+			debitAmount, accountID, debitAmount,
+		)
+		if debitRes.Error != nil {
+			return status.Errorf(codes.Internal, "%v", debitRes.Error)
+		}
+		if debitRes.RowsAffected == 0 {
+			// Insufficient funds — bail without erroring; outer layer counts
+			// these for the supervisor portal summary.
+			return errInsufficientFunds
+		}
+
+		// Credit the state's RSD account. Spec p.63 Napomena 2: država ima
+		// samo RSD račun, so credit is always in RSD regardless of source.
+		credRes := tx.Exec(
+			`UPDATE accounts SET balance = balance + ? WHERE id = ?`,
+			totalRSD, state.ID,
+		)
+		if credRes.Error != nil {
+			return status.Errorf(codes.Internal, "%v", credRes.Error)
+		}
+		if credRes.RowsAffected == 0 {
+			return status.Error(codes.Internal, "state account update affected no rows")
+		}
+
+		now := time.Now()
+		updateQ := tx.Table("capital_gains").
+			Where("account_id = ? AND paid_at IS NULL", accountID)
+		if period != "" {
+			updateQ = updateQ.Where("period = ?", period)
+		}
+		mark := updateQ.Update("paid_at", now)
+		if mark.Error != nil {
+			return status.Errorf(codes.Internal, "%v", mark.Error)
+		}
+		rowsPaid = int(mark.RowsAffected)
+		paid = true
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, errInsufficientFunds) {
+			return false, 0, nil
+		}
+		return false, 0, err
+	}
+	return paid, rowsPaid, nil
+}
+
+// errInsufficientFunds is the sentinel the per-account transaction returns
+// when the balance check fails, so the outer collector can roll the tx back
+// and continue with the remaining accounts.
+var errInsufficientFunds = fmt.Errorf("insufficient funds")
+
+// convertRSDToAccountCcy turns the recorded RSD tax debt back into the source
+// account's currency for the debit. RSD accounts skip the rate lookup.
+// Rounding is up so the placer never under-pays the recorded RSD amount when
+// rates create a fractional result.
+func convertRSDToAccountCcy(tx *gorm.DB, accCurrency string, totalRSD int64) (int64, error) {
+	if accCurrency == "RSD" {
+		return totalRSD, nil
+	}
+	var rate ExchangeRate
+	if err := tx.Where("currency_code = ?", accCurrency).First(&rate).Error; err != nil {
+		return 0, status.Errorf(codes.Internal, "exchange rate for %s: %v", accCurrency, err)
+	}
+	if rate.Rate_to_rsd <= 0 {
+		return 0, status.Errorf(codes.Internal, "non-positive exchange rate for %s", accCurrency)
+	}
+	return int64(math.Ceil(float64(totalRSD) / rate.Rate_to_rsd)), nil
+}
+
+// RunMonthlyCapitalGainsCollection is the cron entrypoint — kicks off the
+// collection for the current calendar month. Logged the same way as the
+// loan-collection cron so operators can scrape the same prefix.
+func (s *Server) RunMonthlyCapitalGainsCollection() {
+	period := time.Now().Format("2006-01")
+	log.Printf("[Cron] Running capital-gains collection for %s", period)
+	res, err := s.CollectCapitalGains(period)
+	if err != nil {
+		log.Printf("[Cron] ERROR collecting capital gains: %v", err)
+		return
+	}
+	log.Printf("[Cron] Capital-gains %s: paid=%d accounts (%d rows, %d RSD), insufficient=%d (%d RSD outstanding)",
+		res.Period, res.AccountsPaid, res.RowsPaid, res.CollectedRSD, res.Insufficient, res.TotalDebtRSD-res.CollectedRSD)
+}

--- a/internal/bank/tax_test.go
+++ b/internal/bank/tax_test.go
@@ -1,0 +1,187 @@
+package bank
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestIsLastOfMonth pins the cron filter so the capital-gains sweep doesn't
+// drift onto the wrong day around month boundaries (Feb 28/29, 30/31 months).
+func TestIsLastOfMonth(t *testing.T) {
+	cases := []struct {
+		name string
+		t    time.Time
+		want bool
+	}{
+		{"jan 31", time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC), true},
+		{"jan 30", time.Date(2026, 1, 30, 0, 0, 0, 0, time.UTC), false},
+		{"feb 28 non-leap", time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC), true},
+		{"feb 28 leap", time.Date(2024, 2, 28, 0, 0, 0, 0, time.UTC), false},
+		{"feb 29 leap", time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC), true},
+		{"apr 30", time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), true},
+		{"apr 29", time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC), false},
+		{"dec 31", time.Date(2026, 12, 31, 23, 59, 0, 0, time.UTC), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isLastOfMonth(c.t); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCollectCapitalGains_HappyPath_RSD walks through the simplest collection
+// shape: one RSD-denominated bucket. Confirms the lookup → bucket scan →
+// per-account debit/credit/mark-paid cycle hits all the right rows and that
+// the result counters add up.
+func TestCollectCapitalGains_HappyPath_RSD(t *testing.T) {
+	server, mock, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	// State RSD account lookup
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT a.id, a.number FROM accounts a`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "number"}).
+			AddRow(int64(99), "333000100000099910"))
+
+	// Bucket scan: one account owes 5000 RSD
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT account_id, SUM(tax_due) AS total FROM "capital_gains" WHERE paid_at IS NULL AND period = $1 GROUP BY "account_id" HAVING SUM(tax_due) > 0`)).
+		WithArgs("2026-04").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "total"}).
+			AddRow(int64(7), int64(5000)))
+
+	// Per-account tx
+	mock.ExpectBegin()
+	// FOR UPDATE select on the account
+	mock.ExpectQuery(`SELECT \* FROM "accounts" WHERE "accounts"\."id" = \$1 .* FOR UPDATE`).
+		WithArgs(int64(7), 1).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "number", "name", "owner", "company_id", "balance",
+			"created_by", "created_at", "valid_until", "currency", "active",
+			"owner_type", "account_type", "maintainance_cost",
+			"daily_limit", "monthly_limit", "daily_expenditure", "monthly_expenditure",
+		}).AddRow(
+			int64(7), "111", "client RSD", int64(1), nil, int64(100_000),
+			int64(1), time.Now(), time.Now().AddDate(1, 0, 0), "RSD", true,
+			"personal", "checking", int64(0),
+			nil, nil, nil, nil,
+		))
+
+	// Debit user account
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE accounts SET balance = balance - $1`)).
+		WithArgs(int64(5000), int64(7), int64(5000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// Credit state account
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE accounts SET balance = balance + $1`)).
+		WithArgs(int64(5000), int64(99)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// Mark rows paid
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "capital_gains" SET "paid_at"=$1 WHERE (account_id = $2 AND paid_at IS NULL) AND period = $3`)).
+		WithArgs(sqlmock.AnyArg(), int64(7), "2026-04").
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectCommit()
+
+	res, err := server.CollectCapitalGains("2026-04")
+	if err != nil {
+		t.Fatalf("CollectCapitalGains: %v", err)
+	}
+	if res.AccountsPaid != 1 {
+		t.Errorf("AccountsPaid: got %d, want 1", res.AccountsPaid)
+	}
+	if res.RowsPaid != 3 {
+		t.Errorf("RowsPaid: got %d, want 3", res.RowsPaid)
+	}
+	if res.CollectedRSD != 5000 {
+		t.Errorf("CollectedRSD: got %d, want 5000", res.CollectedRSD)
+	}
+	if res.TotalDebtRSD != 5000 {
+		t.Errorf("TotalDebtRSD: got %d, want 5000", res.TotalDebtRSD)
+	}
+	if res.Insufficient != 0 {
+		t.Errorf("Insufficient: got %d, want 0", res.Insufficient)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestCollectCapitalGains_InsufficientFunds confirms the per-account
+// transaction is rolled back when the placer can't cover the tax, and that
+// the result counter increments instead of erroring out so the surrounding
+// loop continues with the remaining accounts.
+func TestCollectCapitalGains_InsufficientFunds(t *testing.T) {
+	server, mock, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT a.id, a.number FROM accounts a`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "number"}).
+			AddRow(int64(99), "333000100000099910"))
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT account_id, SUM(tax_due) AS total FROM "capital_gains" WHERE paid_at IS NULL AND period = $1 GROUP BY "account_id" HAVING SUM(tax_due) > 0`)).
+		WithArgs("2026-04").
+		WillReturnRows(sqlmock.NewRows([]string{"account_id", "total"}).
+			AddRow(int64(7), int64(50_000)))
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT \* FROM "accounts" WHERE "accounts"\."id" = \$1 .* FOR UPDATE`).
+		WithArgs(int64(7), 1).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "number", "name", "owner", "company_id", "balance",
+			"created_by", "created_at", "valid_until", "currency", "active",
+			"owner_type", "account_type", "maintainance_cost",
+			"daily_limit", "monthly_limit", "daily_expenditure", "monthly_expenditure",
+		}).AddRow(
+			int64(7), "111", "client RSD", int64(1), nil, int64(10_000),
+			int64(1), time.Now(), time.Now().AddDate(1, 0, 0), "RSD", true,
+			"personal", "checking", int64(0),
+			nil, nil, nil, nil,
+		))
+	// Balance check fails → 0 rows affected
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE accounts SET balance = balance - $1`)).
+		WithArgs(int64(50_000), int64(7), int64(50_000)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	res, err := server.CollectCapitalGains("2026-04")
+	if err != nil {
+		t.Fatalf("CollectCapitalGains: %v", err)
+	}
+	if res.AccountsPaid != 0 {
+		t.Errorf("AccountsPaid: got %d, want 0", res.AccountsPaid)
+	}
+	if res.Insufficient != 1 {
+		t.Errorf("Insufficient: got %d, want 1", res.Insufficient)
+	}
+	if res.CollectedRSD != 0 {
+		t.Errorf("CollectedRSD: got %d, want 0", res.CollectedRSD)
+	}
+	if res.TotalDebtRSD != 50_000 {
+		t.Errorf("TotalDebtRSD: got %d, want 50000", res.TotalDebtRSD)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestCollectCapitalGains_StateAccountMissing surfaces the failure mode where
+// the seed didn't run (or the tax_code=1 row was deleted): the cron should
+// bail instead of silently doing nothing.
+func TestCollectCapitalGains_StateAccountMissing(t *testing.T) {
+	server, mock, db := newGormTestServer(t)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT a.id, a.number FROM accounts a`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "number"}))
+
+	if _, err := server.CollectCapitalGains("2026-04"); err == nil {
+		t.Fatalf("expected error when state account is missing")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -191,6 +191,15 @@ func SetupApi(router *gin.Engine, server *Server) {
 	// market hours (see spec p.40 and issue #194). Admin bypass still applies
 	// through `secured("supervisor")`.
 	api.PATCH("/exchanges/:id/open-override", auth, secured("supervisor"), server.SetExchangeOpenOverride)
+
+	// Supervisor tax portal (spec p.63 / #209). Manual "Pokreni obračun"
+	// button + the per-user dugovanja listing. Supervisor-only at the
+	// gateway; the trading RPC re-checks defense-in-depth.
+	tax := api.Group("/tax", auth, secured("supervisor"))
+	{
+		tax.POST("/run", server.RunCapitalGains)
+		tax.GET("/debts", server.ListTaxDebts)
+	}
 }
 
 func (s *Server) Healthz(c *gin.Context) {

--- a/internal/gateway/tax.go
+++ b/internal/gateway/tax.go
@@ -1,0 +1,73 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"github.com/gin-gonic/gin"
+)
+
+// RunCapitalGains backs `POST /api/tax/run?month=YYYY-MM`. Supervisor-only;
+// the trading RPC re-checks the caller's permissions. Empty `month` runs a
+// back-fill across every still-unpaid period (spec p.63 doesn't define a
+// strict semantics for the manual button — letting the supervisor scope the
+// run by month is the more useful version).
+func (s *Server) RunCapitalGains(c *gin.Context) {
+	month := c.Query("month")
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.RunCapitalGains(ctx, &tradingpb.RunCapitalGainsRequest{
+		CallerEmail: c.GetString("email"),
+		Month:       month,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"period":         resp.Period,
+		"accounts_paid":  resp.AccountsPaid,
+		"rows_paid":      resp.RowsPaid,
+		"insufficient":   resp.Insufficient,
+		"total_debt_rsd": resp.TotalDebtRsd,
+		"collected_rsd":  resp.CollectedRsd,
+	})
+}
+
+// ListTaxDebts backs `GET /api/tax/debts?team=client|actuary&name=...`.
+// Supervisor-only; the trading RPC re-checks the caller's permissions and
+// validates the team filter (anything other than client/actuary/empty
+// returns InvalidArgument).
+func (s *Server) ListTaxDebts(c *gin.Context) {
+	team := c.Query("team")
+	name := c.Query("name")
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.ListTaxDebts(ctx, &tradingpb.ListTaxDebtsRequest{
+		CallerEmail: c.GetString("email"),
+		Team:        team,
+		Name:        name,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(resp.Debtors))
+	for _, d := range resp.Debtors {
+		out = append(out, gin.H{
+			"user_id":    d.UserId,
+			"first_name": d.FirstName,
+			"last_name":  d.LastName,
+			"team":       d.Team,
+			"unpaid_rsd": d.UnpaidRsd,
+			"paid_rsd":   d.PaidRsd,
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/internal/trading/tax.go
+++ b/internal/trading/tax.go
@@ -1,0 +1,139 @@
+package trading
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// monthRe pins the month filter to YYYY-MM so a malformed value can't slip
+// into the SQL `period = ?` predicate. Empty string is allowed and means
+// "every still-unpaid period" (used by manual back-fill runs).
+var monthRe = regexp.MustCompile(`^[0-9]{4}-(0[1-9]|1[0-2])$`)
+
+// teamFilterClient and teamFilterActuary are the two values the supervisor
+// portal uses for its team filter (spec p.63 "filteri po timu korisnika
+// (klijent, aktuar)"). Anything else is rejected with InvalidArgument.
+const (
+	teamFilterClient  = "client"
+	teamFilterActuary = "actuary"
+)
+
+// RunCapitalGains is the supervisor "Pokreni obračun" button (spec p.63).
+// Delegates to bank.CollectCapitalGains so the cron and the manual trigger
+// share one code path. Supervisor-only at the trading layer; the gateway
+// also gates the route with `secured("supervisor")`.
+func (s *Server) RunCapitalGains(_ context.Context, req *tradingpb.RunCapitalGainsRequest) (*tradingpb.RunCapitalGainsResponse, error) {
+	if !callerIsSupervisor(s.db, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "supervisor permission required")
+	}
+	month := strings.TrimSpace(req.Month)
+	if month != "" && !monthRe.MatchString(month) {
+		return nil, status.Error(codes.InvalidArgument, "month must be YYYY-MM")
+	}
+
+	res, err := s.bank.CollectCapitalGains(month)
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.RunCapitalGainsResponse{
+		Period:       res.Period,
+		AccountsPaid: int32(res.AccountsPaid),
+		RowsPaid:     int32(res.RowsPaid),
+		Insufficient: int32(res.Insufficient),
+		TotalDebtRsd: res.TotalDebtRSD,
+		CollectedRsd: res.CollectedRSD,
+	}, nil
+}
+
+// ListTaxDebts powers the supervisor tax portal listing (spec p.63). Returns
+// every user that has at least one capital_gains row, with both their unpaid
+// and historically-paid RSD totals so the UI can show both columns. Filtering
+// scopes the result by team (client/actuary) and by a case-insensitive
+// substring on first or last name.
+//
+// Users with zero rows are intentionally not returned — the spec frames this
+// portal as "users who can trade", and listing every dormant client/employee
+// in the system would drown the actually-relevant rows.
+func (s *Server) ListTaxDebts(_ context.Context, req *tradingpb.ListTaxDebtsRequest) (*tradingpb.ListTaxDebtsResponse, error) {
+	if !callerIsSupervisor(s.db, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "supervisor permission required")
+	}
+	team := strings.ToLower(strings.TrimSpace(req.Team))
+	switch team {
+	case "", teamFilterClient, teamFilterActuary:
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "team must be %q or %q", teamFilterClient, teamFilterActuary)
+	}
+	name := strings.TrimSpace(req.Name)
+
+	type debtorRow struct {
+		UserID    int64
+		FirstName string
+		LastName  string
+		Team      string
+		UnpaidRsd int64
+		PaidRsd   int64
+	}
+
+	// One row per (placer-side identity). The CASE on placer columns derives
+	// the team label without an extra join chain. Filters apply at the SQL
+	// level so the client-side never sees rows it shouldn't, and the LIKE is
+	// parametrized to keep the filter injection-safe.
+	var rows []debtorRow
+	q := s.db.Table("capital_gains AS cg").
+		Select(`
+			COALESCE(c.id, e.id) AS user_id,
+			COALESCE(c.first_name, e.first_name) AS first_name,
+			COALESCE(c.last_name, e.last_name) AS last_name,
+			CASE WHEN p.client_id IS NOT NULL THEN 'client' ELSE 'actuary' END AS team,
+			COALESCE(SUM(CASE WHEN cg.paid_at IS NULL THEN cg.tax_due ELSE 0 END), 0) AS unpaid_rsd,
+			COALESCE(SUM(CASE WHEN cg.paid_at IS NOT NULL THEN cg.tax_due ELSE 0 END), 0) AS paid_rsd
+		`).
+		Joins("JOIN order_placers p ON p.id = cg.seller_placer_id").
+		Joins("LEFT JOIN clients   c ON c.id = p.client_id").
+		Joins("LEFT JOIN employees e ON e.id = p.employee_id")
+
+	switch team {
+	case teamFilterClient:
+		q = q.Where("p.client_id IS NOT NULL")
+	case teamFilterActuary:
+		q = q.Where("p.employee_id IS NOT NULL")
+	}
+	if name != "" {
+		like := "%" + name + "%"
+		q = q.Where(`
+			COALESCE(c.first_name, e.first_name) ILIKE ?
+			OR COALESCE(c.last_name, e.last_name) ILIKE ?
+		`, like, like)
+	}
+	q = q.Group(`COALESCE(c.id, e.id),
+		COALESCE(c.first_name, e.first_name),
+		COALESCE(c.last_name, e.last_name),
+		CASE WHEN p.client_id IS NOT NULL THEN 'client' ELSE 'actuary' END`).
+		Order("unpaid_rsd DESC, last_name ASC, first_name ASC")
+
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+
+	out := make([]*tradingpb.TaxDebtor, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, &tradingpb.TaxDebtor{
+			UserId:    r.UserID,
+			FirstName: r.FirstName,
+			LastName:  r.LastName,
+			Team:      r.Team,
+			UnpaidRsd: r.UnpaidRsd,
+			PaidRsd:   r.PaidRsd,
+		})
+	}
+	return &tradingpb.ListTaxDebtsResponse{Debtors: out}, nil
+}

--- a/internal/trading/tax_test.go
+++ b/internal/trading/tax_test.go
@@ -1,0 +1,134 @@
+package trading
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// newTaxTestServer wires a Server backed by sqlmock for the supervisor-check
+// query alone — every other interaction in the tax RPCs lives behind that
+// gate, so individual tests only need to set up the supervisor lookup.
+func newTaxTestServer(t *testing.T) (*Server, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	raw, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: raw}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return &Server{db: gdb}, mock, func() { _ = raw.Close() }
+}
+
+// expectSupervisorCheck stubs the callerIsSupervisor query so the caller is
+// recognized (count > 0) or rejected (count == 0). The exact SQL is private
+// to callerIsSupervisor in orders_portal.go.
+func expectSupervisorCheck(mock sqlmock.Sqlmock, email string, allowed bool) {
+	count := int64(0)
+	if allowed {
+		count = 1
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT count(*) FROM "employees" JOIN employee_permissions ep ON ep.employee_id = employees.id JOIN permissions p ON p.id = ep.permission_id WHERE employees.email = $1 AND p.name IN ($2,$3)`)).
+		WithArgs(email, "admin", "supervisor").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+func TestRunCapitalGains_RejectsNonSupervisor(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+	expectSupervisorCheck(mock, "agent@banka.raf", false)
+
+	_, err := srv.RunCapitalGains(context.Background(), &tradingpb.RunCapitalGainsRequest{
+		CallerEmail: "agent@banka.raf",
+		Month:       "2026-04",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("got %s, want PermissionDenied", status.Code(err))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunCapitalGains_RejectsBadMonth(t *testing.T) {
+	cases := []string{"2026/04", "2026-13", "2026-1", "abcd-ef", "2026-04-01"}
+	for _, m := range cases {
+		t.Run(m, func(t *testing.T) {
+			srv, mock, done := newTaxTestServer(t)
+			defer done()
+			expectSupervisorCheck(mock, "sup@banka.raf", true)
+
+			_, err := srv.RunCapitalGains(context.Background(), &tradingpb.RunCapitalGainsRequest{
+				CallerEmail: "sup@banka.raf",
+				Month:       m,
+			})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("month=%q: got %s, want InvalidArgument", m, status.Code(err))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestListTaxDebts_RejectsNonSupervisor(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+	expectSupervisorCheck(mock, "client@banka.raf", false)
+
+	_, err := srv.ListTaxDebts(context.Background(), &tradingpb.ListTaxDebtsRequest{
+		CallerEmail: "client@banka.raf",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Errorf("got %s, want PermissionDenied", status.Code(err))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListTaxDebts_RejectsBadTeam(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+	expectSupervisorCheck(mock, "sup@banka.raf", true)
+
+	_, err := srv.ListTaxDebts(context.Background(), &tradingpb.ListTaxDebtsRequest{
+		CallerEmail: "sup@banka.raf",
+		Team:        "supervisor",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("got %s, want InvalidArgument", status.Code(err))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestMonthRegex pins the YYYY-MM filter so a regex tweak doesn't accidentally
+// admit malformed periods (which would silently match zero rows in the
+// `period = ?` predicate at collection time).
+func TestMonthRegex(t *testing.T) {
+	good := []string{"2026-01", "2026-12", "1999-09", "0000-10"}
+	bad := []string{"", "2026-00", "2026-13", "2026-1", "2026-001", "2026/01", "abc-12"}
+	for _, m := range good {
+		if !monthRe.MatchString(m) {
+			t.Errorf("month %q should match", m)
+		}
+	}
+	for _, m := range bad {
+		if monthRe.MatchString(m) {
+			t.Errorf("month %q should NOT match", m)
+		}
+	}
+}

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -22,6 +22,8 @@ service TradingService {
   rpc SellHolding(SellHoldingRequest) returns (SellHoldingResponse);
   rpc SetHoldingPublic(SetHoldingPublicRequest) returns (SetHoldingPublicResponse);
   rpc ExerciseOption(ExerciseOptionRequest) returns (ExerciseOptionResponse);
+  rpc RunCapitalGains(RunCapitalGainsRequest) returns (RunCapitalGainsResponse);
+  rpc ListTaxDebts(ListTaxDebtsRequest) returns (ListTaxDebtsResponse);
 }
 
 message Exchange {
@@ -409,4 +411,48 @@ message ExerciseOptionRequest {
 message ExerciseOptionResponse {
   int64 payout = 1;
   int64 quantity = 2;
+}
+
+// Supervisor-only manual trigger for the monthly capital-gains tax sweep
+// (spec p.63 "Supervizori mogu ručno pokrenuti ovu operaciju putem portala").
+// month is YYYY-MM; passing an empty string sweeps every still-unpaid row
+// regardless of period — useful for back-fills.
+message RunCapitalGainsRequest {
+  string caller_email = 1;
+  string month = 2;
+}
+
+message RunCapitalGainsResponse {
+  string period = 1;
+  int32 accounts_paid = 2;
+  int32 rows_paid = 3;
+  int32 insufficient = 4;
+  int64 total_debt_rsd = 5;
+  int64 collected_rsd = 6;
+}
+
+// TaxDebtor is one user's current unpaid RSD tax debt summed across all of
+// their accounts (spec p.63: "Dugovanja korisnika prikazana su u RSD"). team
+// is "client" or "actuary". Users without any capital-gains rows are not
+// listed — the portal scopes itself to participants in the trading flow.
+message TaxDebtor {
+  int64 user_id = 1;
+  string first_name = 2;
+  string last_name = 3;
+  string team = 4;
+  int64 unpaid_rsd = 5;
+  int64 paid_rsd = 6;
+}
+
+// Filters mirror the spec's two portal filters: team (klijent/aktuar) and
+// name (case-insensitive substring on first or last name). Empty values
+// disable the corresponding filter.
+message ListTaxDebtsRequest {
+  string caller_email = 1;
+  string team = 2;
+  string name = 3;
+}
+
+message ListTaxDebtsResponse {
+  repeated TaxDebtor debtors = 1;
 }


### PR DESCRIPTION
## Summary
- End-of-month cron (`bank.RunMonthlyCapitalGainsCollection`, scheduled at 23:50 on the last day of each month) groups unpaid `capital_gains` by `account_id`, debits each placer in their source-account currency (converting the recorded RSD amount up at the current FX rate), credits the state's RSD account (`companies.tax_code=1`), and stamps `paid_at`. Underfunded accounts roll back per-account and surface as `Insufficient` in the result without blocking the rest.
- `POST /api/tax/run?month=YYYY-MM` — supervisor-only manual trigger that delegates to the same collector (spec p.63 "Supervizori mogu ručno pokrenuti"). Empty `month` back-fills every still-unpaid period.
- `GET /api/tax/debts?team=client|actuary&name=...` — supervisor-only per-user unpaid + paid RSD totals; team filter scopes by placer kind and `name` is a case-insensitive substring on first or last name (spec p.63 "filteri po timu i imenu i prezimenu").

## Test plan
- [x] `go test ./...` — bank cron filter (`isLastOfMonth`), happy-path RSD collection, insufficient-funds skip, missing-state-account error
- [x] `go test ./internal/trading/...` — RPC supervisor checks + `month=YYYY-MM` regex + team filter validation
- [ ] Manual: trigger `POST /api/tax/run?month=2026-04` after a sell-fill and confirm placer balance drops, state RSD balance grows, rows show `paid_at`
- [ ] Manual: hit `GET /api/tax/debts?team=client&name=ana` and confirm filtering + RSD totals

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)