### PR TITLE
fix(trading): suppress after_hours when open_override is set

### DIFF
--- a/services/bank/internal/trading/executor_test.go
+++ b/services/bank/internal/trading/executor_test.go
@@ -81,6 +81,31 @@ func TestNextDelayAfterHoursBonus(t *testing.T) {
 	}
 }
 
+// TestNextDelayOverrideSuppressesBonus locks in the 2026-05-06 regression:
+// an order placed during the XNAS last-4h window with open_override=true was
+// getting after_hours=true via the wall-clock-only IsAfterHours, and the
+// executor's 30-min bonus was pushing every fill past cypress's 60s budget.
+// This test exercises the full chain — IsAfterHours under override → nextDelay
+// — so a future refactor that re-introduces clock-only behavior fails here
+// rather than silently in the suite.
+func TestNextDelayOverrideSuppressesBonus(t *testing.T) {
+	ex := nyse()
+	ex.OpenOverride = true
+	// Wed 13:00 NY → 3h to close, would be after-hours without the override.
+	nyAfternoon := time.Date(2026, 4, 22, 18, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex, nyAfternoon) {
+		t.Fatalf("regression: override + last-4h window flagged after-hours")
+	}
+	// And the resulting delay must stay inside the volume-formula ceiling
+	// (no bonus): remaining=8, volume≈seeded daily volume → maxSec clamps to 1.
+	for i := 0; i < 200; i++ {
+		d := nextDelay(8, 509977, IsAfterHours(ex, nyAfternoon))
+		if d > time.Second {
+			t.Fatalf("override-on delay %s exceeded volume ceiling — after-hours bonus leaked in", d)
+		}
+	}
+}
+
 func TestNextDelayHighVolumeClampsToOneSecond(t *testing.T) {
 	// Volume >> remaining * 1440 → integer division yields 0. The helper
 	// bumps the max to 1s so rand.Int63n doesn't panic on zero.

--- a/services/bank/internal/trading/hours.go
+++ b/services/bank/internal/trading/hours.go
@@ -131,9 +131,17 @@ func IsOpen(ex Exchange, t time.Time) bool {
 
 // IsAfterHours reports whether an order placed at t should be flagged as
 // after-hours per spec p.50: it must land *during* the open window AND within
-// the last 4h before close. open_override does NOT count — after-hours is a
-// clock-based fact, and the override is only a testing convenience.
+// the last 4h before close. open_override suppresses after-hours: the
+// override is the supervisor's "treat as a fresh open day" toggle, and the
+// after-hours penalty (30-min fill delay in the executor) presumes a real
+// close is approaching, which is precisely what the override negates. Without
+// this, suite runs are wall-clock-dependent — a 13:00 NY run flags every
+// freshly-placed order as after-hours and times out the executor specs even
+// when the supervisor has explicitly opened the exchange.
 func IsAfterHours(ex Exchange, t time.Time) bool {
+	if ex.OpenOverride {
+		return false
+	}
 	_, closeMin, nowMin, trading := withinClockWindow(ex, t)
 	if !trading {
 		return false

--- a/services/bank/internal/trading/hours_test.go
+++ b/services/bank/internal/trading/hours_test.go
@@ -140,14 +140,28 @@ func TestIsAfterHours_BoundaryExactlyFourHours(t *testing.T) {
 	}
 }
 
-func TestIsAfterHours_OverrideDoesNotApply(t *testing.T) {
+func TestIsAfterHours_OverrideSuppresses(t *testing.T) {
 	ex := nyse()
 	ex.OpenOverride = true
-	// Sat 3am NY, override is on — IsOpen=true but IsAfterHours=false because
-	// we're not in the clock window at all.
-	now := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+	// Wed 13:00 NY (3h to close) — without override this would be after-hours,
+	// but the override is the supervisor's "treat as fresh open day" toggle and
+	// suppresses the 30-min executor penalty. Otherwise suite runs become
+	// wall-clock-dependent: cypress with override-on at 13:00 NY would still
+	// time out market-fill specs because the executor would gate every fill on
+	// the after-hours bonus.
+	now := time.Date(2026, 4, 22, 18, 0, 0, 0, time.UTC)
 	if IsAfterHours(ex, now) {
-		t.Fatalf("after_hours is clock-based, not override-based")
+		t.Fatalf("open_override must suppress after-hours")
+	}
+
+	// And the closed-clock case still returns false (would have anyway via
+	// withinClockWindow, but this asserts the override path doesn't accidentally
+	// flip the result).
+	ex2 := nyse()
+	ex2.OpenOverride = true
+	sat3am := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+	if IsAfterHours(ex2, sat3am) {
+		t.Fatalf("override + outside clock window: after_hours must stay false")
 	}
 }
 


### PR DESCRIPTION
## Summary
- IsAfterHours was clock-only, so cypress runs in the last 4h of XNAS hours flagged every fresh order after_hours even with open_override on. The executor's 30-min bonus then timed out 7 specs (orders-execution / portfolio / trading-day-e2e) at status=approved.
- Override now suppresses after-hours: it is the supervisor's "treat as fresh open day" toggle, and the after-hours penalty presumes a real close approaching, which the override negates.
- Added a chained regression test (IsAfterHours → nextDelay) so a future refactor that re-introduces clock-only behavior fails in the unit suite rather than silently in cypress.

## Test plan
- [x] `make test bank` — passes
- [x] full celina3 cypress suite — back to 73 / 58 / 0 / 15 / 0 baseline
- [x] reverted hours.go locally → `TestIsAfterHours_OverrideSuppresses` and `TestNextDelayOverrideSuppressesBonus` both fail (regression catches re-break)