### PR TITLE
fix(trading): reject unsupported-currency orders with FailedPrecondition

### DIFF
--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -230,6 +230,13 @@ VALUES
     ('AUD', 'Australian Dollar', 'A$',
      'Australia, Christmas Island, Cocos Islands, Norfolk Island',
      'The Australian dollar (symbol: A$; code: AUD) is the official currency and legal tender of Australia, including all of its external territories.',
+     TRUE),
+    -- NOK exists as a currency but intentionally has NO exchange_rates row,
+    -- so trading orders against a NOK account exercise the unsupported-currency
+    -- rejection path (Scenario 42 in TestoviCelina3.txt).
+    ('NOK', 'Norwegian Krone', 'kr',
+     'Norway, Svalbard, Jan Mayen, Bouvet Island, Queen Maud Land, Peter I Island',
+     'The Norwegian krone (symbol: kr; code: NOK) is the official currency of Norway and its dependent territories. It is subdivided into 100 øre.',
      TRUE)
 ON CONFLICT (label) DO NOTHING;
 
@@ -420,6 +427,30 @@ SELECT
     e.id AS created_by,
     '2099-12-31' AS valid_until,
     'AUD' AS currency,
+    TRUE AS active,
+    'business'::owner_type AS owner_type,
+    'foreign'::account_type AS account_type,
+    0 AS maintainance_cost,
+    0 AS daily_limit,
+    0 AS monthly_limit,
+    0 AS daily_expenditure,
+    0 AS monthly_expenditure
+FROM clients c, employees e
+WHERE c.email = 'system@banka3.rs' AND e.email = :'admin_email'
+ON CONFLICT (number) DO NOTHING;
+
+-- Bank NOK account paired with the rate-less NOK currency above. Used by
+-- Scenario 42 to drive the "unsupported currency" rejection path through the
+-- order-creation flow.
+INSERT INTO accounts (number, name, owner, balance, created_by, valid_until, currency, active, owner_type, account_type, maintainance_cost, daily_limit, monthly_limit, daily_expenditure, monthly_expenditure)
+SELECT
+    '333000100000000920' AS number,
+    'Banka 3 - NOK' AS name,
+    c.id AS owner,
+    1000000 AS balance,
+    e.id AS created_by,
+    '2099-12-31' AS valid_until,
+    'NOK' AS currency,
     TRUE AS active,
     'business'::owner_type AS owner_type,
     'foreign'::account_type AS account_type,

--- a/services/bank/internal/trading/server.go
+++ b/services/bank/internal/trading/server.go
@@ -123,9 +123,15 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 	var rateAccRSD, rateInstrRSD float64 = 1, 1
 	if acc.Currency != info.Currency {
 		if rateAccRSD, err = s.bank.GetExchangeRateToRSD(acc.Currency); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, status.Errorf(codes.FailedPrecondition, "valuta računa (%s) nije podržana za trgovanje", acc.Currency)
+			}
 			return nil, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", acc.Currency, err)
 		}
 		if rateInstrRSD, err = s.bank.GetExchangeRateToRSD(info.Currency); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, status.Errorf(codes.FailedPrecondition, "valuta hartije (%s) nije podržana za trgovanje", info.Currency)
+			}
 			return nil, status.Errorf(codes.Internal, "failed to load exchange rate for %s: %v", info.Currency, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Trading server now distinguishes "currency has no exchange_rates row" from a real DB error: `gorm.ErrRecordNotFound` on either the account or instrument currency lookup is mapped to `codes.FailedPrecondition` (HTTP 409 via the gateway error mapper) with a Serbian "valuta nije podržana za trgovanje" message instead of the prior `codes.Internal` (HTTP 500). Aligns the order-creation rejection path with TestoviCelina3 Scenario 42.
- `seed.sql` adds `NOK` as a known currency label without a corresponding `exchange_rates` row plus a bank-owned NOK account `333000100000000920` so the unsupported-currency code path is reachable end-to-end. The companion frontend PR un-skips cypress orders-creation #42 against this seed.

## Why
Scenario 42 says: "Given korisnik bira račun u valuti koja nije podržana / Then sistem odbija order / And prikazuje poruku o nevalidnoj valuti." A 500 with "failed to load exchange rate" reads as a server fault, not a precondition rejection. The fix keeps the Internal mapping for actual DB errors and only narrows the rate-not-found branch to a 4xx.

## Test plan
- [x] `make nuke && make schema && make seed` — confirm `currencies` has 9 rows including NOK and `accounts` has the new 333000100000000920 row in NOK.
- [x] `docker compose up -d --build bank` to pick up the Go change.
- [x] Run cypress `orders-creation.cy.js` — #42 passes (asserts 4xx + body matches `/NOK|valuta/i`); other #26–#47 unaffected.
- [x] Full Celina 3 suite: 72 / 69 / 3 / 0 (was 72 / 68 / 4 / 0).