### PR TITLE
feat(trading): per-user tax info endpoint for Moj Portfolio (#226)

### DIFF
--- a/gen/trading/trading.pb.go
+++ b/gen/trading/trading.pb.go
@@ -3425,6 +3425,108 @@ func (x *ListTaxDebtsResponse) GetDebtors() []*TaxDebtor {
 	return nil
 }
 
+// GetMyTaxInfo backs the Moj Portfolio tax widget (spec p.61). Caller identity
+// is read from the `user-email` gRPC metadata via bank.ResolveCaller; any
+// authenticated client or actuary may call it. paid_this_year_rsd sums tax
+// rows whose paid_at falls in the current calendar year; unpaid_this_month_rsd
+// sums every still-unpaid row (the cron sweeps monthly, so "tekući mesec" and
+// "all unpaid" coincide in practice).
+type GetMyTaxInfoRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CallerEmail   string                 `protobuf:"bytes,1,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMyTaxInfoRequest) Reset() {
+	*x = GetMyTaxInfoRequest{}
+	mi := &file_trading_trading_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyTaxInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyTaxInfoRequest) ProtoMessage() {}
+
+func (x *GetMyTaxInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyTaxInfoRequest.ProtoReflect.Descriptor instead.
+func (*GetMyTaxInfoRequest) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *GetMyTaxInfoRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type GetMyTaxInfoResponse struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	PaidThisYearRsd    int64                  `protobuf:"varint,1,opt,name=paid_this_year_rsd,json=paidThisYearRsd,proto3" json:"paid_this_year_rsd,omitempty"`
+	UnpaidThisMonthRsd int64                  `protobuf:"varint,2,opt,name=unpaid_this_month_rsd,json=unpaidThisMonthRsd,proto3" json:"unpaid_this_month_rsd,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *GetMyTaxInfoResponse) Reset() {
+	*x = GetMyTaxInfoResponse{}
+	mi := &file_trading_trading_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMyTaxInfoResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMyTaxInfoResponse) ProtoMessage() {}
+
+func (x *GetMyTaxInfoResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_trading_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMyTaxInfoResponse.ProtoReflect.Descriptor instead.
+func (*GetMyTaxInfoResponse) Descriptor() ([]byte, []int) {
+	return file_trading_trading_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *GetMyTaxInfoResponse) GetPaidThisYearRsd() int64 {
+	if x != nil {
+		return x.PaidThisYearRsd
+	}
+	return 0
+}
+
+func (x *GetMyTaxInfoResponse) GetUnpaidThisMonthRsd() int64 {
+	if x != nil {
+		return x.UnpaidThisMonthRsd
+	}
+	return 0
+}
+
 var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
@@ -3715,7 +3817,12 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x04team\x18\x02 \x01(\tR\x04team\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\"D\n" +
 	"\x14ListTaxDebtsResponse\x12,\n" +
-	"\adebtors\x18\x01 \x03(\v2\x12.trading.TaxDebtorR\adebtors2\x8f\f\n" +
+	"\adebtors\x18\x01 \x03(\v2\x12.trading.TaxDebtorR\adebtors\"8\n" +
+	"\x13GetMyTaxInfoRequest\x12!\n" +
+	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\"v\n" +
+	"\x14GetMyTaxInfoResponse\x12+\n" +
+	"\x12paid_this_year_rsd\x18\x01 \x01(\x03R\x0fpaidThisYearRsd\x121\n" +
+	"\x15unpaid_this_month_rsd\x18\x02 \x01(\x03R\x12unpaidThisMonthRsd2\xdc\f\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
@@ -3737,7 +3844,8 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\x10SetHoldingPublic\x12 .trading.SetHoldingPublicRequest\x1a!.trading.SetHoldingPublicResponse\x12Q\n" +
 	"\x0eExerciseOption\x12\x1e.trading.ExerciseOptionRequest\x1a\x1f.trading.ExerciseOptionResponse\x12T\n" +
 	"\x0fRunCapitalGains\x12\x1f.trading.RunCapitalGainsRequest\x1a .trading.RunCapitalGainsResponse\x12K\n" +
-	"\fListTaxDebts\x12\x1c.trading.ListTaxDebtsRequest\x1a\x1d.trading.ListTaxDebtsResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
+	"\fListTaxDebts\x12\x1c.trading.ListTaxDebtsRequest\x1a\x1d.trading.ListTaxDebtsResponse\x12K\n" +
+	"\fGetMyTaxInfo\x12\x1c.trading.GetMyTaxInfoRequest\x1a\x1d.trading.GetMyTaxInfoResponseB4Z2github.com/RAF-SI-2025/Banka-3-Backend/gen/tradingb\x06proto3"
 
 var (
 	file_trading_trading_proto_rawDescOnce sync.Once
@@ -3751,7 +3859,7 @@ func file_trading_trading_proto_rawDescGZIP() []byte {
 	return file_trading_trading_proto_rawDescData
 }
 
-var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_trading_trading_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_trading_trading_proto_goTypes = []any{
 	(*Exchange)(nil),                        // 0: trading.Exchange
 	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
@@ -3801,6 +3909,8 @@ var file_trading_trading_proto_goTypes = []any{
 	(*TaxDebtor)(nil),                       // 45: trading.TaxDebtor
 	(*ListTaxDebtsRequest)(nil),             // 46: trading.ListTaxDebtsRequest
 	(*ListTaxDebtsResponse)(nil),            // 47: trading.ListTaxDebtsResponse
+	(*GetMyTaxInfoRequest)(nil),             // 48: trading.GetMyTaxInfoRequest
+	(*GetMyTaxInfoResponse)(nil),            // 49: trading.GetMyTaxInfoResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0,  // 0: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
@@ -3839,27 +3949,29 @@ var file_trading_trading_proto_depIdxs = []int32{
 	41, // 33: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
 	43, // 34: trading.TradingService.RunCapitalGains:input_type -> trading.RunCapitalGainsRequest
 	46, // 35: trading.TradingService.ListTaxDebts:input_type -> trading.ListTaxDebtsRequest
-	4,  // 36: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	7,  // 37: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	9,  // 38: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
-	12, // 39: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
-	15, // 40: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
-	18, // 41: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
-	22, // 42: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
-	24, // 43: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	27, // 44: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
-	29, // 45: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
-	31, // 46: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
-	33, // 47: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
-	2,  // 48: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	36, // 49: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
-	38, // 50: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
-	40, // 51: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
-	42, // 52: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
-	44, // 53: trading.TradingService.RunCapitalGains:output_type -> trading.RunCapitalGainsResponse
-	47, // 54: trading.TradingService.ListTaxDebts:output_type -> trading.ListTaxDebtsResponse
-	36, // [36:55] is the sub-list for method output_type
-	17, // [17:36] is the sub-list for method input_type
+	48, // 36: trading.TradingService.GetMyTaxInfo:input_type -> trading.GetMyTaxInfoRequest
+	4,  // 37: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	7,  // 38: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	9,  // 39: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	12, // 40: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	15, // 41: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	18, // 42: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
+	22, // 43: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
+	24, // 44: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	27, // 45: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
+	29, // 46: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
+	31, // 47: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
+	33, // 48: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
+	2,  // 49: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	36, // 50: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
+	38, // 51: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
+	40, // 52: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
+	42, // 53: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
+	44, // 54: trading.TradingService.RunCapitalGains:output_type -> trading.RunCapitalGainsResponse
+	47, // 55: trading.TradingService.ListTaxDebts:output_type -> trading.ListTaxDebtsResponse
+	49, // 56: trading.TradingService.GetMyTaxInfo:output_type -> trading.GetMyTaxInfoResponse
+	37, // [37:57] is the sub-list for method output_type
+	17, // [17:37] is the sub-list for method input_type
 	17, // [17:17] is the sub-list for extension type_name
 	17, // [17:17] is the sub-list for extension extendee
 	0,  // [0:17] is the sub-list for field type_name
@@ -3876,7 +3988,7 @@ func file_trading_trading_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_trading_proto_rawDesc), len(file_trading_trading_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/trading/trading_grpc.pb.go
+++ b/gen/trading/trading_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	TradingService_ExerciseOption_FullMethodName          = "/trading.TradingService/ExerciseOption"
 	TradingService_RunCapitalGains_FullMethodName         = "/trading.TradingService/RunCapitalGains"
 	TradingService_ListTaxDebts_FullMethodName            = "/trading.TradingService/ListTaxDebts"
+	TradingService_GetMyTaxInfo_FullMethodName            = "/trading.TradingService/GetMyTaxInfo"
 )
 
 // TradingServiceClient is the client API for TradingService service.
@@ -63,6 +64,7 @@ type TradingServiceClient interface {
 	ExerciseOption(ctx context.Context, in *ExerciseOptionRequest, opts ...grpc.CallOption) (*ExerciseOptionResponse, error)
 	RunCapitalGains(ctx context.Context, in *RunCapitalGainsRequest, opts ...grpc.CallOption) (*RunCapitalGainsResponse, error)
 	ListTaxDebts(ctx context.Context, in *ListTaxDebtsRequest, opts ...grpc.CallOption) (*ListTaxDebtsResponse, error)
+	GetMyTaxInfo(ctx context.Context, in *GetMyTaxInfoRequest, opts ...grpc.CallOption) (*GetMyTaxInfoResponse, error)
 }
 
 type tradingServiceClient struct {
@@ -263,6 +265,16 @@ func (c *tradingServiceClient) ListTaxDebts(ctx context.Context, in *ListTaxDebt
 	return out, nil
 }
 
+func (c *tradingServiceClient) GetMyTaxInfo(ctx context.Context, in *GetMyTaxInfoRequest, opts ...grpc.CallOption) (*GetMyTaxInfoResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMyTaxInfoResponse)
+	err := c.cc.Invoke(ctx, TradingService_GetMyTaxInfo_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TradingServiceServer is the server API for TradingService service.
 // All implementations must embed UnimplementedTradingServiceServer
 // for forward compatibility.
@@ -286,6 +298,7 @@ type TradingServiceServer interface {
 	ExerciseOption(context.Context, *ExerciseOptionRequest) (*ExerciseOptionResponse, error)
 	RunCapitalGains(context.Context, *RunCapitalGainsRequest) (*RunCapitalGainsResponse, error)
 	ListTaxDebts(context.Context, *ListTaxDebtsRequest) (*ListTaxDebtsResponse, error)
+	GetMyTaxInfo(context.Context, *GetMyTaxInfoRequest) (*GetMyTaxInfoResponse, error)
 	mustEmbedUnimplementedTradingServiceServer()
 }
 
@@ -352,6 +365,9 @@ func (UnimplementedTradingServiceServer) RunCapitalGains(context.Context, *RunCa
 }
 func (UnimplementedTradingServiceServer) ListTaxDebts(context.Context, *ListTaxDebtsRequest) (*ListTaxDebtsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListTaxDebts not implemented")
+}
+func (UnimplementedTradingServiceServer) GetMyTaxInfo(context.Context, *GetMyTaxInfoRequest) (*GetMyTaxInfoResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMyTaxInfo not implemented")
 }
 func (UnimplementedTradingServiceServer) mustEmbedUnimplementedTradingServiceServer() {}
 func (UnimplementedTradingServiceServer) testEmbeddedByValue()                        {}
@@ -716,6 +732,24 @@ func _TradingService_ListTaxDebts_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TradingService_GetMyTaxInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMyTaxInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).GetMyTaxInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_GetMyTaxInfo_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).GetMyTaxInfo(ctx, req.(*GetMyTaxInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TradingService_ServiceDesc is the grpc.ServiceDesc for TradingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -798,6 +832,10 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListTaxDebts",
 			Handler:    _TradingService_ListTaxDebts_Handler,
+		},
+		{
+			MethodName: "GetMyTaxInfo",
+			Handler:    _TradingService_GetMyTaxInfo_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/gateway/handlers.go
+++ b/internal/gateway/handlers.go
@@ -200,6 +200,11 @@ func SetupApi(router *gin.Engine, server *Server) {
 		tax.POST("/run", server.RunCapitalGains)
 		tax.GET("/debts", server.ListTaxDebts)
 	}
+
+	// Per-self tax aggregate for the Moj Portfolio page (spec p.61 / #226).
+	// Any authenticated client or actuary; the trading RPC resolves the
+	// caller and returns zeros for users with no trading history.
+	api.GET("/tax/me", auth, server.GetMyTaxInfo)
 }
 
 func (s *Server) Healthz(c *gin.Context) {

--- a/internal/gateway/tax.go
+++ b/internal/gateway/tax.go
@@ -71,3 +71,23 @@ func (s *Server) ListTaxDebts(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, out)
 }
+
+// GetMyTaxInfo backs `GET /api/tax/me` — the two aggregates the Moj Portfolio
+// page renders for the logged-in user (spec p.61). Open to any authenticated
+// client or actuary; the trading RPC resolves the caller via bank.ResolveCaller.
+func (s *Server) GetMyTaxInfo(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.GetMyTaxInfo(ctx, &tradingpb.GetMyTaxInfoRequest{
+		CallerEmail: c.GetString("email"),
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"paid_this_year_rsd":    resp.PaidThisYearRsd,
+		"unpaid_this_month_rsd": resp.UnpaidThisMonthRsd,
+	})
+}

--- a/internal/trading/tax.go
+++ b/internal/trading/tax.go
@@ -2,12 +2,15 @@ package trading
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
+	"time"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/trading"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
 // monthRe pins the month filter to YYYY-MM so a malformed value can't slip
@@ -136,4 +139,85 @@ func (s *Server) ListTaxDebts(_ context.Context, req *tradingpb.ListTaxDebtsRequ
 		})
 	}
 	return &tradingpb.ListTaxDebtsResponse{Debtors: out}, nil
+}
+
+// GetMyTaxInfo returns the two aggregates the Moj Portfolio page renders for
+// the logged-in user (spec p.61): tax already paid this calendar year, and
+// tax still owed. Caller identity comes from bank.ResolveCaller — open to any
+// authenticated client or actuary.
+//
+// A caller with no order_placers row (no orders ever placed) returns zeros
+// rather than NotFound, mirroring ListHoldings: "no trading activity" is a
+// valid state, not an error.
+func (s *Server) GetMyTaxInfo(ctx context.Context, _ *tradingpb.GetMyTaxInfoRequest) (*tradingpb.GetMyTaxInfoResponse, error) {
+	caller, err := s.bank.ResolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !caller.IsClient && !caller.IsEmployee {
+		return nil, status.Error(codes.PermissionDenied, "caller is neither client nor employee")
+	}
+
+	placerID, err := lookupPlacerID(s.db, caller.IsClient, caller.ClientID, caller.Email)
+	if err != nil {
+		return nil, err
+	}
+	if placerID == 0 {
+		return &tradingpb.GetMyTaxInfoResponse{}, nil
+	}
+	return aggregateMyTaxInfo(s.db, placerID, time.Now().Year())
+}
+
+// lookupPlacerID resolves the caller's order_placers.id without creating the
+// row — GetMyTaxInfo only needs to read existing tax history, so a missing
+// placer collapses to "zero rows" rather than triggering a write.
+func lookupPlacerID(db *gorm.DB, isClient bool, clientID int64, email string) (int64, error) {
+	var placerID int64
+	q := db.Table("order_placers").Select("id")
+	if isClient {
+		q = q.Where("client_id = ?", clientID)
+	} else {
+		var empID int64
+		err := db.Table("employees").Select("id").Where("email = ?", email).Take(&empID).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, status.Error(codes.NotFound, "employee not found")
+		}
+		if err != nil {
+			return 0, status.Errorf(codes.Internal, "%v", err)
+		}
+		q = q.Where("employee_id = ?", empID)
+	}
+	err := q.Take(&placerID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "%v", err)
+	}
+	return placerID, nil
+}
+
+// aggregateMyTaxInfo computes the two SUMs the spec asks for in a single
+// query. Year filtering uses paid_at (not period) so a row created in
+// December but settled in January counts toward the year it actually moved
+// money, which is what the user expects to see in the "this year" total.
+func aggregateMyTaxInfo(db *gorm.DB, placerID int64, year int) (*tradingpb.GetMyTaxInfoResponse, error) {
+	var row struct {
+		PaidThisYearRsd    int64
+		UnpaidThisMonthRsd int64
+	}
+	err := db.Table("capital_gains").
+		Select(`
+			COALESCE(SUM(CASE WHEN paid_at IS NOT NULL AND EXTRACT(YEAR FROM paid_at) = ? THEN tax_due ELSE 0 END), 0) AS paid_this_year_rsd,
+			COALESCE(SUM(CASE WHEN paid_at IS NULL THEN tax_due ELSE 0 END), 0) AS unpaid_this_month_rsd
+		`, year).
+		Where("seller_placer_id = ?", placerID).
+		Scan(&row).Error
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	return &tradingpb.GetMyTaxInfoResponse{
+		PaidThisYearRsd:    row.PaidThisYearRsd,
+		UnpaidThisMonthRsd: row.UnpaidThisMonthRsd,
+	}, nil
 }

--- a/internal/trading/tax_test.go
+++ b/internal/trading/tax_test.go
@@ -115,6 +115,107 @@ func TestListTaxDebts_RejectsBadTeam(t *testing.T) {
 	}
 }
 
+// TestLookupPlacerID_ClientFound covers the simple client path: caller is a
+// client, placer row already exists. lookupPlacerID returns the placer id and
+// does not touch the employees table.
+func TestLookupPlacerID_ClientFound(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+
+	mock.ExpectQuery(`SELECT id FROM "order_placers" WHERE client_id = \$1 LIMIT \$2`).
+		WithArgs(int64(42), 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(7)))
+
+	got, err := lookupPlacerID(srv.db, true, 42, "")
+	if err != nil {
+		t.Fatalf("lookupPlacerID: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("got placer %d, want 7", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestLookupPlacerID_NoPlacer covers the "user has never traded" case —
+// lookupPlacerID returns 0, nil so the RPC can collapse to an empty response
+// rather than 404. Mirrors the ListHoldings empty-list semantics.
+func TestLookupPlacerID_NoPlacer(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+
+	mock.ExpectQuery(`SELECT id FROM "order_placers" WHERE client_id = \$1 LIMIT \$2`).
+		WithArgs(int64(42), 1).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	got, err := lookupPlacerID(srv.db, true, 42, "")
+	if err != nil {
+		t.Fatalf("lookupPlacerID: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got placer %d, want 0", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestLookupPlacerID_EmployeeChain pins the two-step employee resolution: look
+// up the employee row by email first, then the placer by employee_id. Each
+// step is a separate query so the supervisor portal's existing
+// employees-by-email join is not duplicated here.
+func TestLookupPlacerID_EmployeeChain(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+
+	mock.ExpectQuery(`SELECT id FROM "employees" WHERE email = \$1 LIMIT \$2`).
+		WithArgs("agent@banka.raf", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(11)))
+	mock.ExpectQuery(`SELECT id FROM "order_placers" WHERE employee_id = \$1 LIMIT \$2`).
+		WithArgs(int64(11), 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(99)))
+
+	got, err := lookupPlacerID(srv.db, false, 0, "agent@banka.raf")
+	if err != nil {
+		t.Fatalf("lookupPlacerID: %v", err)
+	}
+	if got != 99 {
+		t.Errorf("got placer %d, want 99", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestAggregateMyTaxInfo verifies the year-filtered SUM query: paid rows in
+// the requested year roll into paid_this_year_rsd, every still-unpaid row
+// rolls into unpaid_this_month_rsd. The single-query CASE shape means both
+// totals come back from one round trip.
+func TestAggregateMyTaxInfo(t *testing.T) {
+	srv, mock, done := newTaxTestServer(t)
+	defer done()
+
+	mock.ExpectQuery(`FROM "capital_gains" WHERE seller_placer_id = \$2`).
+		WithArgs(2026, int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"paid_this_year_rsd", "unpaid_this_month_rsd"}).
+			AddRow(int64(1500), int64(450)))
+
+	resp, err := aggregateMyTaxInfo(srv.db, 7, 2026)
+	if err != nil {
+		t.Fatalf("aggregateMyTaxInfo: %v", err)
+	}
+	if resp.PaidThisYearRsd != 1500 {
+		t.Errorf("paid_this_year_rsd = %d, want 1500", resp.PaidThisYearRsd)
+	}
+	if resp.UnpaidThisMonthRsd != 450 {
+		t.Errorf("unpaid_this_month_rsd = %d, want 450", resp.UnpaidThisMonthRsd)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 // TestMonthRegex pins the YYYY-MM filter so a regex tweak doesn't accidentally
 // admit malformed periods (which would silently match zero rows in the
 // `period = ?` predicate at collection time).

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -24,6 +24,7 @@ service TradingService {
   rpc ExerciseOption(ExerciseOptionRequest) returns (ExerciseOptionResponse);
   rpc RunCapitalGains(RunCapitalGainsRequest) returns (RunCapitalGainsResponse);
   rpc ListTaxDebts(ListTaxDebtsRequest) returns (ListTaxDebtsResponse);
+  rpc GetMyTaxInfo(GetMyTaxInfoRequest) returns (GetMyTaxInfoResponse);
 }
 
 message Exchange {
@@ -455,4 +456,19 @@ message ListTaxDebtsRequest {
 
 message ListTaxDebtsResponse {
   repeated TaxDebtor debtors = 1;
+}
+
+// GetMyTaxInfo backs the Moj Portfolio tax widget (spec p.61). Caller identity
+// is read from the `user-email` gRPC metadata via bank.ResolveCaller; any
+// authenticated client or actuary may call it. paid_this_year_rsd sums tax
+// rows whose paid_at falls in the current calendar year; unpaid_this_month_rsd
+// sums every still-unpaid row (the cron sweeps monthly, so "tekući mesec" and
+// "all unpaid" coincide in practice).
+message GetMyTaxInfoRequest {
+  string caller_email = 1;
+}
+
+message GetMyTaxInfoResponse {
+  int64 paid_this_year_rsd = 1;
+  int64 unpaid_this_month_rsd = 2;
 }


### PR DESCRIPTION
## Summary
- Adds `GetMyTaxInfo` RPC + `GET /api/tax/me` so the Moj Portfolio page (spec p.61) can show the logged-in Klijent / Aktuar their paid-this-year and still-unpaid capital-gains tax totals.
- Caller resolved via `bank.ResolveCaller`; the placer lookup is read-only, so a user with no `order_placers` row gets zeros instead of 404 (mirrors `ListHoldings` empty-list semantics).
- Year filter uses `EXTRACT(YEAR FROM paid_at)` so a row settled in January counts toward the year it actually moved money. Both totals come back from a single CASE-summed query.

Closes #226.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make lint` (0 issues)
- [x] New unit tests cover client-found, no-placer-empty, employee email→empID→placer chain, and the aggregate SUM
- [ ] Manual smoke: hit `GET /api/tax/me` as a client and as an actuary, verify both totals against `capital_gains` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)