### PR TITLE
feat(trading): daily-history backfill into listing_daily_price_info (#228)

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -57,6 +57,16 @@ func buildPricingClient() pricing.Client {
 	return pricing.NewMulti(clients...)
 }
 
+// buildDailyHistoryClient is AV-only: TIME_SERIES_DAILY is the spec-named
+// daily-history source (p.40) and Alpaca's bars endpoint is out of scope for
+// #228. nil here disables the backfiller, same convention as the refresher.
+func buildDailyHistoryClient() internalTrading.DailyHistoryClient {
+	if key := os.Getenv("ALPHAVANTAGE_KEY"); key != "" {
+		return pricing.NewAlphaVantage(key)
+	}
+	return nil
+}
+
 func main() {
 	port := os.Getenv("GRPC_PORT")
 	if port == "" {
@@ -90,6 +100,10 @@ func main() {
 	// #195.
 	stopRefresher := internalTrading.NewRefresher(gorm_db, buildPricingClient()).Start()
 	defer stopRefresher()
+
+	// Daily-history backfiller (#228). No-op without ALPHAVANTAGE_KEY.
+	stopBackfiller := internalTrading.NewBackfiller(gorm_db, buildDailyHistoryClient()).Start()
+	defer stopBackfiller()
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/internal/trading/backfill.go
+++ b/internal/trading/backfill.go
@@ -1,0 +1,179 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/gorm"
+)
+
+// Daily-history backfiller (#228). Sibling to the price Refresher in
+// refresher.go, but writes into `listing_daily_price_info` instead of
+// `listings`. Spec p.40 names Alpha Vantage's TIME_SERIES_DAILY as the
+// historical-price source, so this is hard-tied to AV (Alpaca's bars endpoint
+// has a different shape and is not in scope).
+//
+// Two boundaries with the executor we have to respect:
+//
+//  1. The executor writes `volume` into the same row on every fill via
+//     `upsertDailyVolume` (executor.go), and the executor's `nextDelay`
+//     formula keys off that volume. Our upsert therefore only updates
+//     price/ask/bid/change — never volume — so historical fills aren't
+//     clobbered.
+//
+//  2. AV daily data has no level-1 spread (close-of-day only), so ask/bid
+//     mirror price. Same compromise the GLOBAL_QUOTE refresher already
+//     makes; the intraday refresher overwrites today's row with a real
+//     spread on the next tick anyway.
+const (
+	backfillDefaultInterval = 24 * time.Hour
+	backfillPerCallDelay    = 13 * time.Second // ~4.6 calls/min — under AV's 5/min cap
+	backfillWindowDays      = 30               // bound on first run so 25/day cap survives
+)
+
+// DailyHistoryClient is the narrow interface the backfiller consumes. The AV
+// client satisfies it; tests stub it. Kept off the generic pricing.Client
+// interface because Alpaca's bars endpoint isn't part of the issue scope and
+// adding a no-op there would just be dead code.
+type DailyHistoryClient interface {
+	GetDailyHistory(ctx context.Context, ticker string) ([]pricing.DailyBar, error)
+}
+
+type Backfiller struct {
+	DB           *gorm.DB
+	Client       DailyHistoryClient
+	Interval     time.Duration
+	PerCallDelay time.Duration
+	WindowDays   int
+	Now          func() time.Time
+}
+
+func NewBackfiller(db *gorm.DB, client DailyHistoryClient) *Backfiller {
+	return &Backfiller{
+		DB:           db,
+		Client:       client,
+		Interval:     backfillDefaultInterval,
+		PerCallDelay: backfillPerCallDelay,
+		WindowDays:   backfillWindowDays,
+		Now:          time.Now,
+	}
+}
+
+// Start mirrors Refresher.Start. Nil client => no-op cancel so dev/CI without
+// AV keys don't spawn a goroutine that does nothing.
+func (b *Backfiller) Start() func() {
+	if b.Client == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go b.run(ctx)
+	return cancel
+}
+
+func (b *Backfiller) run(ctx context.Context) {
+	// First pass fires immediately so an operator restart inside market hours
+	// gets recent history within the per-call-delay budget rather than after
+	// a full day.
+	b.runOnce(ctx)
+	t := time.NewTicker(b.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.runOnce(ctx)
+		}
+	}
+}
+
+func (b *Backfiller) runOnce(ctx context.Context) {
+	targets, err := b.loadTargets()
+	if err != nil {
+		log.Printf("[Backfiller] load targets: %v", err)
+		return
+	}
+	for i, tgt := range targets {
+		if ctx.Err() != nil {
+			return
+		}
+		if i > 0 && b.PerCallDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(b.PerCallDelay):
+			}
+		}
+		if err := b.backfillOne(ctx, tgt); err != nil {
+			if errors.Is(err, pricing.ErrNotFound) {
+				continue
+			}
+			if errors.Is(err, pricing.ErrRateLimited) {
+				log.Printf("[Backfiller] rate limited; aborting tick after %s", tgt.Ticker)
+				return
+			}
+			log.Printf("[Backfiller] %s: %v", tgt.Ticker, err)
+		}
+	}
+}
+
+// loadTargets reuses the same shape as the refresher — same selection rule
+// (stock listings only) since AV's TIME_SERIES_DAILY only handles equities.
+func (b *Backfiller) loadTargets() ([]refreshTarget, error) {
+	var rows []refreshTarget
+	err := b.DB.Table("listings AS l").
+		Select("l.id AS listing_id, s.ticker AS ticker").
+		Joins("JOIN stocks s ON s.id = l.stock_id").
+		Where("l.stock_id IS NOT NULL").
+		Order("l.id").
+		Scan(&rows).Error
+	return rows, err
+}
+
+func (b *Backfiller) backfillOne(ctx context.Context, tgt refreshTarget) error {
+	bars, err := b.Client.GetDailyHistory(ctx, tgt.Ticker)
+	if err != nil {
+		return err
+	}
+	if len(bars) == 0 {
+		return nil
+	}
+	// Bars come back newest-first; trim to the configured window. Older bars
+	// are dropped on purpose — first-run backfill on the full 100-day compact
+	// window would still fit the 25-call cap, but we don't need that depth
+	// for the chart history endpoint.
+	window := b.WindowDays
+	if window <= 0 {
+		window = backfillWindowDays
+	}
+	if len(bars) > window {
+		bars = bars[:window]
+	}
+
+	return b.DB.Transaction(func(tx *gorm.DB) error {
+		for _, bar := range bars {
+			// Intraday change (close - open). AV's daily endpoint doesn't
+			// hand back a "change" field, and computing close-vs-previous-
+			// close would require ordering across rows that aren't all in
+			// scope on every run.
+			change := bar.CloseCents - bar.OpenCents
+			err := tx.Exec(
+				`INSERT INTO listing_daily_price_info (listing_id, date, price, ask_price, bid_price, change, volume)
+				 VALUES (?, ?, ?, ?, ?, ?, 0)
+				 ON CONFLICT (listing_id, date)
+				 DO UPDATE SET price = EXCLUDED.price,
+				               ask_price = EXCLUDED.ask_price,
+				               bid_price = EXCLUDED.bid_price,
+				               change = EXCLUDED.change`,
+				tgt.ListingID, bar.Date, bar.CloseCents, bar.CloseCents, bar.CloseCents, change,
+			).Error
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/trading/backfill_test.go
+++ b/internal/trading/backfill_test.go
@@ -1,0 +1,201 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+)
+
+// dailyHistoryFake stubs the AV daily-history client so backfiller tests don't
+// need httptest. The real provider is covered separately.
+type dailyHistoryFake struct {
+	bars  map[string][]pricing.DailyBar
+	errs  map[string]error
+	calls []string
+}
+
+func (f *dailyHistoryFake) GetDailyHistory(_ context.Context, ticker string) ([]pricing.DailyBar, error) {
+	f.calls = append(f.calls, ticker)
+	if err, ok := f.errs[ticker]; ok {
+		return nil, err
+	}
+	if b, ok := f.bars[ticker]; ok {
+		return b, nil
+	}
+	return nil, pricing.ErrNotFound
+}
+
+func loadTargetsQuery() string {
+	return regexp.QuoteMeta(
+		`SELECT l.id AS listing_id, s.ticker AS ticker FROM listings AS l JOIN stocks s ON s.id = l.stock_id WHERE l.stock_id IS NOT NULL ORDER BY l.id`,
+	)
+}
+
+func TestBackfiller_RunOnce_UpsertsLastWindow(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL")
+	mock.ExpectQuery(loadTargetsQuery()).WillReturnRows(rows)
+
+	// Two-day window covered by three returned bars — oldest must be dropped.
+	d24 := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	d23 := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+	d22 := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	// Newest-first: 04-24 first.
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO listing_daily_price_info`)).
+		WithArgs(int64(1), d24, int64(41710), int64(41710), int64(41710), int64(41710-41200)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO listing_daily_price_info`)).
+		WithArgs(int64(1), d23, int64(41245), int64(41245), int64(41245), int64(41245-41000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Backfiller{
+		DB: gdb,
+		Client: &dailyHistoryFake{bars: map[string][]pricing.DailyBar{
+			"AAPL": {
+				{Date: d24, OpenCents: 41200, HighCents: 41800, LowCents: 41150, CloseCents: 41710},
+				{Date: d23, OpenCents: 41000, HighCents: 41500, LowCents: 40800, CloseCents: 41245},
+				{Date: d22, OpenCents: 40800, HighCents: 41200, LowCents: 40550, CloseCents: 41000},
+			},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		WindowDays:   2,
+		Now:          func() time.Time { return d24 },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestBackfiller_RunOnce_SkipsNotFound(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "RAFA"). // dummy, no AV data
+		AddRow(int64(2), "AAPL")
+	mock.ExpectQuery(loadTargetsQuery()).WillReturnRows(rows)
+
+	d24 := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO listing_daily_price_info`)).
+		WithArgs(int64(2), d24, int64(17421), int64(17421), int64(17421), int64(17421-17400)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Backfiller{
+		DB: gdb,
+		Client: &dailyHistoryFake{bars: map[string][]pricing.DailyBar{
+			"AAPL": {
+				{Date: d24, OpenCents: 17400, HighCents: 17500, LowCents: 17300, CloseCents: 17421},
+			},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		WindowDays:   30,
+		Now:          func() time.Time { return d24 },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestBackfiller_RunOnce_AbortsOnRateLimit(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT").
+		AddRow(int64(3), "GOOG")
+	mock.ExpectQuery(loadTargetsQuery()).WillReturnRows(rows)
+
+	d24 := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO listing_daily_price_info`)).
+		WithArgs(int64(1), d24, int64(17421), int64(17421), int64(17421), int64(17421-17400)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	fake := &dailyHistoryFake{
+		bars: map[string][]pricing.DailyBar{
+			"AAPL": {{Date: d24, OpenCents: 17400, CloseCents: 17421, HighCents: 17500, LowCents: 17300}},
+		},
+		errs: map[string]error{"MSFT": pricing.ErrRateLimited},
+	}
+	r := &Backfiller{
+		DB:           gdb,
+		Client:       fake,
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		WindowDays:   30,
+		Now:          func() time.Time { return d24 },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+	for _, c := range fake.calls {
+		if c == "GOOG" {
+			t.Errorf("GOOG queried after rate-limit; calls=%v", fake.calls)
+		}
+	}
+}
+
+func TestBackfiller_RunOnce_TransientErrorContinues(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"listing_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT")
+	mock.ExpectQuery(loadTargetsQuery()).WillReturnRows(rows)
+
+	d24 := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO listing_daily_price_info`)).
+		WithArgs(int64(2), d24, int64(41245), int64(41245), int64(41245), int64(41245-41000)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &Backfiller{
+		DB: gdb,
+		Client: &dailyHistoryFake{
+			bars: map[string][]pricing.DailyBar{
+				"MSFT": {{Date: d24, OpenCents: 41000, CloseCents: 41245, HighCents: 41500, LowCents: 40900}},
+			},
+			errs: map[string]error{"AAPL": errors.New("connection refused")},
+		},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		WindowDays:   30,
+		Now:          func() time.Time { return d24 },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestBackfiller_Start_NilClientIsNoop(t *testing.T) {
+	r := &Backfiller{Client: nil}
+	cancel := r.Start()
+	cancel()
+}

--- a/internal/trading/pricing/alphavantage.go
+++ b/internal/trading/pricing/alphavantage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -104,4 +105,97 @@ func (c *AlphaVantageClient) GetQuote(ctx context.Context, ticker string) (Quote
 		BidCents:   cents,
 		At:         time.Now().UTC(),
 	}, nil
+}
+
+// DailyBar is a single day of OHLC data from a provider's daily-history
+// endpoint. Volume is intentionally omitted — our `listing_daily_price_info`
+// volume column is owned by the executor's intraday fills (#184), and the
+// provider's reported volume is on a different population (full-market book vs
+// our matched book) so mixing them would corrupt the executor's `nextDelay`
+// formula.
+type DailyBar struct {
+	Date       time.Time
+	OpenCents  int64
+	HighCents  int64
+	LowCents   int64
+	CloseCents int64
+}
+
+// avDailyResponse maps the TIME_SERIES_DAILY shape. Same zero-padded keys as
+// GLOBAL_QUOTE; the rate-limit / not-found / error envelope is also identical.
+type avDailyResponse struct {
+	TimeSeries  map[string]map[string]string `json:"Time Series (Daily)"`
+	Note        string                       `json:"Note"`
+	Information string                       `json:"Information"`
+	ErrorMsg    string                       `json:"Error Message"`
+}
+
+// GetDailyHistory hits TIME_SERIES_DAILY for the ticker and returns parsed
+// OHLC bars sorted newest-first. We rely on the default `outputsize=compact`
+// (last 100 trading days) since the backfiller only persists a recent window
+// and we'd be paying bandwidth for nothing on `full` (20+ years).
+func (c *AlphaVantageClient) GetDailyHistory(ctx context.Context, ticker string) ([]DailyBar, error) {
+	if c.APIKey == "" {
+		return nil, fmt.Errorf("alphavantage: missing API key")
+	}
+	q := url.Values{}
+	q.Set("function", "TIME_SERIES_DAILY")
+	q.Set("symbol", strings.ToUpper(strings.TrimSpace(ticker)))
+	q.Set("apikey", c.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/query?"+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("alphavantage: status %d", resp.StatusCode)
+	}
+
+	var body avDailyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if body.Note != "" || body.Information != "" {
+		return nil, ErrRateLimited
+	}
+	if body.ErrorMsg != "" {
+		return nil, ErrNotFound
+	}
+	if len(body.TimeSeries) == 0 {
+		return nil, ErrNotFound
+	}
+
+	bars := make([]DailyBar, 0, len(body.TimeSeries))
+	for dateStr, vals := range body.TimeSeries {
+		d, err := time.ParseInLocation("2006-01-02", dateStr, time.UTC)
+		if err != nil {
+			continue
+		}
+		open, errOpen := strconv.ParseFloat(vals["1. open"], 64)
+		high, errHigh := strconv.ParseFloat(vals["2. high"], 64)
+		low, errLow := strconv.ParseFloat(vals["3. low"], 64)
+		closeP, errClose := strconv.ParseFloat(vals["4. close"], 64)
+		if errOpen != nil || errHigh != nil || errLow != nil || errClose != nil {
+			continue
+		}
+		oc, ok1 := dollarsToCents(open)
+		hc, ok2 := dollarsToCents(high)
+		lc, ok3 := dollarsToCents(low)
+		cc, ok4 := dollarsToCents(closeP)
+		if !ok1 || !ok2 || !ok3 || !ok4 {
+			continue
+		}
+		bars = append(bars, DailyBar{Date: d, OpenCents: oc, HighCents: hc, LowCents: lc, CloseCents: cc})
+	}
+	if len(bars) == 0 {
+		return nil, ErrNotFound
+	}
+	sort.Slice(bars, func(i, j int) bool { return bars[i].Date.After(bars[j].Date) })
+	return bars, nil
 }

--- a/internal/trading/pricing/alphavantage_daily_test.go
+++ b/internal/trading/pricing/alphavantage_daily_test.go
@@ -1,0 +1,123 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const avDailyOK = `{
+  "Meta Data": {"2. Symbol": "MSFT"},
+  "Time Series (Daily)": {
+    "2026-04-23": {"1. open": "410.00", "2. high": "415.00", "3. low": "408.00", "4. close": "412.45", "5. volume": "12345"},
+    "2026-04-24": {"1. open": "412.00", "2. high": "418.00", "3. low": "411.50", "4. close": "417.10", "5. volume": "98765"},
+    "2026-04-22": {"1. open": "408.00", "2. high": "412.00", "3. low": "405.50", "4. close": "410.00", "5. volume": "55555"}
+  }
+}`
+
+func TestAlphaVantage_DailyHistory_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("function"); got != "TIME_SERIES_DAILY" {
+			t.Errorf("function = %q, want TIME_SERIES_DAILY", got)
+		}
+		if got := r.URL.Query().Get("symbol"); got != "MSFT" {
+			t.Errorf("symbol = %q, want MSFT", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(avDailyOK))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	bars, err := c.GetDailyHistory(context.Background(), "msft")
+	if err != nil {
+		t.Fatalf("GetDailyHistory: %v", err)
+	}
+	if len(bars) != 3 {
+		t.Fatalf("len(bars) = %d, want 3", len(bars))
+	}
+	// Newest-first ordering.
+	if bars[0].Date.Format("2006-01-02") != "2026-04-24" {
+		t.Errorf("bars[0].Date = %s, want 2026-04-24", bars[0].Date.Format("2006-01-02"))
+	}
+	if bars[2].Date.Format("2006-01-02") != "2026-04-22" {
+		t.Errorf("bars[2].Date = %s, want 2026-04-22", bars[2].Date.Format("2006-01-02"))
+	}
+	if bars[0].CloseCents != 41710 || bars[0].OpenCents != 41200 {
+		t.Errorf("bars[0] OHLC mismatch: open=%d close=%d", bars[0].OpenCents, bars[0].CloseCents)
+	}
+	if bars[0].HighCents != 41800 || bars[0].LowCents != 41150 {
+		t.Errorf("bars[0] high/low: %d/%d", bars[0].HighCents, bars[0].LowCents)
+	}
+}
+
+func TestAlphaVantage_DailyHistory_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Note":"frequency cap reached"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetDailyHistory(context.Background(), "MSFT")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestAlphaVantage_DailyHistory_UnknownTicker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// AV returns either an "Error Message" envelope or an empty time series for unknown symbols.
+		_, _ = w.Write([]byte(`{"Error Message":"Invalid API call"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetDailyHistory(context.Background(), "ZZZZZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlphaVantage_DailyHistory_EmptySeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Time Series (Daily)":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetDailyHistory(context.Background(), "ZZZZZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlphaVantage_DailyHistory_MissingKey(t *testing.T) {
+	c := NewAlphaVantage("")
+	_, err := c.GetDailyHistory(context.Background(), "MSFT")
+	if err == nil {
+		t.Fatal("expected error on missing key")
+	}
+}
+
+func TestAlphaVantage_DailyHistory_BadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetDailyHistory(context.Background(), "MSFT")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrRateLimited) {
+		t.Errorf("500 misclassified as %v", err)
+	}
+}


### PR DESCRIPTION
Closes #228.

## Summary
- Adds `pricing.DailyBar` + `AlphaVantageClient.GetDailyHistory` (TIME_SERIES_DAILY). Same rate-limit / not-found envelope handling as the existing `GetQuote`; bars come back newest-first.
- Adds `internal/trading/backfill.go` — a daily `Backfiller` sibling to the price `Refresher` from #184. Walks stock listings on a 24h tick, fetches bars, upserts the last 30 days into `listing_daily_price_info` with `ON CONFLICT (listing_id, date) DO UPDATE` on `price/ask/bid/change` **only** — `volume` stays owned by the executor's intraday `upsertDailyVolume` so the `nextDelay` formula isn't disturbed.
- Wires the backfiller into `cmd/bank/main.go`, gated on `ALPHAVANTAGE_KEY`. Independent of the refresher's gating; nil client => no-op cancel.

## Design notes
- AV daily data has no level-1 spread, so `ask = bid = close`. Same compromise the GLOBAL_QUOTE refresher already makes; today's row gets overwritten with a real spread on the next refresher tick anyway.
- `change` is computed as `close - open` (intraday). AV doesn't expose change-vs-previous-close on this endpoint, and computing it across rows wasn't worth the ordering complexity.
- Per-call delay is 13s (~4.6/min) — under AV's 5/min cap. With 22 stock listings in seed and the 25/day call cap, one cron pass uses 22/25, leaving room for refresher fallbacks. ErrRateLimited short-circuits the rest of the tick.
- `DailyHistoryClient` is a narrow local interface, not added to `pricing.Client`, since Alpaca's bars endpoint isn't in scope for #228.

## Test plan
- [x] `go test ./internal/trading/pricing/...` — `GetDailyHistory` covered: success (newest-first ordering, OHLC math), rate-limit, error envelope, empty series, missing key, 500.
- [x] `go test ./internal/trading/...` — `Backfiller.runOnce` covered with sqlmock + fake client: window trim drops oldest bar, ErrNotFound skip, ErrRateLimited aborts mid-tick, transient errors continue, nil-client `Start()` is a no-op.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- [ ] Smoke run against compose with a real `ALPHAVANTAGE_KEY` (manual; deferred until key available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)