### PR TITLE
fix(trading): scope unpaid_this_month tax to current period

### DIFF
--- a/services/bank/internal/trading/tax.go
+++ b/services/bank/internal/trading/tax.go
@@ -166,7 +166,8 @@ func (s *Server) GetMyTaxInfo(ctx context.Context, _ *tradingpb.GetMyTaxInfoRequ
 	if placerID == 0 {
 		return &tradingpb.GetMyTaxInfoResponse{}, nil
 	}
-	return aggregateMyTaxInfo(s.db, placerID, time.Now().Year())
+	now := time.Now()
+	return aggregateMyTaxInfo(s.db, placerID, now.Year(), now.Format("2006-01"))
 }
 
 // lookupPlacerID resolves the caller's order_placers.id without creating the
@@ -202,7 +203,10 @@ func lookupPlacerID(db *gorm.DB, isClient bool, clientID int64, email string) (i
 // query. Year filtering uses paid_at (not period) so a row created in
 // December but settled in January counts toward the year it actually moved
 // money, which is what the user expects to see in the "this year" total.
-func aggregateMyTaxInfo(db *gorm.DB, placerID int64, year int) (*tradingpb.GetMyTaxInfoResponse, error) {
+// The "unpaid this month" total scopes to period = currentMonth (YYYY-MM)
+// so prior months' unpaid debt doesn't bleed into the current-month figure
+// the portfolio surfaces.
+func aggregateMyTaxInfo(db *gorm.DB, placerID int64, year int, currentMonth string) (*tradingpb.GetMyTaxInfoResponse, error) {
 	var row struct {
 		PaidThisYearRsd    int64
 		UnpaidThisMonthRsd int64
@@ -210,8 +214,8 @@ func aggregateMyTaxInfo(db *gorm.DB, placerID int64, year int) (*tradingpb.GetMy
 	err := db.Table("capital_gains").
 		Select(`
 			COALESCE(SUM(CASE WHEN paid_at IS NOT NULL AND EXTRACT(YEAR FROM paid_at) = ? THEN tax_due ELSE 0 END), 0) AS paid_this_year_rsd,
-			COALESCE(SUM(CASE WHEN paid_at IS NULL THEN tax_due ELSE 0 END), 0) AS unpaid_this_month_rsd
-		`, year).
+			COALESCE(SUM(CASE WHEN paid_at IS NULL AND period = ? THEN tax_due ELSE 0 END), 0) AS unpaid_this_month_rsd
+		`, year, currentMonth).
 		Where("seller_placer_id = ?", placerID).
 		Scan(&row).Error
 	if err != nil {

--- a/services/bank/internal/trading/tax_test.go
+++ b/services/bank/internal/trading/tax_test.go
@@ -196,12 +196,12 @@ func TestAggregateMyTaxInfo(t *testing.T) {
 	srv, mock, done := newTaxTestServer(t)
 	defer done()
 
-	mock.ExpectQuery(`FROM "capital_gains" WHERE seller_placer_id = \$2`).
-		WithArgs(2026, int64(7)).
+	mock.ExpectQuery(`FROM "capital_gains" WHERE seller_placer_id = \$3`).
+		WithArgs(2026, "2026-05", int64(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"paid_this_year_rsd", "unpaid_this_month_rsd"}).
 			AddRow(int64(1500), int64(450)))
 
-	resp, err := aggregateMyTaxInfo(srv.db, 7, 2026)
+	resp, err := aggregateMyTaxInfo(srv.db, 7, 2026, "2026-05")
 	if err != nil {
 		t.Fatalf("aggregateMyTaxInfo: %v", err)
 	}


### PR DESCRIPTION
## Summary
- \`aggregateMyTaxInfo\` summed every still-unpaid \`capital_gains\` row regardless of \`period\`, so as soon as a previous month rolled over with unpaid debt, the portfolio's "neplaćen porez za tekući mesec" tile inflated past the real current-month figure.
- Added a \`period = currentMonth\` predicate (YYYY-MM, matching how \`RunMonthlyCapitalGainsCollection\` writes the column) and threaded the value in from \`GetMyTaxInfo\` so the "now" boundary is set by the caller and stays testable.
- Updated the sqlmock test to the new arg order ($3 for placerID).

Spec mapping: portfolio scenario 69 — "još neplaćen porez za tekući mesec".

## Test plan
- [ ] CI: \`go test ./services/bank/internal/trading/... -run TestAggregateMyTaxInfo\`
- [ ] Manually: as a client/employee with capital_gains rows in two distinct months, hit \`/portfolio\` and confirm the "tekući mesec" total only reflects the current month's unpaid rows.

> Built/tested in CI — no local Go toolchain in this environment.