### PR TITLE
feat(trading): weekly OVERVIEW sync for stock metadata (#229)

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -67,6 +67,16 @@ func buildDailyHistoryClient() internalTrading.DailyHistoryClient {
 	return nil
 }
 
+// buildCompanyOverviewClient is AV-only as well: OVERVIEW has no Alpaca
+// equivalent and the spec table on p.40 names AV as the source for the
+// metadata fields the syncer touches (#229).
+func buildCompanyOverviewClient() internalTrading.CompanyOverviewClient {
+	if key := os.Getenv("ALPHAVANTAGE_KEY"); key != "" {
+		return pricing.NewAlphaVantage(key)
+	}
+	return nil
+}
+
 func main() {
 	port := os.Getenv("GRPC_PORT")
 	if port == "" {
@@ -104,6 +114,11 @@ func main() {
 	// Daily-history backfiller (#228). No-op without ALPHAVANTAGE_KEY.
 	stopBackfiller := internalTrading.NewBackfiller(gorm_db, buildDailyHistoryClient()).Start()
 	defer stopBackfiller()
+
+	// Stock metadata syncer (#229). Weekly OVERVIEW pull. No-op without
+	// ALPHAVANTAGE_KEY.
+	stopMetadata := internalTrading.NewMetadataSyncer(gorm_db, buildCompanyOverviewClient()).Start()
+	defer stopMetadata()
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/internal/trading/metadata.go
+++ b/internal/trading/metadata.go
@@ -1,0 +1,137 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/gorm"
+)
+
+// Stock metadata syncer (#229). Sibling to the price Refresher and the daily
+// Backfiller, but operates at a much lower cadence: spec p.40 lists Alpha
+// Vantage's OVERVIEW endpoint as the source of `outstanding_shares` and
+// `dividend_yield`, both of which only change quarterly. Weekly is plenty
+// and keeps us well clear of AV's free-tier 25-call/day cap.
+//
+// Why not roll this into the Refresher: different cadence (weekly vs
+// 5-min), different table (`stocks` vs `listings`), and OVERVIEW is an
+// AV-only endpoint while the Refresher composes Alpaca+AV via MultiClient.
+// Keeping them separate lets each loop's rate-limit budget stay simple.
+const (
+	metadataDefaultInterval = 7 * 24 * time.Hour
+	metadataPerCallDelay    = 13 * time.Second // ~4.6 calls/min — under AV's 5/min cap
+)
+
+// CompanyOverviewClient is the narrow interface the syncer consumes. Kept
+// off pricing.Client because OVERVIEW is AV-only — Alpaca has no equivalent
+// endpoint, so a unified interface would just be dead code on that side.
+type CompanyOverviewClient interface {
+	GetCompanyOverview(ctx context.Context, ticker string) (pricing.CompanyOverview, error)
+}
+
+type MetadataSyncer struct {
+	DB           *gorm.DB
+	Client       CompanyOverviewClient
+	Interval     time.Duration
+	PerCallDelay time.Duration
+	Now          func() time.Time
+}
+
+func NewMetadataSyncer(db *gorm.DB, client CompanyOverviewClient) *MetadataSyncer {
+	return &MetadataSyncer{
+		DB:           db,
+		Client:       client,
+		Interval:     metadataDefaultInterval,
+		PerCallDelay: metadataPerCallDelay,
+		Now:          time.Now,
+	}
+}
+
+// Start mirrors Refresher.Start / Backfiller.Start: nil client => no-op
+// cancel so dev/CI without ALPHAVANTAGE_KEY don't spawn an idle goroutine.
+func (m *MetadataSyncer) Start() func() {
+	if m.Client == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go m.run(ctx)
+	return cancel
+}
+
+func (m *MetadataSyncer) run(ctx context.Context) {
+	// First sync fires immediately so a fresh deploy doesn't sit on
+	// week-old seed values until the next tick.
+	m.runOnce(ctx)
+	t := time.NewTicker(m.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.runOnce(ctx)
+		}
+	}
+}
+
+// metadataTarget is the projection the sync needs. We update the `stocks`
+// row directly, so the stock id (not a listing id) is the key.
+type metadataTarget struct {
+	StockID int64
+	Ticker  string
+}
+
+func (m *MetadataSyncer) runOnce(ctx context.Context) {
+	targets, err := m.loadTargets()
+	if err != nil {
+		log.Printf("[MetadataSyncer] load targets: %v", err)
+		return
+	}
+	for i, tgt := range targets {
+		if ctx.Err() != nil {
+			return
+		}
+		if i > 0 && m.PerCallDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(m.PerCallDelay):
+			}
+		}
+		if err := m.syncOne(ctx, tgt); err != nil {
+			if errors.Is(err, pricing.ErrNotFound) {
+				continue
+			}
+			if errors.Is(err, pricing.ErrRateLimited) {
+				log.Printf("[MetadataSyncer] rate limited; aborting tick after %s", tgt.Ticker)
+				return
+			}
+			log.Printf("[MetadataSyncer] %s: %v", tgt.Ticker, err)
+		}
+	}
+}
+
+func (m *MetadataSyncer) loadTargets() ([]metadataTarget, error) {
+	var rows []metadataTarget
+	err := m.DB.Table("stocks").
+		Select("id AS stock_id, ticker AS ticker").
+		Order("id").
+		Scan(&rows).Error
+	return rows, err
+}
+
+func (m *MetadataSyncer) syncOne(ctx context.Context, tgt metadataTarget) error {
+	o, err := m.Client.GetCompanyOverview(ctx, tgt.Ticker)
+	if err != nil {
+		return err
+	}
+	return m.DB.Model(&Stock{}).
+		Where("id = ?", tgt.StockID).
+		Updates(map[string]any{
+			"outstanding_shares": o.SharesOutstanding,
+			"dividend_yield":     o.DividendYield,
+		}).Error
+}

--- a/internal/trading/metadata_test.go
+++ b/internal/trading/metadata_test.go
@@ -1,0 +1,132 @@
+package trading
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+)
+
+// overviewFake stubs the AV OVERVIEW client so syncer tests don't need
+// httptest. The provider is covered separately.
+type overviewFake struct {
+	overviews map[string]pricing.CompanyOverview
+	errs      map[string]error
+	calls     []string
+}
+
+func (f *overviewFake) GetCompanyOverview(_ context.Context, ticker string) (pricing.CompanyOverview, error) {
+	f.calls = append(f.calls, ticker)
+	if err, ok := f.errs[ticker]; ok {
+		return pricing.CompanyOverview{}, err
+	}
+	if o, ok := f.overviews[ticker]; ok {
+		return o, nil
+	}
+	return pricing.CompanyOverview{}, pricing.ErrNotFound
+}
+
+func loadStocksQuery() string {
+	return regexp.QuoteMeta(`SELECT id AS stock_id, ticker AS ticker FROM "stocks" ORDER BY id`)
+}
+
+func TestMetadataSyncer_RunOnce_UpdatesStocks(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"stock_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT")
+	mock.ExpectQuery(loadStocksQuery()).WillReturnRows(rows)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "stocks"`).
+		WithArgs(0.005, int64(15500000000), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "stocks"`).
+		WithArgs(0.0072, int64(7430000000), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	m := &MetadataSyncer{
+		DB: gdb,
+		Client: &overviewFake{overviews: map[string]pricing.CompanyOverview{
+			"AAPL": {Ticker: "AAPL", SharesOutstanding: 15500000000, DividendYield: 0.005},
+			"MSFT": {Ticker: "MSFT", SharesOutstanding: 7430000000, DividendYield: 0.0072},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          time.Now,
+	}
+	m.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMetadataSyncer_RunOnce_SkipsNotFound(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"stock_id", "ticker"}).
+		AddRow(int64(1), "RAFA"). // dummy seed
+		AddRow(int64(2), "MSFT")
+	mock.ExpectQuery(loadStocksQuery()).WillReturnRows(rows)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "stocks"`).
+		WithArgs(0.0072, int64(7430000000), int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	m := &MetadataSyncer{
+		DB: gdb,
+		Client: &overviewFake{overviews: map[string]pricing.CompanyOverview{
+			"MSFT": {Ticker: "MSFT", SharesOutstanding: 7430000000, DividendYield: 0.0072},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          time.Now,
+	}
+	m.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMetadataSyncer_RunOnce_AbortsOnRateLimit(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	rows := sqlmock.NewRows([]string{"stock_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT") // never reached
+	mock.ExpectQuery(loadStocksQuery()).WillReturnRows(rows)
+
+	m := &MetadataSyncer{
+		DB:           gdb,
+		Client:       &overviewFake{errs: map[string]error{"AAPL": pricing.ErrRateLimited}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          time.Now,
+	}
+	m.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestMetadataSyncer_NilClient_NoOp(t *testing.T) {
+	m := NewMetadataSyncer(nil, nil)
+	stop := m.Start()
+	stop()
+}

--- a/internal/trading/pricing/alphavantage.go
+++ b/internal/trading/pricing/alphavantage.go
@@ -199,3 +199,89 @@ func (c *AlphaVantageClient) GetDailyHistory(ctx context.Context, ticker string)
 	sort.Slice(bars, func(i, j int) bool { return bars[i].Date.After(bars[j].Date) })
 	return bars, nil
 }
+
+// CompanyOverview is the trimmed projection of AV's OVERVIEW endpoint we
+// actually persist. AV's response carries ~60 fields (sector, industry,
+// margins, ratios, ...); we only need the two the spec table on p.40 calls
+// out as derived from this source.
+type CompanyOverview struct {
+	Ticker            string
+	SharesOutstanding int64
+	// DividendYield is a fraction (0.0072 = 0.72%). AV returns it as a string
+	// in that exact form; "None" means the issuer doesn't pay a dividend, in
+	// which case we surface 0.
+	DividendYield float64
+}
+
+// avOverviewResponse is the relevant subset of AV's OVERVIEW shape. The
+// envelope (Note/Information/Error Message) matches the other endpoints; the
+// not-found case for OVERVIEW is an empty JSON object `{}`, which decodes to
+// a zero Symbol.
+type avOverviewResponse struct {
+	Symbol            string `json:"Symbol"`
+	SharesOutstanding string `json:"SharesOutstanding"`
+	DividendYield     string `json:"DividendYield"`
+	Note              string `json:"Note"`
+	Information       string `json:"Information"`
+	ErrorMsg          string `json:"Error Message"`
+}
+
+// GetCompanyOverview hits function=OVERVIEW for the ticker. Used by the
+// weekly metadata syncer (#229). Treats the empty-body and "None"-dividend
+// cases as soft skips so dummy seeds (RAFA/RAFB) and non-dividend payers
+// don't pollute logs.
+func (c *AlphaVantageClient) GetCompanyOverview(ctx context.Context, ticker string) (CompanyOverview, error) {
+	if c.APIKey == "" {
+		return CompanyOverview{}, fmt.Errorf("alphavantage: missing API key")
+	}
+	q := url.Values{}
+	q.Set("function", "OVERVIEW")
+	q.Set("symbol", strings.ToUpper(strings.TrimSpace(ticker)))
+	q.Set("apikey", c.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/query?"+q.Encode(), nil)
+	if err != nil {
+		return CompanyOverview{}, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return CompanyOverview{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return CompanyOverview{}, fmt.Errorf("alphavantage: status %d", resp.StatusCode)
+	}
+
+	var body avOverviewResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return CompanyOverview{}, err
+	}
+	if body.Note != "" || body.Information != "" {
+		return CompanyOverview{}, ErrRateLimited
+	}
+	if body.ErrorMsg != "" {
+		return CompanyOverview{}, ErrNotFound
+	}
+	if body.Symbol == "" {
+		return CompanyOverview{}, ErrNotFound
+	}
+
+	out := CompanyOverview{Ticker: strings.ToUpper(ticker)}
+	// SharesOutstanding: required for the field to be useful. Treat unparseable
+	// or zero as not-found so we never overwrite a valid seed with garbage.
+	shares, err := strconv.ParseInt(strings.TrimSpace(body.SharesOutstanding), 10, 64)
+	if err != nil || shares <= 0 {
+		return CompanyOverview{}, ErrNotFound
+	}
+	out.SharesOutstanding = shares
+	// DividendYield: "None" or empty means non-dividend payer; surface 0.
+	if dy := strings.TrimSpace(body.DividendYield); dy != "" && !strings.EqualFold(dy, "None") {
+		v, err := strconv.ParseFloat(dy, 64)
+		if err != nil {
+			return CompanyOverview{}, fmt.Errorf("alphavantage: bad dividend yield %q: %w", dy, err)
+		}
+		out.DividendYield = v
+	}
+	return out, nil
+}

--- a/internal/trading/pricing/alphavantage_overview_test.go
+++ b/internal/trading/pricing/alphavantage_overview_test.go
@@ -1,0 +1,108 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAlphaVantageOverview_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("function"); got != "OVERVIEW" {
+			t.Errorf("function = %q, want OVERVIEW", got)
+		}
+		if got := r.URL.Query().Get("symbol"); got != "MSFT" {
+			t.Errorf("symbol = %q, want MSFT", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Symbol":"MSFT","SharesOutstanding":"7430000000","DividendYield":"0.0072"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	o, err := c.GetCompanyOverview(context.Background(), "msft")
+	if err != nil {
+		t.Fatalf("GetCompanyOverview: %v", err)
+	}
+	if o.Ticker != "MSFT" {
+		t.Errorf("ticker = %q", o.Ticker)
+	}
+	if o.SharesOutstanding != 7430000000 {
+		t.Errorf("shares = %d", o.SharesOutstanding)
+	}
+	if o.DividendYield != 0.0072 {
+		t.Errorf("yield = %v", o.DividendYield)
+	}
+}
+
+func TestAlphaVantageOverview_NoneDividend(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Symbol":"NVDA","SharesOutstanding":"24500000000","DividendYield":"None"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	o, err := c.GetCompanyOverview(context.Background(), "NVDA")
+	if err != nil {
+		t.Fatalf("GetCompanyOverview: %v", err)
+	}
+	if o.DividendYield != 0 {
+		t.Errorf("yield = %v, want 0 (None)", o.DividendYield)
+	}
+}
+
+func TestAlphaVantageOverview_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Information":"daily quota exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetCompanyOverview(context.Background(), "MSFT")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestAlphaVantageOverview_UnknownTicker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetCompanyOverview(context.Background(), "RAFA")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlphaVantageOverview_ZeroShares(t *testing.T) {
+	// Defensive: AV occasionally returns "0" or "-" for SharesOutstanding on
+	// stale tickers. We treat that as not-found to avoid clobbering seed data.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Symbol":"X","SharesOutstanding":"0","DividendYield":"0"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAlphaVantage("demo")
+	c.BaseURL = srv.URL
+	_, err := c.GetCompanyOverview(context.Background(), "X")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAlphaVantageOverview_MissingKey(t *testing.T) {
+	c := NewAlphaVantage("")
+	_, err := c.GetCompanyOverview(context.Background(), "MSFT")
+	if err == nil {
+		t.Fatal("expected error on missing key")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GetCompanyOverview` to the AV client (function=OVERVIEW), parsing `Symbol`, `SharesOutstanding`, `DividendYield` with the same rate-limit / not-found envelope as the existing endpoints.
- New `MetadataSyncer` (sibling to `Refresher` and `Backfiller`) walks the `stocks` table on a weekly cron and updates `outstanding_shares` / `dividend_yield`. Skips unrecognized tickers (RAFA/RAFB seeds, "None" dividend, zero shares).
- Wired into `cmd/bank/main.go`; no-op without `ALPHAVANTAGE_KEY` (same convention as #184/#228).

Closes #229.

## Test plan
- [x] `go test ./...`
- [ ] Manual: set `ALPHAVANTAGE_KEY`, restart bank, observe `stocks.outstanding_shares` / `dividend_yield` populate within ~5 min on a known ticker (e.g. MSFT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)