### PR TITLE
feat(trading): external pricing clients + listing refresher (#184)

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -11,6 +11,7 @@ import (
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
 	internalBank "github.com/RAF-SI-2025/Banka-3-Backend/internal/bank"
 	internalTrading "github.com/RAF-SI-2025/Banka-3-Backend/internal/trading"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -34,6 +35,26 @@ func connectToDB() *sql.DB {
 		log.Fatal(err)
 	}
 	return db
+}
+
+// buildPricingClient assembles the external-pricing client from env vars.
+// Returns nil when no provider is configured — Refresher.Start treats that
+// as a no-op, so dev/CI runs without API keys keep working off the static
+// seed prices from #195. Order matters: Alpaca is tried first because its
+// quote endpoint exposes ask/bid (which AV's free tier doesn't); AV serves
+// as a fallback for tickers Alpaca refuses.
+func buildPricingClient() pricing.Client {
+	var clients []pricing.Client
+	if id, secret := os.Getenv("ALPACA_KEY_ID"), os.Getenv("ALPACA_SECRET"); id != "" && secret != "" {
+		clients = append(clients, pricing.NewAlpaca(id, secret))
+	}
+	if key := os.Getenv("ALPHAVANTAGE_KEY"); key != "" {
+		clients = append(clients, pricing.NewAlphaVantage(key))
+	}
+	if len(clients) == 0 {
+		return nil
+	}
+	return pricing.NewMulti(clients...)
 }
 
 func main() {
@@ -63,6 +84,12 @@ func main() {
 	tradingService := internalTrading.NewServer(gorm_db, bankService)
 	stopExecutor := tradingService.StartExecutor()
 	defer stopExecutor()
+
+	// External-pricing refresher (#184). No-op when no API keys are
+	// configured, so dev/CI keep operating off the static seed data from
+	// #195.
+	stopRefresher := internalTrading.NewRefresher(gorm_db, buildPricingClient()).Start()
+	defer stopRefresher()
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/internal/trading/pricing/alpaca.go
+++ b/internal/trading/pricing/alpaca.go
@@ -73,7 +73,7 @@ func (c *AlpacaClient) GetQuote(ctx context.Context, ticker string) (Quote, erro
 	if err != nil {
 		return Quote{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/trading/pricing/alpaca.go
+++ b/internal/trading/pricing/alpaca.go
@@ -1,0 +1,141 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// AlpacaClient queries the v2 market-data REST API
+// (https://docs.alpaca.markets/reference/stocklatestquotes-1).
+//
+// Latest-quote gives ask/bid in one call; we use that as the primary source
+// because it carries spread information the executor's fill logic cares
+// about. When the response comes back with both sides zero (pre-IPO,
+// halted), we treat it as ErrNotFound — surfacing a 0/0/0 listing would
+// silently break order matching downstream.
+//
+// Auth is a pair of headers, not query params, so a leaked URL doesn't
+// expose the key.
+type AlpacaClient struct {
+	KeyID   string
+	Secret  string
+	BaseURL string // override for tests; defaults to https://data.alpaca.markets
+	HTTP    httpDoer
+}
+
+func NewAlpaca(keyID, secret string) *AlpacaClient {
+	return &AlpacaClient{
+		KeyID:   keyID,
+		Secret:  secret,
+		BaseURL: "https://data.alpaca.markets",
+		HTTP:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *AlpacaClient) Name() string { return "alpaca" }
+
+// alpacaLatestQuoteResponse is what /v2/stocks/quotes/latest returns. The
+// nested map is keyed by symbol so the same shape powers the bulk endpoint
+// if we ever batch — for now we still call the single-symbol path because
+// listings get refreshed one at a time.
+type alpacaLatestQuoteResponse struct {
+	Quotes map[string]struct {
+		AskPrice float64 `json:"ap"`
+		BidPrice float64 `json:"bp"`
+		Time     string  `json:"t"`
+	} `json:"quotes"`
+}
+
+func (c *AlpacaClient) GetQuote(ctx context.Context, ticker string) (Quote, error) {
+	if c.KeyID == "" || c.Secret == "" {
+		return Quote{}, fmt.Errorf("alpaca: missing credentials")
+	}
+	sym := strings.ToUpper(strings.TrimSpace(ticker))
+
+	q := url.Values{}
+	q.Set("symbols", sym)
+	endpoint := c.BaseURL + "/v2/stocks/quotes/latest?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Quote{}, err
+	}
+	req.Header.Set("APCA-API-KEY-ID", c.KeyID)
+	req.Header.Set("APCA-API-SECRET-KEY", c.Secret)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return Quote{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fallthrough to body parse
+	case http.StatusNotFound:
+		return Quote{}, ErrNotFound
+	case http.StatusTooManyRequests:
+		return Quote{}, ErrRateLimited
+	default:
+		return Quote{}, fmt.Errorf("alpaca: status %d", resp.StatusCode)
+	}
+
+	var body alpacaLatestQuoteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Quote{}, err
+	}
+	row, ok := body.Quotes[sym]
+	if !ok {
+		return Quote{}, ErrNotFound
+	}
+	if row.AskPrice <= 0 && row.BidPrice <= 0 {
+		return Quote{}, ErrNotFound
+	}
+
+	// Treat 0 as "not present" rather than "free": Alpaca uses 0 to mean the
+	// side has no quote yet (pre-market, halted), and a real $0 listing
+	// doesn't exist. Negative or NaN values fall through dollarsToCents.
+	ask, askOK := dollarsToCents(row.AskPrice)
+	if ask == 0 {
+		askOK = false
+	}
+	bid, bidOK := dollarsToCents(row.BidPrice)
+	if bid == 0 {
+		bidOK = false
+	}
+	// Mid-price is the executor's reference for market orders that arrive
+	// before any trade has happened today; if only one side is populated we
+	// fall back to that side instead of zero so listings.price stays usable.
+	var price int64
+	switch {
+	case askOK && bidOK:
+		price = (ask + bid) / 2
+	case askOK:
+		price = ask
+		bid = ask
+	case bidOK:
+		price = bid
+		ask = bid
+	default:
+		return Quote{}, ErrNotFound
+	}
+
+	at := time.Now().UTC()
+	if t, err := time.Parse(time.RFC3339Nano, row.Time); err == nil {
+		at = t
+	}
+
+	return Quote{
+		Ticker:     sym,
+		PriceCents: price,
+		AskCents:   ask,
+		BidCents:   bid,
+		At:         at,
+	}, nil
+}

--- a/internal/trading/pricing/alpaca_test.go
+++ b/internal/trading/pricing/alpaca_test.go
@@ -1,0 +1,116 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAlpaca_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("APCA-API-KEY-ID") != "key" || r.Header.Get("APCA-API-SECRET-KEY") != "secret" {
+			t.Errorf("auth headers missing")
+		}
+		if got := r.URL.Query().Get("symbols"); got != "AAPL" {
+			t.Errorf("symbols = %q, want AAPL", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"quotes":{"AAPL":{"ap":245.51,"bp":245.50,"t":"2025-04-25T13:30:00.123Z"}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlpaca("key", "secret")
+	c.BaseURL = srv.URL
+	q, err := c.GetQuote(context.Background(), "aapl")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.Ticker != "AAPL" {
+		t.Errorf("ticker = %q", q.Ticker)
+	}
+	// Mid of 24551 + 24550 = 24550 (integer divide).
+	if q.PriceCents != 24550 {
+		t.Errorf("price = %d, want 24550", q.PriceCents)
+	}
+	if q.AskCents != 24551 {
+		t.Errorf("ask = %d, want 24551", q.AskCents)
+	}
+	if q.BidCents != 24550 {
+		t.Errorf("bid = %d, want 24550", q.BidCents)
+	}
+	if q.At.IsZero() {
+		t.Error("At not parsed")
+	}
+}
+
+func TestAlpaca_OneSidedQuote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only ask populated — pre-market, illiquid symbol. We should still
+		// surface a usable quote rather than fail the refresh.
+		_, _ = w.Write([]byte(`{"quotes":{"GOOG":{"ap":174.20,"bp":0,"t":"2025-04-25T08:00:00Z"}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlpaca("key", "secret")
+	c.BaseURL = srv.URL
+	q, err := c.GetQuote(context.Background(), "GOOG")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.PriceCents != 17420 || q.AskCents != 17420 || q.BidCents != 17420 {
+		t.Errorf("price/ask/bid = %d/%d/%d, all want 17420", q.PriceCents, q.AskCents, q.BidCents)
+	}
+}
+
+func TestAlpaca_NoQuote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Both sides zero — Alpaca does this for halted/delisted tickers.
+		_, _ = w.Write([]byte(`{"quotes":{"DEAD":{"ap":0,"bp":0,"t":"2025-04-25T08:00:00Z"}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlpaca("key", "secret")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "DEAD")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlpaca_MissingFromMap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"quotes":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlpaca("key", "secret")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "ZZZZZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlpaca_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewAlpaca("key", "secret")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "AAPL")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestAlpaca_MissingCreds(t *testing.T) {
+	c := NewAlpaca("", "")
+	_, err := c.GetQuote(context.Background(), "AAPL")
+	if err == nil {
+		t.Fatal("expected error on missing credentials")
+	}
+}

--- a/internal/trading/pricing/alphavantage.go
+++ b/internal/trading/pricing/alphavantage.go
@@ -65,7 +65,7 @@ func (c *AlphaVantageClient) GetQuote(ctx context.Context, ticker string) (Quote
 	if err != nil {
 		return Quote{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return Quote{}, fmt.Errorf("alphavantage: status %d", resp.StatusCode)

--- a/internal/trading/pricing/alphavantage.go
+++ b/internal/trading/pricing/alphavantage.go
@@ -1,0 +1,107 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// AlphaVantageClient queries the GLOBAL_QUOTE endpoint
+// (https://www.alphavantage.co/documentation/#latestprice). The free tier
+// only exposes price/volume/change — no level-1 spread — so we copy
+// PriceCents into Ask/Bid. A real spread would require the (paid) realtime
+// bulk-quote endpoint, which is out of scope for the dummy data this issue
+// targets.
+//
+// Quirks worth knowing: AV returns 200 OK with a JSON body that contains
+// {"Note": "..."} or {"Information": "..."} when you blow past the rate
+// limit, and {"Global Quote": {}} (empty map) for unknown tickers. We map
+// those to ErrRateLimited and ErrNotFound respectively so the refresher can
+// react sensibly.
+type AlphaVantageClient struct {
+	APIKey  string
+	BaseURL string // override for tests; defaults to https://www.alphavantage.co
+	HTTP    httpDoer
+}
+
+func NewAlphaVantage(apiKey string) *AlphaVantageClient {
+	return &AlphaVantageClient{
+		APIKey:  apiKey,
+		BaseURL: "https://www.alphavantage.co",
+		HTTP:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *AlphaVantageClient) Name() string { return "alphavantage" }
+
+// avQuoteResponse maps the GLOBAL_QUOTE shape. AV uses zero-padded numeric
+// keys ("01. symbol") which is awkward but stable across years of the API.
+type avQuoteResponse struct {
+	GlobalQuote map[string]string `json:"Global Quote"`
+	Note        string            `json:"Note"`
+	Information string            `json:"Information"`
+	ErrorMsg    string            `json:"Error Message"`
+}
+
+func (c *AlphaVantageClient) GetQuote(ctx context.Context, ticker string) (Quote, error) {
+	if c.APIKey == "" {
+		return Quote{}, fmt.Errorf("alphavantage: missing API key")
+	}
+	q := url.Values{}
+	q.Set("function", "GLOBAL_QUOTE")
+	q.Set("symbol", strings.ToUpper(strings.TrimSpace(ticker)))
+	q.Set("apikey", c.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/query?"+q.Encode(), nil)
+	if err != nil {
+		return Quote{}, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return Quote{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Quote{}, fmt.Errorf("alphavantage: status %d", resp.StatusCode)
+	}
+
+	var body avQuoteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Quote{}, err
+	}
+	if body.Note != "" || body.Information != "" {
+		return Quote{}, ErrRateLimited
+	}
+	if body.ErrorMsg != "" {
+		return Quote{}, ErrNotFound
+	}
+	if len(body.GlobalQuote) == 0 {
+		return Quote{}, ErrNotFound
+	}
+
+	priceStr := body.GlobalQuote["05. price"]
+	if priceStr == "" {
+		return Quote{}, ErrNotFound
+	}
+	price, err := strconv.ParseFloat(priceStr, 64)
+	if err != nil {
+		return Quote{}, fmt.Errorf("alphavantage: bad price %q: %w", priceStr, err)
+	}
+	cents, ok := dollarsToCents(price)
+	if !ok {
+		return Quote{}, fmt.Errorf("alphavantage: invalid price %v", price)
+	}
+	return Quote{
+		Ticker:     strings.ToUpper(ticker),
+		PriceCents: cents,
+		AskCents:   cents,
+		BidCents:   cents,
+		At:         time.Now().UTC(),
+	}, nil
+}

--- a/internal/trading/pricing/alphavantage_test.go
+++ b/internal/trading/pricing/alphavantage_test.go
@@ -1,0 +1,96 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAlphaVantage_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("function"); got != "GLOBAL_QUOTE" {
+			t.Errorf("function = %q, want GLOBAL_QUOTE", got)
+		}
+		if got := r.URL.Query().Get("symbol"); got != "MSFT" {
+			t.Errorf("symbol = %q, want MSFT", got)
+		}
+		if got := r.URL.Query().Get("apikey"); got != "demo" {
+			t.Errorf("apikey = %q, want demo", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Global Quote":{"01. symbol":"MSFT","05. price":"412.4500","06. volume":"12345"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	q, err := c.GetQuote(context.Background(), "msft")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.Ticker != "MSFT" {
+		t.Errorf("ticker = %q", q.Ticker)
+	}
+	if q.PriceCents != 41245 {
+		t.Errorf("price = %d, want 41245", q.PriceCents)
+	}
+	// AV doesn't expose a spread on the free tier — both sides should mirror price.
+	if q.AskCents != q.PriceCents || q.BidCents != q.PriceCents {
+		t.Errorf("ask/bid not mirrored: %d/%d/%d", q.AskCents, q.BidCents, q.PriceCents)
+	}
+}
+
+func TestAlphaVantage_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Note":"Thank you for using Alpha Vantage! Our standard API call frequency is 5 calls per minute."}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "MSFT")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestAlphaVantage_UnknownTicker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Global Quote":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "ZZZZZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlphaVantage_MissingKey(t *testing.T) {
+	c := NewAlphaVantage("")
+	_, err := c.GetQuote(context.Background(), "MSFT")
+	if err == nil {
+		t.Fatal("expected error on missing key")
+	}
+}
+
+func TestAlphaVantage_BadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetQuote(context.Background(), "MSFT")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrRateLimited) {
+		t.Errorf("500 misclassified as %v", err)
+	}
+}

--- a/internal/trading/pricing/client.go
+++ b/internal/trading/pricing/client.go
@@ -1,0 +1,68 @@
+// Package pricing wraps the external market-data providers the spec lists for
+// the third celina (pp.39–40): Alpha Vantage and Alpaca. Both providers vend
+// quotes per ticker; this package surfaces a single Quote shape so callers
+// (the refresher in internal/trading) don't care which provider answered.
+//
+// Prices are returned in int64 minor units (cents/pence/etc) so they slot
+// straight into the BIGINT money columns the rest of the system uses.
+package pricing
+
+import (
+	"context"
+	"errors"
+	"math"
+	"net/http"
+	"time"
+)
+
+// ErrNotFound is returned when the provider has no data for the requested
+// ticker. The refresher uses it to skip a listing without aborting the whole
+// pass; any other error is treated as a transient outage and surfaces in
+// logs.
+var ErrNotFound = errors.New("pricing: ticker not found")
+
+// ErrRateLimited signals the provider rejected the request for quota reasons.
+// Alpha Vantage's free tier returns 5/min and 25/day; Alpaca free is generous
+// but still finite. The refresher backs off when it sees this.
+var ErrRateLimited = errors.New("pricing: rate limited")
+
+// Quote is the normalized snapshot we extract from each provider. AskCents
+// and BidCents fall back to PriceCents when the provider doesn't expose a
+// real spread (Alpha Vantage's GLOBAL_QUOTE is price-only).
+type Quote struct {
+	Ticker     string
+	PriceCents int64
+	AskCents   int64
+	BidCents   int64
+	At         time.Time
+}
+
+// Client is what the refresher consumes. Each provider implements it; a
+// MultiClient composes several providers with first-success semantics.
+type Client interface {
+	// Name is used in log lines so an operator can tell which provider
+	// served (or refused) a given quote.
+	Name() string
+	GetQuote(ctx context.Context, ticker string) (Quote, error)
+}
+
+// httpDoer is the http.Client subset we depend on, kept narrow so tests can
+// stub it without pulling in the full *http.Client surface.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// dollarsToCents converts a provider-reported price (typically a float in
+// major units) to int64 minor units. Rounding is half-away-from-zero, which
+// matches what most exchanges quote at the tick level. We guard against NaN
+// and Inf because both providers occasionally emit them for delisted/halted
+// tickers and the int64 cast on those is undefined.
+func dollarsToCents(v float64) (int64, bool) {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	if v < 0 {
+		return 0, false
+	}
+	return int64(math.Round(v * 100)), true
+}

--- a/internal/trading/pricing/multi.go
+++ b/internal/trading/pricing/multi.go
@@ -1,0 +1,54 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// MultiClient tries its underlying providers in order and returns the first
+// successful quote. ErrNotFound from one provider falls through to the next
+// (a delisted Alpaca ticker may still resolve on Alpha Vantage); other
+// errors short-circuit so a single misconfigured provider doesn't quietly
+// hide a real outage of the next.
+//
+// ErrRateLimited is treated like ErrNotFound for fall-through: AV's
+// 25-call/day cap is the operationally noisy one, and we'd rather try
+// Alpaca than fail the whole refresh tick.
+type MultiClient struct {
+	Providers []Client
+}
+
+func NewMulti(clients ...Client) *MultiClient {
+	out := make([]Client, 0, len(clients))
+	for _, c := range clients {
+		if c != nil {
+			out = append(out, c)
+		}
+	}
+	return &MultiClient{Providers: out}
+}
+
+func (m *MultiClient) Name() string { return "multi" }
+
+func (m *MultiClient) GetQuote(ctx context.Context, ticker string) (Quote, error) {
+	if len(m.Providers) == 0 {
+		return Quote{}, fmt.Errorf("pricing: no providers configured")
+	}
+	var lastSkip error
+	for _, p := range m.Providers {
+		q, err := p.GetQuote(ctx, ticker)
+		if err == nil {
+			return q, nil
+		}
+		if errors.Is(err, ErrNotFound) || errors.Is(err, ErrRateLimited) {
+			lastSkip = err
+			continue
+		}
+		return Quote{}, fmt.Errorf("%s: %w", p.Name(), err)
+	}
+	if lastSkip != nil {
+		return Quote{}, lastSkip
+	}
+	return Quote{}, ErrNotFound
+}

--- a/internal/trading/pricing/multi_test.go
+++ b/internal/trading/pricing/multi_test.go
@@ -1,0 +1,101 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeClient struct {
+	name string
+	q    Quote
+	err  error
+}
+
+func (f *fakeClient) Name() string { return f.name }
+func (f *fakeClient) GetQuote(_ context.Context, _ string) (Quote, error) {
+	return f.q, f.err
+}
+
+func TestMulti_FirstSuccess(t *testing.T) {
+	a := &fakeClient{name: "a", q: Quote{Ticker: "X", PriceCents: 100}}
+	b := &fakeClient{name: "b", q: Quote{Ticker: "X", PriceCents: 200}}
+	m := NewMulti(a, b)
+	q, err := m.GetQuote(context.Background(), "X")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.PriceCents != 100 {
+		t.Errorf("got price %d, want first provider's 100", q.PriceCents)
+	}
+}
+
+func TestMulti_FallthroughOnNotFound(t *testing.T) {
+	a := &fakeClient{name: "a", err: ErrNotFound}
+	b := &fakeClient{name: "b", q: Quote{Ticker: "X", PriceCents: 200}}
+	m := NewMulti(a, b)
+	q, err := m.GetQuote(context.Background(), "X")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.PriceCents != 200 {
+		t.Errorf("got price %d, want fallback's 200", q.PriceCents)
+	}
+}
+
+func TestMulti_FallthroughOnRateLimit(t *testing.T) {
+	a := &fakeClient{name: "a", err: ErrRateLimited}
+	b := &fakeClient{name: "b", q: Quote{Ticker: "X", PriceCents: 200}}
+	m := NewMulti(a, b)
+	q, err := m.GetQuote(context.Background(), "X")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.PriceCents != 200 {
+		t.Errorf("got price %d, want fallback's 200", q.PriceCents)
+	}
+}
+
+func TestMulti_HardErrorShortCircuits(t *testing.T) {
+	hard := errors.New("connection refused")
+	a := &fakeClient{name: "a", err: hard}
+	b := &fakeClient{name: "b", q: Quote{Ticker: "X", PriceCents: 200}}
+	m := NewMulti(a, b)
+	_, err := m.GetQuote(context.Background(), "X")
+	if err == nil {
+		t.Fatal("expected error on hard failure")
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrRateLimited) {
+		t.Errorf("hard error misclassified: %v", err)
+	}
+}
+
+func TestMulti_AllSkipped(t *testing.T) {
+	a := &fakeClient{name: "a", err: ErrNotFound}
+	b := &fakeClient{name: "b", err: ErrRateLimited}
+	m := NewMulti(a, b)
+	_, err := m.GetQuote(context.Background(), "X")
+	if !errors.Is(err, ErrRateLimited) && !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want last skip error", err)
+	}
+}
+
+func TestMulti_NoProviders(t *testing.T) {
+	m := NewMulti()
+	_, err := m.GetQuote(context.Background(), "X")
+	if err == nil {
+		t.Fatal("expected error with no providers")
+	}
+}
+
+func TestMulti_NilSkipped(t *testing.T) {
+	a := &fakeClient{name: "a", q: Quote{Ticker: "X", PriceCents: 7}}
+	m := NewMulti(nil, a, nil)
+	q, err := m.GetQuote(context.Background(), "X")
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.PriceCents != 7 {
+		t.Errorf("price = %d", q.PriceCents)
+	}
+}

--- a/internal/trading/refresher.go
+++ b/internal/trading/refresher.go
@@ -1,0 +1,157 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/gorm"
+)
+
+// External-pricing refresher (#184). Walks stock listings on a fixed
+// interval, asks the configured pricing client for a fresh quote, and
+// writes price/ask/bid back to the row. Implements the spec's "Podaci o
+// cenama biće preuzimani iz eksternog izvora" requirement (p.37): listings
+// were seeded statically by #195 and stay frozen without something to keep
+// them moving.
+//
+// Two design notes:
+//
+//  1. Listings without an Alpaca/Alpha-Vantage-shaped ticker (futures,
+//     foreign exchanges, dummy tickers) are not refreshable from these
+//     providers. We filter on stock_id IS NOT NULL up front and let
+//     ErrNotFound from the client skip individual rows, so a single
+//     unrecognized ticker never blocks the rest.
+//
+//  2. Per-quote spacing: AV's free tier caps at 5/min. We sleep between
+//     calls inside a tick rather than fanning out goroutines so the rate
+//     limit holds without an external limiter library.
+//
+// Pricing client is optional: nil disables the refresher. Operators wire it
+// up only when they've supplied API keys via env (see cmd/bank/main.go).
+const (
+	refresherDefaultInterval = 5 * time.Minute
+	refresherPerCallDelay    = 13 * time.Second // ~4.6 calls/min — under AV's 5/min cap
+)
+
+type Refresher struct {
+	DB       *gorm.DB
+	Client   pricing.Client
+	Interval time.Duration
+	// PerCallDelay throttles successive calls within one tick. Defaulted to
+	// refresherPerCallDelay; tests override it to 0.
+	PerCallDelay time.Duration
+	// Now is overridden in tests so the last_refresh stamp is deterministic.
+	Now func() time.Time
+}
+
+func NewRefresher(db *gorm.DB, client pricing.Client) *Refresher {
+	return &Refresher{
+		DB:           db,
+		Client:       client,
+		Interval:     refresherDefaultInterval,
+		PerCallDelay: refresherPerCallDelay,
+		Now:          time.Now,
+	}
+}
+
+// Start kicks the refresher loop and returns a cancel func mirroring
+// StartExecutor's shape so cmd/bank/main.go can stop both with the same
+// pattern.
+func (r *Refresher) Start() func() {
+	if r.Client == nil {
+		// Nothing wired up — return a no-op cancel rather than spinning a
+		// goroutine that does nothing.
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.run(ctx)
+	return cancel
+}
+
+func (r *Refresher) run(ctx context.Context) {
+	// First refresh fires immediately so an operator who restarts during
+	// market hours sees prices move within seconds, not minutes.
+	r.runOnce(ctx)
+	t := time.NewTicker(r.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+// refreshTarget is the projection we actually need. Listings table holds
+// stock_id but the ticker lives on stocks; one join keeps the per-row
+// fetch+update simple.
+type refreshTarget struct {
+	ListingID int64
+	Ticker    string
+}
+
+func (r *Refresher) runOnce(ctx context.Context) {
+	targets, err := r.loadTargets()
+	if err != nil {
+		log.Printf("[Refresher] load targets: %v", err)
+		return
+	}
+	for i, tgt := range targets {
+		if ctx.Err() != nil {
+			return
+		}
+		if i > 0 && r.PerCallDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(r.PerCallDelay):
+			}
+		}
+		if err := r.refreshOne(ctx, tgt); err != nil {
+			// ErrNotFound is logged at debug level worth: it's expected for
+			// dummy tickers in the seed (e.g. RAFA/RAFB) that don't exist on
+			// either provider. We collapse it to a single line so logs stay
+			// readable.
+			if errors.Is(err, pricing.ErrNotFound) {
+				continue
+			}
+			if errors.Is(err, pricing.ErrRateLimited) {
+				log.Printf("[Refresher] rate limited; aborting tick after %s", tgt.Ticker)
+				return
+			}
+			log.Printf("[Refresher] %s: %v", tgt.Ticker, err)
+		}
+	}
+}
+
+func (r *Refresher) loadTargets() ([]refreshTarget, error) {
+	var rows []refreshTarget
+	err := r.DB.Table("listings AS l").
+		Select("l.id AS listing_id, s.ticker AS ticker").
+		Joins("JOIN stocks s ON s.id = l.stock_id").
+		Where("l.stock_id IS NOT NULL").
+		Order("l.id").
+		Scan(&rows).Error
+	return rows, err
+}
+
+func (r *Refresher) refreshOne(ctx context.Context, tgt refreshTarget) error {
+	q, err := r.Client.GetQuote(ctx, tgt.Ticker)
+	if err != nil {
+		return err
+	}
+	now := r.Now().UTC()
+	return r.DB.Model(&Listing{}).
+		Where("id = ?", tgt.ListingID).
+		Updates(map[string]any{
+			"price":        q.PriceCents,
+			"ask_price":    q.AskCents,
+			"bid_price":    q.BidCents,
+			"last_refresh": now,
+		}).Error
+}

--- a/internal/trading/refresher_test.go
+++ b/internal/trading/refresher_test.go
@@ -1,0 +1,216 @@
+package trading
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newRefresherTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: db}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return gormDB, mock, db
+}
+
+// pricingFake is a hand-rolled stub so we don't have to spin httptest in
+// the refresher tests — the providers are already covered separately.
+type pricingFake struct {
+	quotes map[string]pricing.Quote
+	errs   map[string]error
+	calls  []string
+}
+
+func (f *pricingFake) Name() string { return "fake" }
+func (f *pricingFake) GetQuote(_ context.Context, ticker string) (pricing.Quote, error) {
+	f.calls = append(f.calls, ticker)
+	if err, ok := f.errs[ticker]; ok {
+		return pricing.Quote{}, err
+	}
+	if q, ok := f.quotes[ticker]; ok {
+		return q, nil
+	}
+	return pricing.Quote{}, pricing.ErrNotFound
+}
+
+func TestRefresher_RunOnce_UpdatesPrices(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT l.id AS listing_id, s.ticker AS ticker FROM listings AS l JOIN stocks s ON s.id = l.stock_id WHERE l.stock_id IS NOT NULL ORDER BY l.id`,
+	)).WillReturnRows(rows)
+
+	frozen := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "listings"`).
+		WithArgs(int64(17430), int64(17420), frozen, int64(17421), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "listings"`).
+		WithArgs(int64(41250), int64(41240), frozen, int64(41245), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Refresher{
+		DB: gdb,
+		Client: &pricingFake{quotes: map[string]pricing.Quote{
+			"AAPL": {Ticker: "AAPL", PriceCents: 17421, AskCents: 17430, BidCents: 17420},
+			"MSFT": {Ticker: "MSFT", PriceCents: 41245, AskCents: 41250, BidCents: 41240},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          func() time.Time { return frozen },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRefresher_RunOnce_SkipsNotFound(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "RAFA"). // dummy ticker — not on either provider
+		AddRow(int64(2), "AAPL")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT l.id AS listing_id, s.ticker AS ticker FROM listings AS l JOIN stocks s ON s.id = l.stock_id WHERE l.stock_id IS NOT NULL ORDER BY l.id`,
+	)).WillReturnRows(rows)
+
+	// Only AAPL should produce an UPDATE.
+	frozen := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "listings"`).
+		WithArgs(int64(17430), int64(17420), frozen, int64(17421), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Refresher{
+		DB: gdb,
+		Client: &pricingFake{quotes: map[string]pricing.Quote{
+			"AAPL": {Ticker: "AAPL", PriceCents: 17421, AskCents: 17430, BidCents: 17420},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          func() time.Time { return frozen },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRefresher_RunOnce_AbortsOnRateLimit(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT").
+		AddRow(int64(3), "GOOG")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT l.id AS listing_id, s.ticker AS ticker FROM listings AS l JOIN stocks s ON s.id = l.stock_id WHERE l.stock_id IS NOT NULL ORDER BY l.id`,
+	)).WillReturnRows(rows)
+
+	frozen := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	// AAPL succeeds, MSFT triggers ErrRateLimited, GOOG should never be called.
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "listings"`).
+		WithArgs(int64(17430), int64(17420), frozen, int64(17421), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	fake := &pricingFake{
+		quotes: map[string]pricing.Quote{
+			"AAPL": {Ticker: "AAPL", PriceCents: 17421, AskCents: 17430, BidCents: 17420},
+		},
+		errs: map[string]error{
+			"MSFT": pricing.ErrRateLimited,
+		},
+	}
+	r := &Refresher{
+		DB:           gdb,
+		Client:       fake,
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          func() time.Time { return frozen },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+	// GOOG must not have been queried after the rate-limit short-circuit.
+	for _, c := range fake.calls {
+		if c == "GOOG" {
+			t.Errorf("GOOG was queried after rate limit; calls=%v", fake.calls)
+		}
+	}
+}
+
+func TestRefresher_RunOnce_TransientErrorContinues(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT l.id AS listing_id, s.ticker AS ticker FROM listings AS l JOIN stocks s ON s.id = l.stock_id WHERE l.stock_id IS NOT NULL ORDER BY l.id`,
+	)).WillReturnRows(rows)
+
+	frozen := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	// AAPL fails with a transient error (logged + skipped). MSFT proceeds.
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "listings"`).
+		WithArgs(int64(41250), int64(41240), frozen, int64(41245), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Refresher{
+		DB: gdb,
+		Client: &pricingFake{
+			quotes: map[string]pricing.Quote{
+				"MSFT": {Ticker: "MSFT", PriceCents: 41245, AskCents: 41250, BidCents: 41240},
+			},
+			errs: map[string]error{"AAPL": errors.New("connection refused")},
+		},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          func() time.Time { return frozen },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestRefresher_Start_NilClientIsNoop(t *testing.T) {
+	r := &Refresher{Client: nil}
+	cancel := r.Start()
+	cancel() // must not panic and must not have spawned a loop
+}


### PR DESCRIPTION
Closes #184.

## Summary
- Adds `internal/trading/pricing/` with Alpaca and Alpha Vantage clients behind a common `Client` interface (`GetQuote(ticker) → Quote{price/ask/bid in cents}`), plus a `MultiClient` that tries providers in order and falls through on `ErrNotFound`/`ErrRateLimited`.
- Adds a `Refresher` goroutine (sibling to the existing `StartExecutor`) that walks stock listings on a 5-minute tick and updates `listings.price/ask/bid/last_refresh` from whichever provider answers first. Per-call delay throttles below Alpha Vantage's 5/min free-tier cap.
- Wires the refresher into `cmd/bank/main.go`, gated by `ALPACA_KEY_ID`/`ALPACA_SECRET` and `ALPHAVANTAGE_KEY` env vars. Without keys it's a no-op so dev/CI keep operating off the static seed prices from #195.

## What's deferred (follow-up issues to file)
- Daily-history backfill into `listing_daily_price_info` (touches the executor's volume model).
- Company-Overview sync (outstanding shares, dividend yield) so stock metadata isn't seed-frozen.
- Options chain (Yahoo) and forex pricing — different APIs and different table targets.

## Test plan
- [x] `go test ./internal/trading/pricing/...` — both clients covered with `httptest.Server`: success, rate-limit, unknown-ticker, missing creds, bad status.
- [x] `go test ./internal/trading/...` — `Refresher.runOnce` covered with sqlmock: happy-path updates, ErrNotFound rows skipped, rate-limit short-circuits the rest of the tick, transient errors logged but loop continues.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- [ ] Smoke run against compose stack with real keys (manual; deferred until keys available).