### PR TITLE
feat(trading): external pricing for options chain and forex pairs (#230)

### DIFF
--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -77,6 +77,27 @@ func buildCompanyOverviewClient() internalTrading.CompanyOverviewClient {
 	return nil
 }
 
+// buildOptionsChainClient wires Yahoo Finance's options endpoint (#230).
+// Yahoo's public endpoint requires no API key, so we expose a single boolean
+// gate (TRADING_OPTIONS_REFRESH=1) to opt in — defaulting off so dev/CI runs
+// don't make outbound calls every hour.
+func buildOptionsChainClient() internalTrading.OptionsChainClient {
+	if os.Getenv("TRADING_OPTIONS_REFRESH") == "1" {
+		return pricing.NewYahoo()
+	}
+	return nil
+}
+
+// buildForexRatesClient wires exchangerate-api (#230). Open endpoint is
+// keyless; EXCHANGERATE_KEY routes to the paid host with the same response
+// shape. nil disables the forex refresher.
+func buildForexRatesClient() internalTrading.ForexRatesClient {
+	if os.Getenv("TRADING_FOREX_REFRESH") == "1" || os.Getenv("EXCHANGERATE_KEY") != "" {
+		return pricing.NewExchangeRate(os.Getenv("EXCHANGERATE_KEY"))
+	}
+	return nil
+}
+
 func main() {
 	port := os.Getenv("GRPC_PORT")
 	if port == "" {
@@ -119,6 +140,16 @@ func main() {
 	// ALPHAVANTAGE_KEY.
 	stopMetadata := internalTrading.NewMetadataSyncer(gorm_db, buildCompanyOverviewClient()).Start()
 	defer stopMetadata()
+
+	// Options-chain refresher (#230). Yahoo Finance, opt-in via
+	// TRADING_OPTIONS_REFRESH=1.
+	stopOptions := internalTrading.NewOptionsRefresher(gorm_db, buildOptionsChainClient()).Start()
+	defer stopOptions()
+
+	// Forex-rates refresher (#230). exchangerate-api, opt-in via
+	// TRADING_FOREX_REFRESH=1 or by setting EXCHANGERATE_KEY.
+	stopForex := internalTrading.NewForexRefresher(gorm_db, buildForexRatesClient()).Start()
+	defer stopForex()
 
 	srv := grpc.NewServer()
 	bank.RegisterBankServiceServer(srv, bankService)

--- a/internal/trading/forex_refresher.go
+++ b/internal/trading/forex_refresher.go
@@ -1,0 +1,142 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/gorm"
+)
+
+// Forex refresher (#230). Pulls latest FX rates from exchangerate-api and
+// writes `forex_pairs.exchange_rate`. Spec p.42 lists 8 supported currencies
+// → 8x7=56 pairs; one call per base currency covers all quote pairs that
+// share it, so a tick costs at most 8 requests.
+//
+// Cadence matches the price refresher so dashboards see FX moves with the
+// same latency as stock prices.
+const (
+	forexRefreshDefaultInterval = 5 * time.Minute
+	forexRefreshPerCallDelay    = 1 * time.Second // open endpoint is generous; small delay smooths bursts.
+)
+
+// ForexRatesClient is the narrow interface the forex refresher consumes. Kept
+// off pricing.Client because the rates endpoint returns a map, not a Quote.
+type ForexRatesClient interface {
+	GetRates(ctx context.Context, base string) (map[string]float64, error)
+}
+
+type ForexRefresher struct {
+	DB           *gorm.DB
+	Client       ForexRatesClient
+	Interval     time.Duration
+	PerCallDelay time.Duration
+	Now          func() time.Time
+}
+
+func NewForexRefresher(db *gorm.DB, client ForexRatesClient) *ForexRefresher {
+	return &ForexRefresher{
+		DB:           db,
+		Client:       client,
+		Interval:     forexRefreshDefaultInterval,
+		PerCallDelay: forexRefreshPerCallDelay,
+		Now:          time.Now,
+	}
+}
+
+func (r *ForexRefresher) Start() func() {
+	if r.Client == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.run(ctx)
+	return cancel
+}
+
+func (r *ForexRefresher) run(ctx context.Context) {
+	r.runOnce(ctx)
+	t := time.NewTicker(r.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+func (r *ForexRefresher) runOnce(ctx context.Context) {
+	bases, err := r.loadBases()
+	if err != nil {
+		log.Printf("[ForexRefresher] load bases: %v", err)
+		return
+	}
+	for i, base := range bases {
+		if ctx.Err() != nil {
+			return
+		}
+		if i > 0 && r.PerCallDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(r.PerCallDelay):
+			}
+		}
+		if err := r.refreshBase(ctx, base); err != nil {
+			if errors.Is(err, pricing.ErrNotFound) {
+				continue
+			}
+			if errors.Is(err, pricing.ErrRateLimited) {
+				log.Printf("[ForexRefresher] rate limited; aborting tick after %s", base)
+				return
+			}
+			log.Printf("[ForexRefresher] %s: %v", base, err)
+		}
+	}
+}
+
+// loadBases collects the distinct base currencies in our 56-pair grid. One
+// upstream call covers every quote currency that shares the base.
+func (r *ForexRefresher) loadBases() ([]string, error) {
+	var bases []string
+	err := r.DB.Table("forex_pairs").
+		Distinct("base_currency").
+		Order("base_currency").
+		Pluck("base_currency", &bases).Error
+	return bases, err
+}
+
+func (r *ForexRefresher) refreshBase(ctx context.Context, base string) error {
+	rates, err := r.Client.GetRates(ctx, base)
+	if err != nil {
+		return err
+	}
+
+	// One UPDATE per pair under this base. Could be condensed into a CASE
+	// WHEN, but the per-base set is at most 7 rows and the simple loop keeps
+	// the query inspectable in logs.
+	return r.DB.Transaction(func(tx *gorm.DB) error {
+		var pairs []ForexPair
+		if err := tx.Where("base_currency = ?", base).Find(&pairs).Error; err != nil {
+			return err
+		}
+		for _, p := range pairs {
+			rate, ok := rates[p.QuoteCurrency]
+			if !ok || rate <= 0 {
+				// Quote currency not offered by the upstream — skip rather
+				// than overwrite the seed with zero.
+				continue
+			}
+			if err := tx.Model(&ForexPair{}).
+				Where("id = ?", p.ID).
+				Update("exchange_rate", rate).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/trading/forex_refresher_test.go
+++ b/internal/trading/forex_refresher_test.go
@@ -1,0 +1,144 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+)
+
+type forexFake struct {
+	rates map[string]map[string]float64
+	errs  map[string]error
+	calls []string
+}
+
+func (f *forexFake) GetRates(_ context.Context, base string) (map[string]float64, error) {
+	f.calls = append(f.calls, base)
+	if err, ok := f.errs[base]; ok {
+		return nil, err
+	}
+	if r, ok := f.rates[base]; ok {
+		return r, nil
+	}
+	return nil, pricing.ErrNotFound
+}
+
+func TestForexRefresher_RunOnce_UpdatesPairs(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT DISTINCT base_currency FROM "forex_pairs" ORDER BY base_currency`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"base_currency"}).AddRow("USD"))
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "forex_pairs" WHERE base_currency = $1`)).
+		WithArgs("USD").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "ticker", "name", "base_currency", "quote_currency", "exchange_rate", "liquidity",
+		}).
+			AddRow(int64(1), "USD/EUR", "x", "USD", "EUR", 0.90, "high").
+			AddRow(int64(2), "USD/JPY", "x", "USD", "JPY", 150.0, "high").
+			// XYZ has no rate from upstream — must be left untouched.
+			AddRow(int64(3), "USD/XYZ", "x", "USD", "XYZ", 1.0, "low"))
+
+	mock.ExpectExec(`UPDATE "forex_pairs"`).
+		WithArgs(0.93, int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE "forex_pairs"`).
+		WithArgs(151.42, int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &ForexRefresher{
+		DB: gdb,
+		Client: &forexFake{rates: map[string]map[string]float64{
+			"USD": {"EUR": 0.93, "JPY": 151.42},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}
+
+func TestForexRefresher_AbortsOnRateLimit(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT DISTINCT base_currency FROM "forex_pairs" ORDER BY base_currency`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"base_currency"}).
+		AddRow("EUR").
+		AddRow("USD"))
+
+	fake := &forexFake{errs: map[string]error{"EUR": pricing.ErrRateLimited}}
+	r := &ForexRefresher{
+		DB:           gdb,
+		Client:       fake,
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+	for _, c := range fake.calls {
+		if c == "USD" {
+			t.Errorf("USD was called after rate limit; calls=%v", fake.calls)
+		}
+	}
+}
+
+func TestForexRefresher_TransientErrorContinues(t *testing.T) {
+	gdb, mock, raw := newRefresherTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT DISTINCT base_currency FROM "forex_pairs" ORDER BY base_currency`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"base_currency"}).
+		AddRow("EUR").
+		AddRow("USD"))
+
+	// EUR fails transiently. USD proceeds to write.
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "forex_pairs" WHERE base_currency = $1`)).
+		WithArgs("USD").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "ticker", "name", "base_currency", "quote_currency", "exchange_rate", "liquidity",
+		}).AddRow(int64(2), "USD/EUR", "x", "USD", "EUR", 0.90, "high"))
+	mock.ExpectExec(`UPDATE "forex_pairs"`).
+		WithArgs(0.91, int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &ForexRefresher{
+		DB: gdb,
+		Client: &forexFake{
+			errs:  map[string]error{"EUR": errors.New("dns timeout")},
+			rates: map[string]map[string]float64{"USD": {"EUR": 0.91}},
+		},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}
+
+func TestForexRefresher_Start_NilClientIsNoop(t *testing.T) {
+	r := &ForexRefresher{Client: nil}
+	cancel := r.Start()
+	cancel()
+}

--- a/internal/trading/options_refresher.go
+++ b/internal/trading/options_refresher.go
@@ -1,0 +1,176 @@
+package trading
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/gorm"
+)
+
+// Options refresher (#230). Pulls per-stock option chains from Yahoo and
+// writes premium + implied_volatility back to matching `options` rows. Spec
+// p.44 names this endpoint and lists premium/IV as the fields fed by it.
+//
+// Why a separate refresher (instead of extending price Refresher):
+//
+//  1. Different provider (Yahoo, no API key) and different shape (per-stock
+//     chain, not per-ticker quote).
+//  2. Different write target (`options` rows, keyed on stock_id +
+//     option_type + strike + settlement_date — see #197 seed format which
+//     differs from Yahoo's contract symbol).
+//  3. Different cadence — one chain fetch covers many contracts so the
+//     bottleneck is unique stock count, not option count. Hourly is plenty
+//     and keeps us well clear of Yahoo's soft 429 threshold.
+const (
+	optionsRefreshDefaultInterval = time.Hour
+	optionsRefreshPerCallDelay    = 2 * time.Second // Yahoo has no published cap; spread calls so a many-stock seed doesn't burst.
+)
+
+// OptionsChainClient is the narrow interface the options refresher consumes.
+// Kept off pricing.Client because chains aren't quote-shaped — adding it to
+// the unified interface would just be dead weight on Alpaca/AV.
+type OptionsChainClient interface {
+	GetOptionsChain(ctx context.Context, ticker string) ([]pricing.OptionContract, error)
+}
+
+type OptionsRefresher struct {
+	DB           *gorm.DB
+	Client       OptionsChainClient
+	Interval     time.Duration
+	PerCallDelay time.Duration
+	Now          func() time.Time
+}
+
+func NewOptionsRefresher(db *gorm.DB, client OptionsChainClient) *OptionsRefresher {
+	return &OptionsRefresher{
+		DB:           db,
+		Client:       client,
+		Interval:     optionsRefreshDefaultInterval,
+		PerCallDelay: optionsRefreshPerCallDelay,
+		Now:          time.Now,
+	}
+}
+
+func (r *OptionsRefresher) Start() func() {
+	if r.Client == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.run(ctx)
+	return cancel
+}
+
+func (r *OptionsRefresher) run(ctx context.Context) {
+	r.runOnce(ctx)
+	t := time.NewTicker(r.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+// optionsRefreshTarget is the underlying stock we walk per tick. We fetch one
+// chain per stock and apply matches to every option row that shares stock_id.
+type optionsRefreshTarget struct {
+	StockID int64
+	Ticker  string
+}
+
+func (r *OptionsRefresher) runOnce(ctx context.Context) {
+	targets, err := r.loadTargets()
+	if err != nil {
+		log.Printf("[OptionsRefresher] load targets: %v", err)
+		return
+	}
+	for i, tgt := range targets {
+		if ctx.Err() != nil {
+			return
+		}
+		if i > 0 && r.PerCallDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(r.PerCallDelay):
+			}
+		}
+		if err := r.refreshOne(ctx, tgt); err != nil {
+			if errors.Is(err, pricing.ErrNotFound) {
+				continue
+			}
+			if errors.Is(err, pricing.ErrRateLimited) {
+				log.Printf("[OptionsRefresher] rate limited; aborting tick after %s", tgt.Ticker)
+				return
+			}
+			log.Printf("[OptionsRefresher] %s: %v", tgt.Ticker, err)
+		}
+	}
+}
+
+// loadTargets walks the distinct stocks that have at least one option row.
+// Stocks with no options would just waste a Yahoo call; the inner join
+// filters them.
+func (r *OptionsRefresher) loadTargets() ([]optionsRefreshTarget, error) {
+	var rows []optionsRefreshTarget
+	err := r.DB.Table("stocks AS s").
+		Select("s.id AS stock_id, s.ticker AS ticker").
+		Joins("JOIN options o ON o.stock_id = s.id").
+		Group("s.id, s.ticker").
+		Order("s.id").
+		Scan(&rows).Error
+	return rows, err
+}
+
+func (r *OptionsRefresher) refreshOne(ctx context.Context, tgt optionsRefreshTarget) error {
+	chain, err := r.Client.GetOptionsChain(ctx, tgt.Ticker)
+	if err != nil {
+		return err
+	}
+	// Index the provider chain by (side, strike_cents, settle_date_utc) — the
+	// canonical fields. We can't match on contract symbol because the seed
+	// format (#197) doesn't follow Yahoo's MSFT220404C00180000 layout.
+	type key struct {
+		side   string
+		strike int64
+		settle time.Time
+	}
+	idx := make(map[key]pricing.OptionContract, len(chain))
+	for _, c := range chain {
+		idx[key{c.OptionType, c.StrikeCents, c.SettlementDate.UTC().Truncate(24 * time.Hour)}] = c
+	}
+
+	var rows []Option
+	if err := r.DB.Where("stock_id = ?", tgt.StockID).Find(&rows).Error; err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	return r.DB.Transaction(func(tx *gorm.DB) error {
+		for _, opt := range rows {
+			k := key{string(opt.OptionType), opt.StrikePrice, opt.SettlementDate.UTC().Truncate(24 * time.Hour)}
+			match, ok := idx[k]
+			if !ok {
+				continue
+			}
+			err := tx.Model(&Option{}).
+				Where("id = ?", opt.ID).
+				Updates(map[string]any{
+					"premium":            match.PremiumCents,
+					"implied_volatility": match.ImpliedVolatility,
+				}).Error
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/trading/options_refresher_test.go
+++ b/internal/trading/options_refresher_test.go
@@ -1,0 +1,201 @@
+package trading
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/internal/trading/pricing"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newOptionsTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: db}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return gormDB, mock, db
+}
+
+type optionsChainFake struct {
+	chains map[string][]pricing.OptionContract
+	errs   map[string]error
+	calls  []string
+}
+
+func (f *optionsChainFake) GetOptionsChain(_ context.Context, ticker string) ([]pricing.OptionContract, error) {
+	f.calls = append(f.calls, ticker)
+	if err, ok := f.errs[ticker]; ok {
+		return nil, err
+	}
+	if c, ok := f.chains[ticker]; ok {
+		return c, nil
+	}
+	return nil, pricing.ErrNotFound
+}
+
+func TestOptionsRefresher_RunOnce_UpdatesMatches(t *testing.T) {
+	gdb, mock, raw := newOptionsTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	settle := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+
+	// loadTargets: one stock with options.
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT s.id AS stock_id, s.ticker AS ticker FROM stocks AS s JOIN options o ON o.stock_id = s.id GROUP BY s.id, s.ticker ORDER BY s.id`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"stock_id", "ticker"}).AddRow(int64(7), "AAPL"))
+
+	// Inner load of options for the stock.
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "options" WHERE stock_id = $1`)).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "ticker", "name", "stock_id", "option_type",
+			"strike_price", "premium", "implied_volatility", "open_interest", "settlement_date",
+		}).
+			AddRow(int64(101), "AAPL_20260515_00015000_C", "x", int64(7), "call",
+				int64(15000), int64(500), 1.0, int64(0), settle).
+			AddRow(int64(102), "AAPL_20260515_00015000_P", "x", int64(7), "put",
+				int64(15000), int64(200), 1.0, int64(0), settle).
+			// row 103 has no provider counterpart (different strike) — must be left alone.
+			AddRow(int64(103), "AAPL_20260515_00099900_C", "x", int64(7), "call",
+				int64(99900), int64(50), 1.0, int64(0), settle))
+
+	mock.ExpectBegin()
+	// Two updates, one per matched row (call then put).
+	mock.ExpectExec(`UPDATE "options"`).
+		WithArgs(0.42, int64(1230), int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE "options"`).
+		WithArgs(0.39, int64(280), int64(102)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &OptionsRefresher{
+		DB: gdb,
+		Client: &optionsChainFake{chains: map[string][]pricing.OptionContract{
+			"AAPL": {
+				{OptionType: "call", StrikeCents: 15000, PremiumCents: 1230, ImpliedVolatility: 0.42, SettlementDate: settle},
+				{OptionType: "put", StrikeCents: 15000, PremiumCents: 280, ImpliedVolatility: 0.39, SettlementDate: settle},
+			},
+		}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+		Now:          func() time.Time { return time.Now() },
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}
+
+func TestOptionsRefresher_RunOnce_AbortsOnRateLimit(t *testing.T) {
+	gdb, mock, raw := newOptionsTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT s.id AS stock_id, s.ticker AS ticker FROM stocks AS s JOIN options o ON o.stock_id = s.id GROUP BY s.id, s.ticker ORDER BY s.id`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"stock_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT"))
+
+	fake := &optionsChainFake{
+		errs: map[string]error{"AAPL": pricing.ErrRateLimited},
+	}
+	r := &OptionsRefresher{
+		DB:           gdb,
+		Client:       fake,
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+	for _, c := range fake.calls {
+		if c == "MSFT" {
+			t.Errorf("MSFT was called after rate limit; calls=%v", fake.calls)
+		}
+	}
+}
+
+func TestOptionsRefresher_NotFoundIsSkipped(t *testing.T) {
+	gdb, mock, raw := newOptionsTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT s.id AS stock_id, s.ticker AS ticker FROM stocks AS s JOIN options o ON o.stock_id = s.id GROUP BY s.id, s.ticker ORDER BY s.id`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"stock_id", "ticker"}).AddRow(int64(99), "RAFA"))
+
+	r := &OptionsRefresher{
+		DB:           gdb,
+		Client:       &optionsChainFake{errs: map[string]error{"RAFA": pricing.ErrNotFound}},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}
+
+func TestOptionsRefresher_Start_NilClientIsNoop(t *testing.T) {
+	r := &OptionsRefresher{Client: nil}
+	cancel := r.Start()
+	cancel()
+}
+
+func TestOptionsRefresher_TransientErrorContinues(t *testing.T) {
+	gdb, mock, raw := newOptionsTestDB(t)
+	defer func() { _ = raw.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT s.id AS stock_id, s.ticker AS ticker FROM stocks AS s JOIN options o ON o.stock_id = s.id GROUP BY s.id, s.ticker ORDER BY s.id`,
+	)).WillReturnRows(sqlmock.NewRows([]string{"stock_id", "ticker"}).
+		AddRow(int64(1), "AAPL").
+		AddRow(int64(2), "MSFT"))
+
+	settle := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	// AAPL fails transiently — refresher should log + continue to MSFT.
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "options" WHERE stock_id = $1`)).
+		WithArgs(int64(2)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "ticker", "name", "stock_id", "option_type",
+			"strike_price", "premium", "implied_volatility", "open_interest", "settlement_date",
+		}).AddRow(int64(50), "x", "x", int64(2), "call",
+			int64(20000), int64(100), 1.0, int64(0), settle))
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "options"`).
+		WithArgs(0.5, int64(150), int64(50)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	r := &OptionsRefresher{
+		DB: gdb,
+		Client: &optionsChainFake{
+			errs: map[string]error{"AAPL": errors.New("connection reset")},
+			chains: map[string][]pricing.OptionContract{
+				"MSFT": {{OptionType: "call", StrikeCents: 20000, PremiumCents: 150, ImpliedVolatility: 0.5, SettlementDate: settle}},
+			},
+		},
+		Interval:     time.Hour,
+		PerCallDelay: 0,
+	}
+	r.runOnce(context.Background())
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet: %v", err)
+	}
+}

--- a/internal/trading/pricing/exchangerate.go
+++ b/internal/trading/pricing/exchangerate.go
@@ -1,0 +1,109 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ExchangeRateClient queries exchangerate-api.com's open endpoint
+// (https://open.er-api.com/v6/latest/{base}). Spec p.42 names this provider
+// for forex pair pricing. The open endpoint requires no API key and returns
+// every quote currency for a given base in one call, which fits the spec's
+// 8-currency / 56-pair grid in 8 requests max.
+//
+// The paid endpoint at https://v6.exchangerate-api.com/v6/{key}/latest/{base}
+// has the same response shape. APIKey is optional: when set we route through
+// the paid endpoint, otherwise the open one.
+type ExchangeRateClient struct {
+	APIKey  string
+	BaseURL string
+	HTTP    httpDoer
+}
+
+func NewExchangeRate(apiKey string) *ExchangeRateClient {
+	base := "https://open.er-api.com"
+	if apiKey != "" {
+		base = "https://v6.exchangerate-api.com"
+	}
+	return &ExchangeRateClient{
+		APIKey:  apiKey,
+		BaseURL: base,
+		HTTP:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *ExchangeRateClient) Name() string { return "exchangerate" }
+
+// exchangeRateResp covers both the open and paid endpoint shapes — they share
+// the same field names. `error-type` is set on failure (unsupported-code,
+// invalid-key, etc.); `result` is "success" or "error".
+type exchangeRateResp struct {
+	Result    string             `json:"result"`
+	BaseCode  string             `json:"base_code"`
+	Rates     map[string]float64 `json:"rates"`
+	ErrorType string             `json:"error-type"`
+}
+
+// GetRates returns the {quote-currency: rate} map for the given base. Rate is
+// "how many units of quote per 1 unit of base" — same direction as the
+// `forex_pairs.exchange_rate` column.
+func (c *ExchangeRateClient) GetRates(ctx context.Context, base string) (map[string]float64, error) {
+	base = strings.ToUpper(strings.TrimSpace(base))
+	if base == "" {
+		return nil, fmt.Errorf("exchangerate: empty base currency")
+	}
+
+	var u string
+	if c.APIKey != "" {
+		u = c.BaseURL + "/v6/" + url.PathEscape(c.APIKey) + "/latest/" + url.PathEscape(base)
+	} else {
+		u = c.BaseURL + "/v6/latest/" + url.PathEscape(base)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return nil, ErrRateLimited
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	case http.StatusOK:
+	default:
+		return nil, fmt.Errorf("exchangerate: status %d", resp.StatusCode)
+	}
+
+	var body exchangeRateResp
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if body.ErrorType != "" {
+		// Unsupported / unknown bases come back as 200 with an error envelope.
+		// Map the obvious not-found shapes; everything else is surfaced for
+		// logs (bad keys, plan-quota, etc).
+		switch body.ErrorType {
+		case "unsupported-code", "malformed-request", "base-code":
+			return nil, ErrNotFound
+		case "quota-reached":
+			return nil, ErrRateLimited
+		default:
+			return nil, fmt.Errorf("exchangerate: %s", body.ErrorType)
+		}
+	}
+	if len(body.Rates) == 0 {
+		return nil, ErrNotFound
+	}
+	return body.Rates, nil
+}

--- a/internal/trading/pricing/exchangerate_test.go
+++ b/internal/trading/pricing/exchangerate_test.go
@@ -1,0 +1,101 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExchangeRate_OpenEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v6/latest/USD" {
+			t.Errorf("path = %q, want /v6/latest/USD", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":"success","base_code":"USD","rates":{"EUR":0.93,"GBP":0.79,"JPY":151.42}}`))
+	}))
+	defer srv.Close()
+
+	c := NewExchangeRate("")
+	c.BaseURL = srv.URL
+	rates, err := c.GetRates(context.Background(), "usd")
+	if err != nil {
+		t.Fatalf("GetRates: %v", err)
+	}
+	if rates["EUR"] != 0.93 || rates["JPY"] != 151.42 {
+		t.Errorf("rates = %v", rates)
+	}
+}
+
+func TestExchangeRate_PaidEndpointEmbedsKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v6/secret-key/latest/") {
+			t.Errorf("path = %q, want it to embed the key", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"result":"success","base_code":"EUR","rates":{"USD":1.07}}`))
+	}))
+	defer srv.Close()
+
+	c := NewExchangeRate("secret-key")
+	c.BaseURL = srv.URL
+	rates, err := c.GetRates(context.Background(), "EUR")
+	if err != nil {
+		t.Fatalf("GetRates: %v", err)
+	}
+	if rates["USD"] != 1.07 {
+		t.Errorf("rates = %v", rates)
+	}
+}
+
+func TestExchangeRate_UnsupportedCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"error","error-type":"unsupported-code"}`))
+	}))
+	defer srv.Close()
+
+	c := NewExchangeRate("")
+	c.BaseURL = srv.URL
+	_, err := c.GetRates(context.Background(), "XYZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestExchangeRate_QuotaReached(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"error","error-type":"quota-reached"}`))
+	}))
+	defer srv.Close()
+
+	c := NewExchangeRate("k")
+	c.BaseURL = srv.URL
+	_, err := c.GetRates(context.Background(), "USD")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestExchangeRate_RateLimited429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewExchangeRate("")
+	c.BaseURL = srv.URL
+	_, err := c.GetRates(context.Background(), "USD")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestExchangeRate_EmptyBase(t *testing.T) {
+	c := NewExchangeRate("")
+	_, err := c.GetRates(context.Background(), "  ")
+	if err == nil {
+		t.Fatal("expected error on empty base")
+	}
+}

--- a/internal/trading/pricing/yahoo.go
+++ b/internal/trading/pricing/yahoo.go
@@ -1,0 +1,193 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// YahooClient queries the v6/finance/options endpoint
+// (https://query1.finance.yahoo.com/v6/finance/options/{ticker}). Spec p.44
+// names this as the source for the per-stock option chain — premium and
+// implied volatility for each strike/side/expiry. Yahoo's response also
+// includes a top-level `expirationDates` slice; a request without `?date=`
+// returns only the nearest expiry, so we make follow-up calls for each
+// remaining date and stitch the chain together.
+//
+// Rate limiting: Yahoo's public endpoint is not officially rate-limited but
+// will start returning 429 under heavy use. We surface that as
+// ErrRateLimited so the per-stock refresher can back off the same way the
+// stock-price refresher already does for AV.
+type YahooClient struct {
+	BaseURL string
+	HTTP    httpDoer
+}
+
+func NewYahoo() *YahooClient {
+	return &YahooClient{
+		BaseURL: "https://query1.finance.yahoo.com",
+		HTTP:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *YahooClient) Name() string { return "yahoo" }
+
+// OptionContract is the normalized projection of one Yahoo contract row. The
+// refresher keys on (OptionType, StrikeCents, SettlementDate) rather than the
+// contract symbol because our seed (#197) uses a different ticker format —
+// Yahoo's MSFT220404C00180000 vs our MSFT_20220404_00180000_C — and the spec
+// (p.43) explicitly notes formats differ across providers.
+type OptionContract struct {
+	ContractSymbol    string
+	OptionType        string // "call" or "put"
+	StrikeCents       int64
+	PremiumCents      int64
+	ImpliedVolatility float64
+	SettlementDate    time.Time
+}
+
+type yahooOptionsResp struct {
+	OptionChain struct {
+		Result []yahooOptionResult `json:"result"`
+		Error  *struct {
+			Code        string `json:"code"`
+			Description string `json:"description"`
+		} `json:"error"`
+	} `json:"optionChain"`
+}
+
+type yahooOptionResult struct {
+	UnderlyingSymbol string             `json:"underlyingSymbol"`
+	ExpirationDates  []int64            `json:"expirationDates"`
+	Options          []yahooOptionGroup `json:"options"`
+}
+
+type yahooOptionGroup struct {
+	ExpirationDate int64           `json:"expirationDate"`
+	Calls          []yahooContract `json:"calls"`
+	Puts           []yahooContract `json:"puts"`
+}
+
+type yahooContract struct {
+	ContractSymbol    string  `json:"contractSymbol"`
+	Strike            float64 `json:"strike"`
+	LastPrice         float64 `json:"lastPrice"`
+	ImpliedVolatility float64 `json:"impliedVolatility"`
+}
+
+// GetOptionsChain fetches every expiration the underlying carries. The first
+// request returns the closest expiry plus the full `expirationDates` index;
+// the remaining expiries each cost one call. This costs more requests per
+// ticker than a stock quote, which is why the options refresher walks at a
+// looser cadence than the price refresher (see options_refresher.go).
+func (c *YahooClient) GetOptionsChain(ctx context.Context, ticker string) ([]OptionContract, error) {
+	first, err := c.fetchChain(ctx, ticker, 0)
+	if err != nil {
+		return nil, err
+	}
+	if len(first.OptionChain.Result) == 0 {
+		return nil, ErrNotFound
+	}
+	res := first.OptionChain.Result[0]
+
+	seen := make(map[int64]bool, len(res.ExpirationDates))
+	out := make([]OptionContract, 0)
+	for _, g := range res.Options {
+		seen[g.ExpirationDate] = true
+		out = append(out, convertYahooContracts(g.ExpirationDate, g.Calls, "call")...)
+		out = append(out, convertYahooContracts(g.ExpirationDate, g.Puts, "put")...)
+	}
+	for _, exp := range res.ExpirationDates {
+		if seen[exp] {
+			continue
+		}
+		body, err := c.fetchChain(ctx, ticker, exp)
+		if err != nil {
+			// Rate limit short-circuits the whole call so the refresher can
+			// abort the tick. Per-expiry NotFound or transient errors are
+			// tolerated — a single bad expiry shouldn't lose the rest.
+			if errors.Is(err, ErrRateLimited) {
+				return nil, err
+			}
+			continue
+		}
+		if len(body.OptionChain.Result) == 0 {
+			continue
+		}
+		for _, g := range body.OptionChain.Result[0].Options {
+			out = append(out, convertYahooContracts(g.ExpirationDate, g.Calls, "call")...)
+			out = append(out, convertYahooContracts(g.ExpirationDate, g.Puts, "put")...)
+		}
+	}
+	if len(out) == 0 {
+		return nil, ErrNotFound
+	}
+	return out, nil
+}
+
+func (c *YahooClient) fetchChain(ctx context.Context, ticker string, date int64) (*yahooOptionsResp, error) {
+	u := c.BaseURL + "/v6/finance/options/" + url.PathEscape(strings.ToUpper(strings.TrimSpace(ticker)))
+	if date > 0 {
+		u += "?date=" + strconv.FormatInt(date, 10)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return nil, ErrRateLimited
+	case http.StatusNotFound:
+		return nil, ErrNotFound
+	case http.StatusOK:
+	default:
+		return nil, fmt.Errorf("yahoo: status %d", resp.StatusCode)
+	}
+
+	var body yahooOptionsResp
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if body.OptionChain.Error != nil {
+		return nil, ErrNotFound
+	}
+	return &body, nil
+}
+
+func convertYahooContracts(exp int64, contracts []yahooContract, kind string) []OptionContract {
+	out := make([]OptionContract, 0, len(contracts))
+	settle := time.Unix(exp, 0).UTC().Truncate(24 * time.Hour)
+	for _, k := range contracts {
+		sc, ok := dollarsToCents(k.Strike)
+		if !ok {
+			continue
+		}
+		// Premium can legitimately be 0 for deep OTM contracts; dollarsToCents
+		// rejects negatives and NaN/Inf only.
+		pc, ok := dollarsToCents(k.LastPrice)
+		if !ok {
+			continue
+		}
+		out = append(out, OptionContract{
+			ContractSymbol:    k.ContractSymbol,
+			OptionType:        kind,
+			StrikeCents:       sc,
+			PremiumCents:      pc,
+			ImpliedVolatility: k.ImpliedVolatility,
+			SettlementDate:    settle,
+		})
+	}
+	return out
+}

--- a/internal/trading/pricing/yahoo_test.go
+++ b/internal/trading/pricing/yahoo_test.go
@@ -1,0 +1,147 @@
+package pricing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestYahoo_FetchesAllExpirations(t *testing.T) {
+	exp1 := int64(1714694400) // 2024-05-03
+	exp2 := int64(1717113600) // 2024-05-31
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if !strings.HasPrefix(r.URL.Path, "/v6/finance/options/AAPL") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		date := r.URL.Query().Get("date")
+		if date == "" {
+			// First call: nearest expiry returned in `options`, full list in `expirationDates`.
+			fmt.Fprintf(w, `{"optionChain":{"result":[{"underlyingSymbol":"AAPL","expirationDates":[%d,%d],"options":[{"expirationDate":%d,"calls":[{"contractSymbol":"AAPL240503C00150000","strike":150,"lastPrice":12.5,"impliedVolatility":0.3}],"puts":[{"contractSymbol":"AAPL240503P00150000","strike":150,"lastPrice":2.25,"impliedVolatility":0.28}]}]}]}}`, exp1, exp2, exp1)
+			return
+		}
+		if date != "1717113600" {
+			t.Errorf("unexpected date param %q", date)
+		}
+		fmt.Fprintf(w, `{"optionChain":{"result":[{"underlyingSymbol":"AAPL","expirationDates":[%d,%d],"options":[{"expirationDate":%d,"calls":[{"contractSymbol":"AAPL240531C00160000","strike":160,"lastPrice":7.10,"impliedVolatility":0.32}],"puts":[]}]}]}}`, exp1, exp2, exp2)
+	}))
+	defer srv.Close()
+
+	c := NewYahoo()
+	c.BaseURL = srv.URL
+
+	chain, err := c.GetOptionsChain(context.Background(), "aapl")
+	if err != nil {
+		t.Fatalf("GetOptionsChain: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (one per expiry)", calls)
+	}
+	if len(chain) != 3 {
+		t.Fatalf("len(chain) = %d, want 3 (2 from exp1 + 1 from exp2)", len(chain))
+	}
+
+	// Spot-check normalization: 12.5 USD → 1250 cents, IV preserved as-is.
+	var aaplCall *OptionContract
+	for i := range chain {
+		if chain[i].ContractSymbol == "AAPL240503C00150000" {
+			aaplCall = &chain[i]
+			break
+		}
+	}
+	if aaplCall == nil {
+		t.Fatal("missing AAPL240503C00150000 in chain")
+	}
+	if aaplCall.PremiumCents != 1250 {
+		t.Errorf("premium = %d, want 1250", aaplCall.PremiumCents)
+	}
+	if aaplCall.StrikeCents != 15000 {
+		t.Errorf("strike = %d, want 15000", aaplCall.StrikeCents)
+	}
+	if aaplCall.OptionType != "call" {
+		t.Errorf("type = %q", aaplCall.OptionType)
+	}
+	if aaplCall.ImpliedVolatility != 0.3 {
+		t.Errorf("iv = %v, want 0.3", aaplCall.ImpliedVolatility)
+	}
+}
+
+func TestYahoo_UnknownTickerErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"optionChain":{"result":[],"error":{"code":"Not Found","description":"No data found"}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewYahoo()
+	c.BaseURL = srv.URL
+	_, err := c.GetOptionsChain(context.Background(), "ZZZZ")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestYahoo_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewYahoo()
+	c.BaseURL = srv.URL
+	_, err := c.GetOptionsChain(context.Background(), "AAPL")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestYahoo_BadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewYahoo()
+	c.BaseURL = srv.URL
+	_, err := c.GetOptionsChain(context.Background(), "AAPL")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrRateLimited) {
+		t.Errorf("500 misclassified as %v", err)
+	}
+}
+
+// Per-expiry transient errors should be tolerated — the chain returns the
+// expiries that did succeed rather than aborting the whole fetch.
+func TestYahoo_TolerateMissingExpiry(t *testing.T) {
+	exp1 := int64(1714694400)
+	exp2 := int64(1717113600)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		date := r.URL.Query().Get("date")
+		if date == "" {
+			fmt.Fprintf(w, `{"optionChain":{"result":[{"underlyingSymbol":"AAPL","expirationDates":[%d,%d],"options":[{"expirationDate":%d,"calls":[{"contractSymbol":"AAPL240503C00150000","strike":150,"lastPrice":12.5,"impliedVolatility":0.3}],"puts":[]}]}]}}`, exp1, exp2, exp1)
+			return
+		}
+		// Second expiry returns a server error.
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewYahoo()
+	c.BaseURL = srv.URL
+	chain, err := c.GetOptionsChain(context.Background(), "AAPL")
+	if err != nil {
+		t.Fatalf("GetOptionsChain: %v", err)
+	}
+	if len(chain) != 1 {
+		t.Errorf("len(chain) = %d, want 1 (only exp1 succeeded)", len(chain))
+	}
+}


### PR DESCRIPTION
Closes #230. Follow-up to #184 — extends external pricing to the two non-stock instrument types the spec calls out separately (pp.42, 44).

## Summary
- `pricing.YahooClient` — `GetOptionsChain(ticker)` against `query1.finance.yahoo.com/v6/finance/options/{ticker}`. Walks the `expirationDates` index so one call per expiry covers the whole chain. Maps 429 → `ErrRateLimited`, error envelope → `ErrNotFound`.
- `pricing.ExchangeRateClient` — `GetRates(base)` against exchangerate-api. Open endpoint when no key, paid endpoint when `EXCHANGERATE_KEY` is set; both share the response shape.
- `OptionsRefresher` (hourly) — walks distinct stocks that have options, fetches the chain, and updates `options.premium` + `options.implied_volatility` matching on (option_type, strike_cents, settlement_date) since the seed (#197) doesn't follow Yahoo's contract-symbol format.
- `ForexRefresher` (5-min) — walks distinct base currencies, calls upstream once per base (≤8 calls per tick for the 56-pair grid), updates `forex_pairs.exchange_rate`.
- Both refreshers opt-in via env (`TRADING_OPTIONS_REFRESH=1`, `TRADING_FOREX_REFRESH=1` / `EXCHANGERATE_KEY`), nil-client => no-op cancel — same convention as the existing refresher / backfiller / metadata-syncer.

## Why separate refreshers
Different providers, different shapes (chain vs quote vs rates map), different write targets, different cadences — bundling into the existing `Refresher` would have meant a polymorphic mess for very little shared code. Each has its own narrow client interface for the same reason `DailyHistoryClient` and `CompanyOverviewClient` aren't on `pricing.Client`.

## Test plan
- [x] `go test ./...` — all green
- [x] Yahoo client: success across multiple expiries, unknown ticker (error envelope), 429, 5xx, per-expiry transient tolerated
- [x] ExchangeRate client: open + paid endpoints, unsupported-code → NotFound, quota-reached → RateLimited, 429, empty base
- [x] OptionsRefresher: matches by (side, strike, settle), skips unmatched rows, aborts on rate-limit, NotFound skipped, transient continues, nil-client noop
- [x] ForexRefresher: updates per pair, leaves missing-quote pairs alone, aborts on rate-limit, transient continues, nil-client noop

🤖 Generated with [Claude Code](https://claude.com/claude-code)