### PR TITLE
feat(bank): debug HTTP listener for cron triggers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,14 @@ services:
     restart: on-failure
     ports:
       - "${BANK_GRPC_PORT:-50053}:50051"
+      - "${BANK_DEBUG_HTTP_PORT:-50090}:50090"
     environment:
       DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
       GRPC_PORT: "50051"
+      # Cypress on-demand cron trigger (cron_debug.go). Set to empty to
+      # disable. Bound only on the docker-internal port; the host mapping
+      # is what cypress hits at localhost:${BANK_DEBUG_HTTP_PORT}.
+      BANK_DEBUG_HTTP_PORT: "50090"
       NOTIFICATION_GRPC_ADDR: ${NOTIFICATION_GRPC_ADDR:-notification:50051}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_FORMAT: ${LOG_FORMAT:-text}

--- a/services/bank/cmd/main.go
+++ b/services/bank/cmd/main.go
@@ -145,6 +145,11 @@ func main() {
 	stopScheduler := bankService.StartScheduler()
 	defer stopScheduler()
 
+	// Debug-only cron trigger HTTP (cypress consumer). No-op when
+	// BANK_DEBUG_HTTP_PORT is unset — never bound in production.
+	stopDebugHTTP := bankService.StartDebugHTTP(os.Getenv("BANK_DEBUG_HTTP_PORT"))
+	defer stopDebugHTTP()
+
 	tradingService := internalTrading.NewServer(gorm_db, bankService)
 	stopExecutor := tradingService.StartExecutor()
 	defer stopExecutor()

--- a/services/bank/internal/bank/cron_debug.go
+++ b/services/bank/internal/bank/cron_debug.go
@@ -1,0 +1,70 @@
+package bank
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
+)
+
+// StartDebugHTTP exposes the cron entrypoints over plain HTTP so cypress can
+// trigger them on demand. Only listens when BANK_DEBUG_HTTP_PORT is set —
+// production deployments leave it unset and the listener never binds.
+//
+// Security note: routes are unauthenticated by design. The gating mechanism
+// is "the port isn't exposed", not "the handler checks a token". Setting the
+// env var in any environment that's reachable from outside the docker
+// network is a misconfiguration.
+func (s *Server) StartDebugHTTP(port string) func() {
+	if port == "" {
+		return func() {}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/cron/used-limit-reset", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		s.RunDailyUsedLimitReset()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/debug/cron/capital-gains", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		// `?period=YYYY-MM` lets cypress target a specific month; the cron
+		// entrypoint itself uses time.Now() but the seeded unpaid rows live
+		// in a fixed past period. Empty falls back to the cron entrypoint
+		// so callers that want the natural current-month behavior still get
+		// it.
+		if period := r.URL.Query().Get("period"); period != "" {
+			if _, err := s.CollectCapitalGains(period); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			s.RunMonthlyCapitalGainsCollection()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		logger.L().Info("debug HTTP listening", "port", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.L().Error("debug HTTP failed", "err", err)
+		}
+	}()
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a small HTTP listener inside the bank service, gated by `BANK_DEBUG_HTTP_PORT` (port 50090 in compose). Exposes `POST /debug/cron/used-limit-reset` and `POST /debug/cron/capital-gains[?period=YYYY-MM]`, which call `RunDailyUsedLimitReset` / `RunMonthlyCapitalGainsCollection` (or `CollectCapitalGains(period)` when a period override is given).
- Env-gated: the listener never binds when the env var is unset, so production deployments are unaffected.
- Consumer is the Banka-3-Frontend cypress suite (companion PR), which uses this to lift the three cron-driven `it.skip` scenarios (agents-management #7, trading-day-e2e DEO 12, tax-tracking #78).

## Test plan
- [x] `go build ./...` from `services/bank` clean
- [x] Existing cron tests pass (`go test ./internal/bank/ -run 'Cron|UsedLimit|CapitalGains'`)
- [x] `curl -X POST http://localhost:50090/debug/cron/used-limit-reset` → 204
- [x] `curl -X POST http://localhost:50090/debug/cron/capital-gains?period=2026-04` → 204; pre-cron unpaid rows for that period become paid
- [x] Companion frontend PR's full Celina 3 cypress suite green: 72 / 68 / 4 / 0