### PR TITLE
fix(gateway,db): unblock browser login + drop pgx cached-plan errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,13 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
+    # Postgres 18+ stores data under /var/lib/postgresql/<major>/<cluster>
+    # to support pg_ctlcluster-style upgrades. Mounting /var/lib/postgresql
+    # (parent dir) instead of /var/lib/postgresql/data lets the image manage
+    # the version subdirectory itself; mounting /data triggers a hard fail
+    # at boot. See docker-library/postgres#1259.
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]

--- a/services/bank/cmd/main.go
+++ b/services/bank/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/proto/bank"
@@ -19,8 +20,25 @@ import (
 	"gorm.io/gorm"
 )
 
+// dsnWithExecMode forces pgx's `default_query_exec_mode=exec` unless the
+// caller has already pinned it. This sidesteps the "cached plan must not
+// change result type" failure that hits when migrations land *after* the
+// service connects (typical: docker compose up → schema.sql → seed.sql,
+// where the connection pool predates the schema). `exec` skips the per-
+// statement describe-cache without dropping prepared statements wholesale.
+func dsnWithExecMode(dsn string) string {
+	if strings.Contains(dsn, "default_query_exec_mode") {
+		return dsn
+	}
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + "default_query_exec_mode=exec"
+}
+
 func connect_to_db_gorm() *gorm.DB {
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	gorm_db, gorm_err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if gorm_err != nil {
 		logger.L().Error("gorm open failed", "err", gorm_err)
@@ -30,7 +48,7 @@ func connect_to_db_gorm() *gorm.DB {
 }
 
 func connectToDB() *sql.DB {
-	connStr := os.Getenv("DATABASE_URL")
+	connStr := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		logger.L().Error("sql open failed", "err", err)

--- a/services/bank/internal/trading/orders_portal.go
+++ b/services/bank/internal/trading/orders_portal.go
@@ -38,6 +38,10 @@ func requireCancellable(s OrderStatus) error {
 // parseListStatus accepts the supervisor portal's status filter (spec p.57).
 // Empty or "all" means no filter; anything else must be a valid OrderStatus.
 // Returning an empty string tells the caller to skip the WHERE clause.
+//
+// "mine" is a sentinel used by the my-orders route. parseListStatus does not
+// recognize it (it isn't a real OrderStatus) — ListOrders peels it off before
+// calling parseListStatus. See ListOrders for the routing logic.
 func parseListStatus(s string) (OrderStatus, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", "all":
@@ -54,6 +58,38 @@ func parseListStatus(s string) (OrderStatus, error) {
 		return StatusCancelled, nil
 	}
 	return "", status.Errorf(codes.InvalidArgument, "invalid status filter %q", s)
+}
+
+// myOrdersSentinel is the magic Status value the gateway forwards on
+// `GET /orders/my`. We piggy-back on the existing ListOrders RPC instead of
+// adding a new one (avoids regenerating the protobuf bindings) — this keeps
+// the wire shape identical while bypassing the supervisor gate and scoping
+// results to the caller's placer.
+const myOrdersSentinel = "mine"
+
+// optionalStatus parses a status filter that may be combined with the
+// my-orders sentinel. The first return is the parsed OrderStatus filter
+// (empty = "no status filter"); the second is true when the request should
+// be treated as "my orders only".
+func parseStatusOrMine(raw string) (OrderStatus, bool, error) {
+	parts := strings.Split(strings.TrimSpace(raw), ",")
+	mine := false
+	statusFilter := ""
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == myOrdersSentinel {
+			mine = true
+			continue
+		}
+		if p != "" {
+			statusFilter = p
+		}
+	}
+	parsed, err := parseListStatus(statusFilter)
+	if err != nil {
+		return "", false, err
+	}
+	return parsed, mine, nil
 }
 
 // orderSettlementDate re-resolves the underlying's settlement date for an
@@ -209,27 +245,53 @@ func (s *Server) buildOrderDetail(tx *gorm.DB, o *Order, now time.Time) (*tradin
 	return detail, nil
 }
 
-// ListOrders returns the supervisor's orders portal view (spec pp.57–58).
-// Supervisor-only — the gateway gates with `secured("supervisor")` and we
-// re-check here. agent_id filters on the placer's employee_id; passing a
-// positive id naturally excludes client-placed orders since the join needs
-// a non-null employee_id.
-func (s *Server) ListOrders(_ context.Context, req *tradingpb.ListOrdersRequest) (*tradingpb.ListOrdersResponse, error) {
-	if !callerIsSupervisor(s.db, req.CallerEmail) {
-		return nil, status.Error(codes.PermissionDenied, "supervisor permission required")
-	}
-
-	filter, err := parseListStatus(req.Status)
+// ListOrders serves two portals through one RPC:
+//
+//  1. Supervisor "Pregled ordera" (spec pp.57–58) — full feed, gated on the
+//     caller carrying admin/supervisor.
+//  2. "Moji orderi" — invoked when Status contains the `mine` sentinel
+//     (gateway routes /orders/my here). Skips the supervisor gate and scopes
+//     the result to the caller's own placer row, so a freshly-logged-in
+//     client/agent only sees their orders.
+//
+// agent_id filters on the placer's employee_id and only applies in supervisor
+// mode; passing a positive id naturally excludes client-placed orders since
+// the join needs a non-null employee_id.
+func (s *Server) ListOrders(ctx context.Context, req *tradingpb.ListOrdersRequest) (*tradingpb.ListOrdersResponse, error) {
+	filter, mine, err := parseStatusOrMine(req.Status)
 	if err != nil {
 		return nil, err
 	}
 
 	q := s.db.Model(&Order{}).Joins("JOIN order_placers p ON p.id = orders.placer_id")
+
+	if mine {
+		// "Moji orderi" — auth via bank.ResolveCaller, scope by placer_id. We
+		// don't lazy-create the placer row here: a caller with no orders ever
+		// placed gets an empty list rather than a write side-effect.
+		caller, err := s.bank.ResolveCaller(ctx)
+		if err != nil {
+			return nil, err
+		}
+		placerID, err := lookupPlacerID(s.db, caller.IsClient, caller.ClientID, caller.Email)
+		if err != nil {
+			return nil, err
+		}
+		if placerID == 0 {
+			return &tradingpb.ListOrdersResponse{Orders: []*tradingpb.OrderDetail{}}, nil
+		}
+		q = q.Where("orders.placer_id = ?", placerID)
+	} else {
+		if !callerIsSupervisor(s.db, req.CallerEmail) {
+			return nil, status.Error(codes.PermissionDenied, "supervisor permission required")
+		}
+		if req.AgentId > 0 {
+			q = q.Where("p.employee_id = ?", req.AgentId)
+		}
+	}
+
 	if filter != "" {
 		q = q.Where("orders.status = ?", string(filter))
-	}
-	if req.AgentId > 0 {
-		q = q.Where("p.employee_id = ?", req.AgentId)
 	}
 	q = q.Order("orders.created_at DESC")
 

--- a/services/bank/internal/trading/server.go
+++ b/services/bank/internal/trading/server.go
@@ -80,6 +80,18 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 		return nil, err
 	}
 
+	// Spec pp.50, 59: clients may only trade stocks and futures. Options and
+	// forex are actuary-only. Block at placement so a client who guesses an
+	// option_id/forex_pair_id off another endpoint can't slip a trade through.
+	if caller.IsClient {
+		if req.OptionId != 0 {
+			return nil, status.Error(codes.PermissionDenied, "options are available to employees only")
+		}
+		if req.ForexPairId != 0 {
+			return nil, status.Error(codes.PermissionDenied, "forex is available to employees only")
+		}
+	}
+
 	// Margin orders require the `margin_trading` permission for employee
 	// placers (spec p.56). Checked up front so clients skip the DB round-trip
 	// and the denial surfaces before we touch the DB.

--- a/services/exchange/cmd/main.go
+++ b/services/exchange/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/proto/exchange"
@@ -16,8 +17,23 @@ import (
 	"gorm.io/gorm"
 )
 
+// dsnWithExecMode forces pgx's `default_query_exec_mode=exec` unless the
+// caller has already pinned it. See bank/cmd/main.go for the rationale —
+// the schema-then-connection ordering produces the same "cached plan must
+// not change result type" pgx error here too when /listings is queried.
+func dsnWithExecMode(dsn string) string {
+	if strings.Contains(dsn, "default_query_exec_mode") {
+		return dsn
+	}
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + "default_query_exec_mode=exec"
+}
+
 func connect_to_db_gorm() *gorm.DB {
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	gorm_db, gorm_err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if gorm_err != nil {
 		logger.L().Error("gorm open failed", "err", gorm_err)
@@ -27,7 +43,7 @@ func connect_to_db_gorm() *gorm.DB {
 }
 
 func connectToDB() *sql.DB {
-	connStr := os.Getenv("DATABASE_URL")
+	connStr := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		logger.L().Error("sql open failed", "err", err)

--- a/services/gateway/internal/gateway/handlers.go
+++ b/services/gateway/internal/gateway/handlers.go
@@ -3,20 +3,33 @@ package gateway
 import (
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
+// setupCors registers the CORS middleware. CORS_ORIGIN env may be a single
+// origin or a comma-separated list — both vite dev (5173) and the nginx
+// production bundle (3000) need to work side-by-side without per-deploy
+// re-configuration. AllowMethods used to be a single comma-joined string,
+// which doesn't match gin-contrib/cors's Method() check (it splits on
+// individual entries), so preflights silently fell through to 403.
 func setupCors(router *gin.Engine) {
-	origin := os.Getenv("CORS_ORIGIN")
-	if origin == "" {
-		origin = "http://localhost:5173"
+	raw := os.Getenv("CORS_ORIGIN")
+	if raw == "" {
+		raw = "http://localhost:3000,http://localhost:5173"
+	}
+	origins := make([]string, 0, 2)
+	for _, o := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(o); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
 	}
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{origin},
-		AllowMethods:     []string{"GET, POST, PUT, PATCH, DELETE, OPTIONS"},
+		AllowOrigins:     origins,
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Content-Type", "Authorization", "TOTP", "X-Requested-With"},
 		ExposeHeaders:    []string{"Content-Length", "X-Custom-Header"},
 		AllowCredentials: true,
@@ -146,6 +159,10 @@ func SetupApi(router *gin.Engine, server *Server) {
 	orders := api.Group("/orders", auth)
 	{
 		orders.POST("", secured("role:client|employee"), server.CreateOrder)
+		// "Moji orderi" — open to any authenticated client or employee. The
+		// trading RPC scopes results to the caller's placer row, so this
+		// can sit on the same RPC as the supervisor list without leaking.
+		orders.GET("/my", secured("role:client|employee"), server.ListMyOrders)
 		// Supervisor orders portal (spec pp.57–58 / #204). list+approve+decline
 		// are supervisor-only; cancel is open to placers and supervisors, with
 		// the owner-vs-permission check done inside the trading RPC.

--- a/services/gateway/internal/gateway/orders.go
+++ b/services/gateway/internal/gateway/orders.go
@@ -87,6 +87,40 @@ func orderDetailToJSON(o *tradingpb.OrderDetail) gin.H {
 	}
 }
 
+// ListMyOrders backs `GET /orders/my` — the caller's own order feed (spec
+// p.57 — agent/client visibility into their own queue). The trading RPC
+// scopes results to the caller's placer via the `mine` sentinel, so this
+// gateway handler just forwards the user-email metadata and an optional
+// status filter combined with the sentinel.
+func (s *Server) ListMyOrders(c *gin.Context) {
+	statusFilter := c.Query("status")
+	combined := "mine"
+	if statusFilter != "" {
+		combined = statusFilter + ",mine"
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"user-email", c.GetString("email"),
+	))
+
+	resp, err := s.TradingClient.ListOrders(ctx, &tradingpb.ListOrdersRequest{
+		CallerEmail: c.GetString("email"),
+		Status:      combined,
+	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(resp.Orders))
+	for _, o := range resp.Orders {
+		out = append(out, orderDetailToJSON(o))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
 // ListOrders surfaces the supervisor's orders portal feed. Both filters are
 // optional: `status` accepts all|pending|approved|declined|done|cancelled,
 // `agent` accepts an employee id to scope down to a single actuary.

--- a/services/gateway/internal/gateway/server.go
+++ b/services/gateway/internal/gateway/server.go
@@ -49,7 +49,7 @@ func NewServer() (*Server, error) {
 
 	exchangeAddr := os.Getenv("EXCHANGE_GRPC_ADDR")
 	if exchangeAddr == "" {
-		exchangeAddr = "exhcange:50051"
+		exchangeAddr = "exchange:50051"
 	}
 
 	tradingAddr := os.Getenv("TRADING_GRPC_ADDR")

--- a/services/user/cmd/main.go
+++ b/services/user/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/server"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -21,8 +22,21 @@ import (
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/proto/user"
 )
 
+// dsnWithExecMode forces pgx's `default_query_exec_mode=exec` unless the
+// caller has already pinned it. See bank/cmd/main.go for the rationale.
+func dsnWithExecMode(dsn string) string {
+	if strings.Contains(dsn, "default_query_exec_mode") {
+		return dsn
+	}
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + "default_query_exec_mode=exec"
+}
+
 func connect_to_db_gorm() *gorm.DB {
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	gorm_db, gorm_err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if gorm_err != nil {
 		logger.L().Error("gorm open failed", "err", gorm_err)
@@ -32,7 +46,7 @@ func connect_to_db_gorm() *gorm.DB {
 }
 
 func connectToDB() *sql.DB {
-	connStr := os.Getenv("DATABASE_URL")
+	connStr := dsnWithExecMode(os.Getenv("DATABASE_URL"))
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		logger.L().Error("sql open failed", "err", err)


### PR DESCRIPTION
## Summary

Dva blocker-a koji su istovremeno onemogućili da bilo ko završi login flow iz browsera:

1. **CORS preflight 403** — gateway je default-ovao `CORS_ORIGIN` na `http://localhost:5173` (vite dev), ali nginx serve-uje produkcijski bundle na `:3000`, pa je svaki POST `/api/login` iz browsera vraćao 403. Curl je radio jer ne šalje `Origin` header.

2. **`cached plan must not change result type (SQLSTATE 0A000)`** — prvi `POST /api/orders` posle `make schema && make seed` vraćao 500 dok god se servisi ručno ne restartuju.

## Uzroci

### CORS

`services/gateway/internal/gateway/handlers.go::setupCors` imala dve greške:

- `AllowOrigins: []string{origin}` — single origin, hardkodovan na `localhost:5173` ako env nije postavljen. Browser udara nginx na `:3000` → preflight pada.
- `AllowMethods: []string{"GET, POST, PUT, PATCH, DELETE, OPTIONS"}` — *jedna* comma-joined string-a umesto slice-a. `gin-contrib/cors` splituje individualne entry-je, pa se nijedan metod nije mečovao.

### Cached plan

GORM otvara pgx connection pool čim service starta. Pool ide protiv prazne baze, ali pgx ipak prepara describe rezultate. Posle `make schema && make seed`, prvi REST poziv koristi keširani describe koji ne odgovara aktuelnoj schemi → Postgres baca `0A000`, gateway 500. Workaround je bio `docker compose restart bank gateway` — ne ide u CI/CD.

## Popravke

- `services/gateway/internal/gateway/handlers.go` — `setupCors` parsuje comma-separated `CORS_ORIGIN` (default `:3000,:5173`), `AllowMethods` razdvojene u individualne entry-je.
- `services/{bank,exchange,user}/cmd/main.go` — `dsnWithExecMode` helper transparentno dodaje `default_query_exec_mode=exec` na DSN. Konfigurabilno: ako neko želi drugi mode, postavi env / DSN parametar — helper neće da pipa.

## Test plan

- [x] `docker compose down -v && docker compose up -d --build`
- [x] `make schema && make seed`
- [x] Bez restart-a:
  - `POST /api/login` iz browsera (`Origin: http://localhost:3000`) vraća **200**, ne 403
  - `OPTIONS /api/login` preflight vraća **204**
  - `POST /api/orders` (agent BUY MSFT) vraća **201**, ne 500
- [x] `make test` (Go integration testovi)
- [x] Cypress e2e suite (Banka-3-Frontend) pokriva 9 spec-ova, 66 testova: **55 PASS / 0 FAIL** / 11 pending