### PR TITLE
feat(trading): closed_override flag and queued closed-market orders

### DIFF
--- a/pkg/proto/trading/exchange.pb.go
+++ b/pkg/proto/trading/exchange.pb.go
@@ -33,10 +33,14 @@ type Exchange struct {
 	OpenOverride   bool                   `protobuf:"varint,8,opt,name=open_override,json=openOverride,proto3" json:"open_override,omitempty"`
 	// Local-time working hours as "HH:MM:SS" (Postgres TIME). Clients that only
 	// care about HH:MM can truncate.
-	OpenTime      string `protobuf:"bytes,9,opt,name=open_time,json=openTime,proto3" json:"open_time,omitempty"`
-	CloseTime     string `protobuf:"bytes,10,opt,name=close_time,json=closeTime,proto3" json:"close_time,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	OpenTime  string `protobuf:"bytes,9,opt,name=open_time,json=openTime,proto3" json:"open_time,omitempty"`
+	CloseTime string `protobuf:"bytes,10,opt,name=close_time,json=closeTime,proto3" json:"close_time,omitempty"`
+	// closed_override is the inverse of open_override — supervisor-toggle that
+	// forces IsOpen=false regardless of the wall clock. Lets cypress exercise
+	// closed-market flows during NY business hours without time-control.
+	ClosedOverride bool `protobuf:"varint,11,opt,name=closed_override,json=closedOverride,proto3" json:"closed_override,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Exchange) Reset() {
@@ -137,6 +141,13 @@ func (x *Exchange) GetCloseTime() string {
 		return x.CloseTime
 	}
 	return ""
+}
+
+func (x *Exchange) GetClosedOverride() bool {
+	if x != nil {
+		return x.ClosedOverride
+	}
+	return false
 }
 
 type ListExchangesRequest struct {
@@ -328,11 +339,118 @@ func (x *SetExchangeOpenOverrideResponse) GetExchange() *Exchange {
 	return nil
 }
 
+// Mirror of SetExchangeOpenOverride for the closed-side toggle. When
+// closed_override=true, IsOpen returns false regardless of clock and
+// open_override; useful for exercising closed-market order paths in cypress.
+type SetExchangeClosedOverrideRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ExchangeId     int64                  `protobuf:"varint,1,opt,name=exchange_id,json=exchangeId,proto3" json:"exchange_id,omitempty"`
+	ClosedOverride bool                   `protobuf:"varint,2,opt,name=closed_override,json=closedOverride,proto3" json:"closed_override,omitempty"`
+	CallerEmail    string                 `protobuf:"bytes,3,opt,name=caller_email,json=callerEmail,proto3" json:"caller_email,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SetExchangeClosedOverrideRequest) Reset() {
+	*x = SetExchangeClosedOverrideRequest{}
+	mi := &file_trading_exchange_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetExchangeClosedOverrideRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetExchangeClosedOverrideRequest) ProtoMessage() {}
+
+func (x *SetExchangeClosedOverrideRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_exchange_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetExchangeClosedOverrideRequest.ProtoReflect.Descriptor instead.
+func (*SetExchangeClosedOverrideRequest) Descriptor() ([]byte, []int) {
+	return file_trading_exchange_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SetExchangeClosedOverrideRequest) GetExchangeId() int64 {
+	if x != nil {
+		return x.ExchangeId
+	}
+	return 0
+}
+
+func (x *SetExchangeClosedOverrideRequest) GetClosedOverride() bool {
+	if x != nil {
+		return x.ClosedOverride
+	}
+	return false
+}
+
+func (x *SetExchangeClosedOverrideRequest) GetCallerEmail() string {
+	if x != nil {
+		return x.CallerEmail
+	}
+	return ""
+}
+
+type SetExchangeClosedOverrideResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Exchange      *Exchange              `protobuf:"bytes,1,opt,name=exchange,proto3" json:"exchange,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetExchangeClosedOverrideResponse) Reset() {
+	*x = SetExchangeClosedOverrideResponse{}
+	mi := &file_trading_exchange_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetExchangeClosedOverrideResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetExchangeClosedOverrideResponse) ProtoMessage() {}
+
+func (x *SetExchangeClosedOverrideResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_exchange_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetExchangeClosedOverrideResponse.ProtoReflect.Descriptor instead.
+func (*SetExchangeClosedOverrideResponse) Descriptor() ([]byte, []int) {
+	return file_trading_exchange_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SetExchangeClosedOverrideResponse) GetExchange() *Exchange {
+	if x != nil {
+		return x.Exchange
+	}
+	return nil
+}
+
 var File_trading_exchange_proto protoreflect.FileDescriptor
 
 const file_trading_exchange_proto_rawDesc = "" +
 	"\n" +
-	"\x16trading/exchange.proto\x12\atrading\"\xa2\x02\n" +
+	"\x16trading/exchange.proto\x12\atrading\"\xcb\x02\n" +
 	"\bExchange\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -345,7 +463,8 @@ const file_trading_exchange_proto_rawDesc = "" +
 	"\topen_time\x18\t \x01(\tR\bopenTime\x12\x1d\n" +
 	"\n" +
 	"close_time\x18\n" +
-	" \x01(\tR\tcloseTime\"\x16\n" +
+	" \x01(\tR\tcloseTime\x12'\n" +
+	"\x0fclosed_override\x18\v \x01(\bR\x0eclosedOverride\"\x16\n" +
 	"\x14ListExchangesRequest\"H\n" +
 	"\x15ListExchangesResponse\x12/\n" +
 	"\texchanges\x18\x01 \x03(\v2\x11.trading.ExchangeR\texchanges\"\x89\x01\n" +
@@ -355,6 +474,13 @@ const file_trading_exchange_proto_rawDesc = "" +
 	"\ropen_override\x18\x02 \x01(\bR\fopenOverride\x12!\n" +
 	"\fcaller_email\x18\x03 \x01(\tR\vcallerEmail\"P\n" +
 	"\x1fSetExchangeOpenOverrideResponse\x12-\n" +
+	"\bexchange\x18\x01 \x01(\v2\x11.trading.ExchangeR\bexchange\"\x8f\x01\n" +
+	" SetExchangeClosedOverrideRequest\x12\x1f\n" +
+	"\vexchange_id\x18\x01 \x01(\x03R\n" +
+	"exchangeId\x12'\n" +
+	"\x0fclosed_override\x18\x02 \x01(\bR\x0eclosedOverride\x12!\n" +
+	"\fcaller_email\x18\x03 \x01(\tR\vcallerEmail\"R\n" +
+	"!SetExchangeClosedOverrideResponse\x12-\n" +
 	"\bexchange\x18\x01 \x01(\v2\x11.trading.ExchangeR\bexchangeB:Z8github.com/RAF-SI-2025/Banka-3-Backend/pkg/proto/tradingb\x06proto3"
 
 var (
@@ -369,22 +495,25 @@ func file_trading_exchange_proto_rawDescGZIP() []byte {
 	return file_trading_exchange_proto_rawDescData
 }
 
-var file_trading_exchange_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_trading_exchange_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_trading_exchange_proto_goTypes = []any{
-	(*Exchange)(nil),                        // 0: trading.Exchange
-	(*ListExchangesRequest)(nil),            // 1: trading.ListExchangesRequest
-	(*ListExchangesResponse)(nil),           // 2: trading.ListExchangesResponse
-	(*SetExchangeOpenOverrideRequest)(nil),  // 3: trading.SetExchangeOpenOverrideRequest
-	(*SetExchangeOpenOverrideResponse)(nil), // 4: trading.SetExchangeOpenOverrideResponse
+	(*Exchange)(nil),                          // 0: trading.Exchange
+	(*ListExchangesRequest)(nil),              // 1: trading.ListExchangesRequest
+	(*ListExchangesResponse)(nil),             // 2: trading.ListExchangesResponse
+	(*SetExchangeOpenOverrideRequest)(nil),    // 3: trading.SetExchangeOpenOverrideRequest
+	(*SetExchangeOpenOverrideResponse)(nil),   // 4: trading.SetExchangeOpenOverrideResponse
+	(*SetExchangeClosedOverrideRequest)(nil),  // 5: trading.SetExchangeClosedOverrideRequest
+	(*SetExchangeClosedOverrideResponse)(nil), // 6: trading.SetExchangeClosedOverrideResponse
 }
 var file_trading_exchange_proto_depIdxs = []int32{
 	0, // 0: trading.ListExchangesResponse.exchanges:type_name -> trading.Exchange
 	0, // 1: trading.SetExchangeOpenOverrideResponse.exchange:type_name -> trading.Exchange
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	0, // 2: trading.SetExchangeClosedOverrideResponse.exchange:type_name -> trading.Exchange
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_trading_exchange_proto_init() }
@@ -398,7 +527,7 @@ func file_trading_exchange_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_exchange_proto_rawDesc), len(file_trading_exchange_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/trading/order.pb.go
+++ b/pkg/proto/trading/order.pb.go
@@ -226,6 +226,7 @@ type OrderDetail struct {
 	Margin            bool                   `protobuf:"varint,16,opt,name=margin,proto3" json:"margin,omitempty"`
 	AllOrNone         bool                   `protobuf:"varint,17,opt,name=all_or_none,json=allOrNone,proto3" json:"all_or_none,omitempty"`
 	Commission        int64                  `protobuf:"varint,18,opt,name=commission,proto3" json:"commission,omitempty"`
+	AfterHours        bool                   `protobuf:"varint,19,opt,name=after_hours,json=afterHours,proto3" json:"after_hours,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -384,6 +385,13 @@ func (x *OrderDetail) GetCommission() int64 {
 		return x.Commission
 	}
 	return 0
+}
+
+func (x *OrderDetail) GetAfterHours() bool {
+	if x != nil {
+		return x.AfterHours
+	}
+	return false
 }
 
 // Supervisor-only. status: "" or "all" returns every order, otherwise one of
@@ -802,7 +810,7 @@ const file_trading_order_proto_rawDesc = "" +
 	"\x06margin\x18\v \x01(\bR\x06margin\"H\n" +
 	"\x13CreateOrderResponse\x12\x19\n" +
 	"\border_id\x18\x01 \x01(\x03R\aorderId\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status\"\xec\x04\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"\x8d\x05\n" +
 	"\vOrderDetail\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1d\n" +
@@ -828,7 +836,9 @@ const file_trading_order_proto_rawDesc = "" +
 	"\vall_or_none\x18\x11 \x01(\bR\tallOrNone\x12\x1e\n" +
 	"\n" +
 	"commission\x18\x12 \x01(\x03R\n" +
-	"commission\"i\n" +
+	"commission\x12\x1f\n" +
+	"\vafter_hours\x18\x13 \x01(\bR\n" +
+	"afterHours\"i\n" +
 	"\x11ListOrdersRequest\x12!\n" +
 	"\fcaller_email\x18\x01 \x01(\tR\vcallerEmail\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x19\n" +

--- a/pkg/proto/trading/trading.pb.go
+++ b/pkg/proto/trading/trading.pb.go
@@ -24,10 +24,11 @@ var File_trading_trading_proto protoreflect.FileDescriptor
 
 const file_trading_trading_proto_rawDesc = "" +
 	"\n" +
-	"\x15trading/trading.proto\x12\atrading\x1a\x16trading/exchange.proto\x1a\x15trading/listing.proto\x1a\x13trading/forex.proto\x1a\x14trading/option.proto\x1a\x13trading/order.proto\x1a\x15trading/holding.proto\x1a\x11trading/tax.proto2\xdc\f\n" +
+	"\x15trading/trading.proto\x12\atrading\x1a\x16trading/exchange.proto\x1a\x15trading/listing.proto\x1a\x13trading/forex.proto\x1a\x14trading/option.proto\x1a\x13trading/order.proto\x1a\x15trading/holding.proto\x1a\x11trading/tax.proto2\xd0\r\n" +
 	"\x0eTradingService\x12N\n" +
 	"\rListExchanges\x12\x1d.trading.ListExchangesRequest\x1a\x1e.trading.ListExchangesResponse\x12l\n" +
-	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponse\x12K\n" +
+	"\x17SetExchangeOpenOverride\x12'.trading.SetExchangeOpenOverrideRequest\x1a(.trading.SetExchangeOpenOverrideResponse\x12r\n" +
+	"\x19SetExchangeClosedOverride\x12).trading.SetExchangeClosedOverrideRequest\x1a*.trading.SetExchangeClosedOverrideResponse\x12K\n" +
 	"\fListListings\x12\x1c.trading.ListListingsRequest\x1a\x1d.trading.ListListingsResponse\x12E\n" +
 	"\n" +
 	"GetListing\x12\x1a.trading.GetListingRequest\x1a\x1b.trading.GetListingResponse\x12]\n" +
@@ -50,90 +51,94 @@ const file_trading_trading_proto_rawDesc = "" +
 	"\fGetMyTaxInfo\x12\x1c.trading.GetMyTaxInfoRequest\x1a\x1d.trading.GetMyTaxInfoResponseB:Z8github.com/RAF-SI-2025/Banka-3-Backend/pkg/proto/tradingb\x06proto3"
 
 var file_trading_trading_proto_goTypes = []any{
-	(*ListExchangesRequest)(nil),            // 0: trading.ListExchangesRequest
-	(*SetExchangeOpenOverrideRequest)(nil),  // 1: trading.SetExchangeOpenOverrideRequest
-	(*ListListingsRequest)(nil),             // 2: trading.ListListingsRequest
-	(*GetListingRequest)(nil),               // 3: trading.GetListingRequest
-	(*ListListingHistoryRequest)(nil),       // 4: trading.ListListingHistoryRequest
-	(*ListForexPairsRequest)(nil),           // 5: trading.ListForexPairsRequest
-	(*ListOptionDatesRequest)(nil),          // 6: trading.ListOptionDatesRequest
-	(*ListOptionsRequest)(nil),              // 7: trading.ListOptionsRequest
-	(*ExerciseOptionRequest)(nil),           // 8: trading.ExerciseOptionRequest
-	(*CreateOrderRequest)(nil),              // 9: trading.CreateOrderRequest
-	(*ListOrdersRequest)(nil),               // 10: trading.ListOrdersRequest
-	(*ApproveOrderRequest)(nil),             // 11: trading.ApproveOrderRequest
-	(*DeclineOrderRequest)(nil),             // 12: trading.DeclineOrderRequest
-	(*CancelOrderRequest)(nil),              // 13: trading.CancelOrderRequest
-	(*ListHoldingsRequest)(nil),             // 14: trading.ListHoldingsRequest
-	(*SellHoldingRequest)(nil),              // 15: trading.SellHoldingRequest
-	(*SetHoldingPublicRequest)(nil),         // 16: trading.SetHoldingPublicRequest
-	(*RunCapitalGainsRequest)(nil),          // 17: trading.RunCapitalGainsRequest
-	(*ListTaxDebtsRequest)(nil),             // 18: trading.ListTaxDebtsRequest
-	(*GetMyTaxInfoRequest)(nil),             // 19: trading.GetMyTaxInfoRequest
-	(*ListExchangesResponse)(nil),           // 20: trading.ListExchangesResponse
-	(*SetExchangeOpenOverrideResponse)(nil), // 21: trading.SetExchangeOpenOverrideResponse
-	(*ListListingsResponse)(nil),            // 22: trading.ListListingsResponse
-	(*GetListingResponse)(nil),              // 23: trading.GetListingResponse
-	(*ListListingHistoryResponse)(nil),      // 24: trading.ListListingHistoryResponse
-	(*ListForexPairsResponse)(nil),          // 25: trading.ListForexPairsResponse
-	(*ListOptionDatesResponse)(nil),         // 26: trading.ListOptionDatesResponse
-	(*ListOptionsResponse)(nil),             // 27: trading.ListOptionsResponse
-	(*ExerciseOptionResponse)(nil),          // 28: trading.ExerciseOptionResponse
-	(*CreateOrderResponse)(nil),             // 29: trading.CreateOrderResponse
-	(*ListOrdersResponse)(nil),              // 30: trading.ListOrdersResponse
-	(*ApproveOrderResponse)(nil),            // 31: trading.ApproveOrderResponse
-	(*DeclineOrderResponse)(nil),            // 32: trading.DeclineOrderResponse
-	(*CancelOrderResponse)(nil),             // 33: trading.CancelOrderResponse
-	(*ListHoldingsResponse)(nil),            // 34: trading.ListHoldingsResponse
-	(*SellHoldingResponse)(nil),             // 35: trading.SellHoldingResponse
-	(*SetHoldingPublicResponse)(nil),        // 36: trading.SetHoldingPublicResponse
-	(*RunCapitalGainsResponse)(nil),         // 37: trading.RunCapitalGainsResponse
-	(*ListTaxDebtsResponse)(nil),            // 38: trading.ListTaxDebtsResponse
-	(*GetMyTaxInfoResponse)(nil),            // 39: trading.GetMyTaxInfoResponse
+	(*ListExchangesRequest)(nil),              // 0: trading.ListExchangesRequest
+	(*SetExchangeOpenOverrideRequest)(nil),    // 1: trading.SetExchangeOpenOverrideRequest
+	(*SetExchangeClosedOverrideRequest)(nil),  // 2: trading.SetExchangeClosedOverrideRequest
+	(*ListListingsRequest)(nil),               // 3: trading.ListListingsRequest
+	(*GetListingRequest)(nil),                 // 4: trading.GetListingRequest
+	(*ListListingHistoryRequest)(nil),         // 5: trading.ListListingHistoryRequest
+	(*ListForexPairsRequest)(nil),             // 6: trading.ListForexPairsRequest
+	(*ListOptionDatesRequest)(nil),            // 7: trading.ListOptionDatesRequest
+	(*ListOptionsRequest)(nil),                // 8: trading.ListOptionsRequest
+	(*ExerciseOptionRequest)(nil),             // 9: trading.ExerciseOptionRequest
+	(*CreateOrderRequest)(nil),                // 10: trading.CreateOrderRequest
+	(*ListOrdersRequest)(nil),                 // 11: trading.ListOrdersRequest
+	(*ApproveOrderRequest)(nil),               // 12: trading.ApproveOrderRequest
+	(*DeclineOrderRequest)(nil),               // 13: trading.DeclineOrderRequest
+	(*CancelOrderRequest)(nil),                // 14: trading.CancelOrderRequest
+	(*ListHoldingsRequest)(nil),               // 15: trading.ListHoldingsRequest
+	(*SellHoldingRequest)(nil),                // 16: trading.SellHoldingRequest
+	(*SetHoldingPublicRequest)(nil),           // 17: trading.SetHoldingPublicRequest
+	(*RunCapitalGainsRequest)(nil),            // 18: trading.RunCapitalGainsRequest
+	(*ListTaxDebtsRequest)(nil),               // 19: trading.ListTaxDebtsRequest
+	(*GetMyTaxInfoRequest)(nil),               // 20: trading.GetMyTaxInfoRequest
+	(*ListExchangesResponse)(nil),             // 21: trading.ListExchangesResponse
+	(*SetExchangeOpenOverrideResponse)(nil),   // 22: trading.SetExchangeOpenOverrideResponse
+	(*SetExchangeClosedOverrideResponse)(nil), // 23: trading.SetExchangeClosedOverrideResponse
+	(*ListListingsResponse)(nil),              // 24: trading.ListListingsResponse
+	(*GetListingResponse)(nil),                // 25: trading.GetListingResponse
+	(*ListListingHistoryResponse)(nil),        // 26: trading.ListListingHistoryResponse
+	(*ListForexPairsResponse)(nil),            // 27: trading.ListForexPairsResponse
+	(*ListOptionDatesResponse)(nil),           // 28: trading.ListOptionDatesResponse
+	(*ListOptionsResponse)(nil),               // 29: trading.ListOptionsResponse
+	(*ExerciseOptionResponse)(nil),            // 30: trading.ExerciseOptionResponse
+	(*CreateOrderResponse)(nil),               // 31: trading.CreateOrderResponse
+	(*ListOrdersResponse)(nil),                // 32: trading.ListOrdersResponse
+	(*ApproveOrderResponse)(nil),              // 33: trading.ApproveOrderResponse
+	(*DeclineOrderResponse)(nil),              // 34: trading.DeclineOrderResponse
+	(*CancelOrderResponse)(nil),               // 35: trading.CancelOrderResponse
+	(*ListHoldingsResponse)(nil),              // 36: trading.ListHoldingsResponse
+	(*SellHoldingResponse)(nil),               // 37: trading.SellHoldingResponse
+	(*SetHoldingPublicResponse)(nil),          // 38: trading.SetHoldingPublicResponse
+	(*RunCapitalGainsResponse)(nil),           // 39: trading.RunCapitalGainsResponse
+	(*ListTaxDebtsResponse)(nil),              // 40: trading.ListTaxDebtsResponse
+	(*GetMyTaxInfoResponse)(nil),              // 41: trading.GetMyTaxInfoResponse
 }
 var file_trading_trading_proto_depIdxs = []int32{
 	0,  // 0: trading.TradingService.ListExchanges:input_type -> trading.ListExchangesRequest
 	1,  // 1: trading.TradingService.SetExchangeOpenOverride:input_type -> trading.SetExchangeOpenOverrideRequest
-	2,  // 2: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
-	3,  // 3: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
-	4,  // 4: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
-	5,  // 5: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
-	6,  // 6: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
-	7,  // 7: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
-	8,  // 8: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
-	9,  // 9: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
-	10, // 10: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
-	11, // 11: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
-	12, // 12: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
-	13, // 13: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
-	14, // 14: trading.TradingService.ListHoldings:input_type -> trading.ListHoldingsRequest
-	15, // 15: trading.TradingService.SellHolding:input_type -> trading.SellHoldingRequest
-	16, // 16: trading.TradingService.SetHoldingPublic:input_type -> trading.SetHoldingPublicRequest
-	17, // 17: trading.TradingService.RunCapitalGains:input_type -> trading.RunCapitalGainsRequest
-	18, // 18: trading.TradingService.ListTaxDebts:input_type -> trading.ListTaxDebtsRequest
-	19, // 19: trading.TradingService.GetMyTaxInfo:input_type -> trading.GetMyTaxInfoRequest
-	20, // 20: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
-	21, // 21: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
-	22, // 22: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
-	23, // 23: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
-	24, // 24: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
-	25, // 25: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
-	26, // 26: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
-	27, // 27: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
-	28, // 28: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
-	29, // 29: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
-	30, // 30: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
-	31, // 31: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
-	32, // 32: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
-	33, // 33: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
-	34, // 34: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
-	35, // 35: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
-	36, // 36: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
-	37, // 37: trading.TradingService.RunCapitalGains:output_type -> trading.RunCapitalGainsResponse
-	38, // 38: trading.TradingService.ListTaxDebts:output_type -> trading.ListTaxDebtsResponse
-	39, // 39: trading.TradingService.GetMyTaxInfo:output_type -> trading.GetMyTaxInfoResponse
-	20, // [20:40] is the sub-list for method output_type
-	0,  // [0:20] is the sub-list for method input_type
+	2,  // 2: trading.TradingService.SetExchangeClosedOverride:input_type -> trading.SetExchangeClosedOverrideRequest
+	3,  // 3: trading.TradingService.ListListings:input_type -> trading.ListListingsRequest
+	4,  // 4: trading.TradingService.GetListing:input_type -> trading.GetListingRequest
+	5,  // 5: trading.TradingService.ListListingHistory:input_type -> trading.ListListingHistoryRequest
+	6,  // 6: trading.TradingService.ListForexPairs:input_type -> trading.ListForexPairsRequest
+	7,  // 7: trading.TradingService.ListOptionDates:input_type -> trading.ListOptionDatesRequest
+	8,  // 8: trading.TradingService.ListOptions:input_type -> trading.ListOptionsRequest
+	9,  // 9: trading.TradingService.ExerciseOption:input_type -> trading.ExerciseOptionRequest
+	10, // 10: trading.TradingService.CreateOrder:input_type -> trading.CreateOrderRequest
+	11, // 11: trading.TradingService.ListOrders:input_type -> trading.ListOrdersRequest
+	12, // 12: trading.TradingService.ApproveOrder:input_type -> trading.ApproveOrderRequest
+	13, // 13: trading.TradingService.DeclineOrder:input_type -> trading.DeclineOrderRequest
+	14, // 14: trading.TradingService.CancelOrder:input_type -> trading.CancelOrderRequest
+	15, // 15: trading.TradingService.ListHoldings:input_type -> trading.ListHoldingsRequest
+	16, // 16: trading.TradingService.SellHolding:input_type -> trading.SellHoldingRequest
+	17, // 17: trading.TradingService.SetHoldingPublic:input_type -> trading.SetHoldingPublicRequest
+	18, // 18: trading.TradingService.RunCapitalGains:input_type -> trading.RunCapitalGainsRequest
+	19, // 19: trading.TradingService.ListTaxDebts:input_type -> trading.ListTaxDebtsRequest
+	20, // 20: trading.TradingService.GetMyTaxInfo:input_type -> trading.GetMyTaxInfoRequest
+	21, // 21: trading.TradingService.ListExchanges:output_type -> trading.ListExchangesResponse
+	22, // 22: trading.TradingService.SetExchangeOpenOverride:output_type -> trading.SetExchangeOpenOverrideResponse
+	23, // 23: trading.TradingService.SetExchangeClosedOverride:output_type -> trading.SetExchangeClosedOverrideResponse
+	24, // 24: trading.TradingService.ListListings:output_type -> trading.ListListingsResponse
+	25, // 25: trading.TradingService.GetListing:output_type -> trading.GetListingResponse
+	26, // 26: trading.TradingService.ListListingHistory:output_type -> trading.ListListingHistoryResponse
+	27, // 27: trading.TradingService.ListForexPairs:output_type -> trading.ListForexPairsResponse
+	28, // 28: trading.TradingService.ListOptionDates:output_type -> trading.ListOptionDatesResponse
+	29, // 29: trading.TradingService.ListOptions:output_type -> trading.ListOptionsResponse
+	30, // 30: trading.TradingService.ExerciseOption:output_type -> trading.ExerciseOptionResponse
+	31, // 31: trading.TradingService.CreateOrder:output_type -> trading.CreateOrderResponse
+	32, // 32: trading.TradingService.ListOrders:output_type -> trading.ListOrdersResponse
+	33, // 33: trading.TradingService.ApproveOrder:output_type -> trading.ApproveOrderResponse
+	34, // 34: trading.TradingService.DeclineOrder:output_type -> trading.DeclineOrderResponse
+	35, // 35: trading.TradingService.CancelOrder:output_type -> trading.CancelOrderResponse
+	36, // 36: trading.TradingService.ListHoldings:output_type -> trading.ListHoldingsResponse
+	37, // 37: trading.TradingService.SellHolding:output_type -> trading.SellHoldingResponse
+	38, // 38: trading.TradingService.SetHoldingPublic:output_type -> trading.SetHoldingPublicResponse
+	39, // 39: trading.TradingService.RunCapitalGains:output_type -> trading.RunCapitalGainsResponse
+	40, // 40: trading.TradingService.ListTaxDebts:output_type -> trading.ListTaxDebtsResponse
+	41, // 41: trading.TradingService.GetMyTaxInfo:output_type -> trading.GetMyTaxInfoResponse
+	21, // [21:42] is the sub-list for method output_type
+	0,  // [0:21] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/proto/trading/trading_grpc.pb.go
+++ b/pkg/proto/trading/trading_grpc.pb.go
@@ -19,26 +19,27 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TradingService_ListExchanges_FullMethodName           = "/trading.TradingService/ListExchanges"
-	TradingService_SetExchangeOpenOverride_FullMethodName = "/trading.TradingService/SetExchangeOpenOverride"
-	TradingService_ListListings_FullMethodName            = "/trading.TradingService/ListListings"
-	TradingService_GetListing_FullMethodName              = "/trading.TradingService/GetListing"
-	TradingService_ListListingHistory_FullMethodName      = "/trading.TradingService/ListListingHistory"
-	TradingService_ListForexPairs_FullMethodName          = "/trading.TradingService/ListForexPairs"
-	TradingService_ListOptionDates_FullMethodName         = "/trading.TradingService/ListOptionDates"
-	TradingService_ListOptions_FullMethodName             = "/trading.TradingService/ListOptions"
-	TradingService_ExerciseOption_FullMethodName          = "/trading.TradingService/ExerciseOption"
-	TradingService_CreateOrder_FullMethodName             = "/trading.TradingService/CreateOrder"
-	TradingService_ListOrders_FullMethodName              = "/trading.TradingService/ListOrders"
-	TradingService_ApproveOrder_FullMethodName            = "/trading.TradingService/ApproveOrder"
-	TradingService_DeclineOrder_FullMethodName            = "/trading.TradingService/DeclineOrder"
-	TradingService_CancelOrder_FullMethodName             = "/trading.TradingService/CancelOrder"
-	TradingService_ListHoldings_FullMethodName            = "/trading.TradingService/ListHoldings"
-	TradingService_SellHolding_FullMethodName             = "/trading.TradingService/SellHolding"
-	TradingService_SetHoldingPublic_FullMethodName        = "/trading.TradingService/SetHoldingPublic"
-	TradingService_RunCapitalGains_FullMethodName         = "/trading.TradingService/RunCapitalGains"
-	TradingService_ListTaxDebts_FullMethodName            = "/trading.TradingService/ListTaxDebts"
-	TradingService_GetMyTaxInfo_FullMethodName            = "/trading.TradingService/GetMyTaxInfo"
+	TradingService_ListExchanges_FullMethodName             = "/trading.TradingService/ListExchanges"
+	TradingService_SetExchangeOpenOverride_FullMethodName   = "/trading.TradingService/SetExchangeOpenOverride"
+	TradingService_SetExchangeClosedOverride_FullMethodName = "/trading.TradingService/SetExchangeClosedOverride"
+	TradingService_ListListings_FullMethodName              = "/trading.TradingService/ListListings"
+	TradingService_GetListing_FullMethodName                = "/trading.TradingService/GetListing"
+	TradingService_ListListingHistory_FullMethodName        = "/trading.TradingService/ListListingHistory"
+	TradingService_ListForexPairs_FullMethodName            = "/trading.TradingService/ListForexPairs"
+	TradingService_ListOptionDates_FullMethodName           = "/trading.TradingService/ListOptionDates"
+	TradingService_ListOptions_FullMethodName               = "/trading.TradingService/ListOptions"
+	TradingService_ExerciseOption_FullMethodName            = "/trading.TradingService/ExerciseOption"
+	TradingService_CreateOrder_FullMethodName               = "/trading.TradingService/CreateOrder"
+	TradingService_ListOrders_FullMethodName                = "/trading.TradingService/ListOrders"
+	TradingService_ApproveOrder_FullMethodName              = "/trading.TradingService/ApproveOrder"
+	TradingService_DeclineOrder_FullMethodName              = "/trading.TradingService/DeclineOrder"
+	TradingService_CancelOrder_FullMethodName               = "/trading.TradingService/CancelOrder"
+	TradingService_ListHoldings_FullMethodName              = "/trading.TradingService/ListHoldings"
+	TradingService_SellHolding_FullMethodName               = "/trading.TradingService/SellHolding"
+	TradingService_SetHoldingPublic_FullMethodName          = "/trading.TradingService/SetHoldingPublic"
+	TradingService_RunCapitalGains_FullMethodName           = "/trading.TradingService/RunCapitalGains"
+	TradingService_ListTaxDebts_FullMethodName              = "/trading.TradingService/ListTaxDebts"
+	TradingService_GetMyTaxInfo_FullMethodName              = "/trading.TradingService/GetMyTaxInfo"
 )
 
 // TradingServiceClient is the client API for TradingService service.
@@ -48,6 +49,7 @@ type TradingServiceClient interface {
 	// Exchanges
 	ListExchanges(ctx context.Context, in *ListExchangesRequest, opts ...grpc.CallOption) (*ListExchangesResponse, error)
 	SetExchangeOpenOverride(ctx context.Context, in *SetExchangeOpenOverrideRequest, opts ...grpc.CallOption) (*SetExchangeOpenOverrideResponse, error)
+	SetExchangeClosedOverride(ctx context.Context, in *SetExchangeClosedOverrideRequest, opts ...grpc.CallOption) (*SetExchangeClosedOverrideResponse, error)
 	// Listings
 	ListListings(ctx context.Context, in *ListListingsRequest, opts ...grpc.CallOption) (*ListListingsResponse, error)
 	GetListing(ctx context.Context, in *GetListingRequest, opts ...grpc.CallOption) (*GetListingResponse, error)
@@ -96,6 +98,16 @@ func (c *tradingServiceClient) SetExchangeOpenOverride(ctx context.Context, in *
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SetExchangeOpenOverrideResponse)
 	err := c.cc.Invoke(ctx, TradingService_SetExchangeOpenOverride_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tradingServiceClient) SetExchangeClosedOverride(ctx context.Context, in *SetExchangeClosedOverrideRequest, opts ...grpc.CallOption) (*SetExchangeClosedOverrideResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetExchangeClosedOverrideResponse)
+	err := c.cc.Invoke(ctx, TradingService_SetExchangeClosedOverride_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -289,6 +301,7 @@ type TradingServiceServer interface {
 	// Exchanges
 	ListExchanges(context.Context, *ListExchangesRequest) (*ListExchangesResponse, error)
 	SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error)
+	SetExchangeClosedOverride(context.Context, *SetExchangeClosedOverrideRequest) (*SetExchangeClosedOverrideResponse, error)
 	// Listings
 	ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error)
 	GetListing(context.Context, *GetListingRequest) (*GetListingResponse, error)
@@ -328,6 +341,9 @@ func (UnimplementedTradingServiceServer) ListExchanges(context.Context, *ListExc
 }
 func (UnimplementedTradingServiceServer) SetExchangeOpenOverride(context.Context, *SetExchangeOpenOverrideRequest) (*SetExchangeOpenOverrideResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetExchangeOpenOverride not implemented")
+}
+func (UnimplementedTradingServiceServer) SetExchangeClosedOverride(context.Context, *SetExchangeClosedOverrideRequest) (*SetExchangeClosedOverrideResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetExchangeClosedOverride not implemented")
 }
 func (UnimplementedTradingServiceServer) ListListings(context.Context, *ListListingsRequest) (*ListListingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListListings not implemented")
@@ -436,6 +452,24 @@ func _TradingService_SetExchangeOpenOverride_Handler(srv interface{}, ctx contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TradingServiceServer).SetExchangeOpenOverride(ctx, req.(*SetExchangeOpenOverrideRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TradingService_SetExchangeClosedOverride_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetExchangeClosedOverrideRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TradingServiceServer).SetExchangeClosedOverride(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TradingService_SetExchangeClosedOverride_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TradingServiceServer).SetExchangeClosedOverride(ctx, req.(*SetExchangeClosedOverrideRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -778,6 +812,10 @@ var TradingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetExchangeOpenOverride",
 			Handler:    _TradingService_SetExchangeOpenOverride_Handler,
+		},
+		{
+			MethodName: "SetExchangeClosedOverride",
+			Handler:    _TradingService_SetExchangeClosedOverride_Handler,
 		},
 		{
 			MethodName: "ListListings",

--- a/proto/trading/exchange.proto
+++ b/proto/trading/exchange.proto
@@ -17,6 +17,10 @@ message Exchange {
   // care about HH:MM can truncate.
   string open_time = 9;
   string close_time = 10;
+  // closed_override is the inverse of open_override — supervisor-toggle that
+  // forces IsOpen=false regardless of the wall clock. Lets cypress exercise
+  // closed-market flows during NY business hours without time-control.
+  bool closed_override = 11;
 }
 
 message ListExchangesRequest {}
@@ -37,6 +41,19 @@ message SetExchangeOpenOverrideRequest {
 }
 
 message SetExchangeOpenOverrideResponse {
+  Exchange exchange = 1;
+}
+
+// Mirror of SetExchangeOpenOverride for the closed-side toggle. When
+// closed_override=true, IsOpen returns false regardless of clock and
+// open_override; useful for exercising closed-market order paths in cypress.
+message SetExchangeClosedOverrideRequest {
+  int64 exchange_id = 1;
+  bool closed_override = 2;
+  string caller_email = 3;
+}
+
+message SetExchangeClosedOverrideResponse {
   Exchange exchange = 1;
 }
 

--- a/proto/trading/order.proto
+++ b/proto/trading/order.proto
@@ -51,6 +51,7 @@ message OrderDetail {
   bool margin = 16;
   bool all_or_none = 17;
   int64 commission = 18;
+  bool after_hours = 19;
 }
 
 // Supervisor-only. status: "" or "all" returns every order, otherwise one of

--- a/proto/trading/trading.proto
+++ b/proto/trading/trading.proto
@@ -16,6 +16,7 @@ service TradingService {
   // Exchanges
   rpc ListExchanges(ListExchangesRequest) returns (ListExchangesResponse);
   rpc SetExchangeOpenOverride(SetExchangeOpenOverrideRequest) returns (SetExchangeOpenOverrideResponse);
+  rpc SetExchangeClosedOverride(SetExchangeClosedOverrideRequest) returns (SetExchangeClosedOverrideResponse);
 
   // Listings
   rpc ListListings(ListListingsRequest) returns (ListListingsResponse);

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -305,6 +305,7 @@ CREATE TABLE IF NOT EXISTS exchanges (
     open_time           TIME            NOT NULL DEFAULT '09:30',
     close_time          TIME            NOT NULL DEFAULT '16:00',
     open_override       BOOLEAN         NOT NULL DEFAULT FALSE,
+    closed_override     BOOLEAN         NOT NULL DEFAULT FALSE,
     UNIQUE(mic_code)
 );
 

--- a/services/bank/internal/trading/executor_test.go
+++ b/services/bank/internal/trading/executor_test.go
@@ -106,6 +106,48 @@ func TestNextDelayOverrideSuppressesBonus(t *testing.T) {
 	}
 }
 
+// TestNextDelayClosedOverrideAppliesBonus is the inverse of
+// TestNextDelayOverrideSuppressesBonus: a market order placed while
+// closed_override=true must pick up the 30-min bonus so fills are slow when
+// the supervisor reopens the exchange (spec #46). Locks in the IsAfterHours
+// → nextDelay chain so a future refactor that drops ClosedOverride from the
+// after-hours decision fails here instead of silently in cypress.
+func TestNextDelayClosedOverrideAppliesBonus(t *testing.T) {
+	ex := nyse()
+	ex.ClosedOverride = true
+	// Wall-clock at NY 14:00 (naturally open) — closed_override must still
+	// force after-hours regardless.
+	nyMidday := time.Date(2026, 4, 22, 19, 0, 0, 0, time.UTC)
+	if !IsAfterHours(ex, nyMidday) {
+		t.Fatalf("closed_override during open hours must flag after-hours")
+	}
+	for i := 0; i < 200; i++ {
+		d := nextDelay(8, 509977, IsAfterHours(ex, nyMidday))
+		if d < afterHoursDelayBonus {
+			t.Fatalf("closed_override delay %s below bonus floor %s", d, afterHoursDelayBonus)
+		}
+	}
+}
+
+// TestNextDelayNaturallyClosedAppliesBonus pins the second half of the #46
+// IsAfterHours change: even without closed_override, an exchange that's
+// naturally closed (weekend, holiday, or off-hours) flags after-hours so the
+// queued fill carries the 30-min bonus when trading resumes.
+func TestNextDelayNaturallyClosedAppliesBonus(t *testing.T) {
+	ex := nyse()
+	// Saturday — naturally closed, no overrides.
+	sat := time.Date(2026, 4, 25, 19, 0, 0, 0, time.UTC)
+	if !IsAfterHours(ex, sat) {
+		t.Fatalf("naturally-closed exchange must flag after-hours")
+	}
+	for i := 0; i < 200; i++ {
+		d := nextDelay(8, 509977, IsAfterHours(ex, sat))
+		if d < afterHoursDelayBonus {
+			t.Fatalf("weekend delay %s below bonus floor %s", d, afterHoursDelayBonus)
+		}
+	}
+}
+
 func TestNextDelayHighVolumeClampsToOneSecond(t *testing.T) {
 	// Volume >> remaining * 1440 → integer division yields 0. The helper
 	// bumps the max to 1s so rand.Int63n doesn't panic on zero.

--- a/services/bank/internal/trading/hours.go
+++ b/services/bank/internal/trading/hours.go
@@ -117,11 +117,16 @@ func withinClockWindow(ex Exchange, t time.Time) (openMin, closeMin, nowMin int,
 	return openMin, closeMin, nowMin, trading
 }
 
-// IsOpen reports whether the exchange accepts orders at instant t. When
-// open_override is set (supervisor toggle for testing outside market hours)
-// the exchange is always open; otherwise we check TZ, weekends, holidays,
-// and working hours.
+// IsOpen reports whether the exchange accepts orders at instant t.
+// closed_override wins: when set, the exchange is force-closed regardless of
+// open_override or the wall clock (spec #46 / cypress force-closed flow).
+// open_override is the inverse supervisor toggle for testing outside market
+// hours. Without either override, we check TZ, weekends, holidays, and
+// working hours.
 func IsOpen(ex Exchange, t time.Time) bool {
+	if ex.ClosedOverride {
+		return false
+	}
 	if ex.OpenOverride {
 		return true
 	}
@@ -130,21 +135,31 @@ func IsOpen(ex Exchange, t time.Time) bool {
 }
 
 // IsAfterHours reports whether an order placed at t should be flagged as
-// after-hours per spec p.50: it must land *during* the open window AND within
-// the last 4h before close. open_override suppresses after-hours: the
-// override is the supervisor's "treat as a fresh open day" toggle, and the
-// after-hours penalty (30-min fill delay in the executor) presumes a real
-// close is approaching, which is precisely what the override negates. Without
-// this, suite runs are wall-clock-dependent — a 13:00 NY run flags every
-// freshly-placed order as after-hours and times out the executor specs even
-// when the supervisor has explicitly opened the exchange.
+// after-hours — i.e. fills should carry the 30-min executor delay bonus.
+// Three triggers:
+//  1. closed_override set — force-closed; the order will queue until the
+//     supervisor reopens the exchange and should fill slowly when it does
+//     (spec #46).
+//  2. exchange is naturally closed (weekend, holiday, outside working hours)
+//     and no override is in play. Same reasoning as #1.
+//  3. order placed during open hours within the last 4h before close
+//     (spec p.50 strict definition).
+//
+// open_override suppresses after-hours: it's the "treat as a fresh open day"
+// toggle, and the 30-min penalty presumes a real close is approaching, which
+// is precisely what the override negates. Without this, suite runs become
+// wall-clock-dependent — a 13:00 NY run with override-on would flag every
+// fresh order as after-hours and time out the executor specs.
 func IsAfterHours(ex Exchange, t time.Time) bool {
+	if ex.ClosedOverride {
+		return true
+	}
 	if ex.OpenOverride {
 		return false
 	}
 	_, closeMin, nowMin, trading := withinClockWindow(ex, t)
 	if !trading {
-		return false
+		return true
 	}
 	return closeMin-nowMin < 4*60
 }

--- a/services/bank/internal/trading/hours_test.go
+++ b/services/bank/internal/trading/hours_test.go
@@ -118,10 +118,45 @@ func TestIsAfterHours_NotYetInWindow(t *testing.T) {
 
 func TestIsAfterHours_OutsideOpen(t *testing.T) {
 	ex := nyse()
-	// NY 17:00 — market closed
+	// NY 17:00 — market closed. Naturally-closed windows count as after-hours
+	// so closed-market orders pick up the executor's 30-min delay bonus when
+	// the market reopens (spec #46).
 	now := time.Date(2026, 4, 22, 22, 0, 0, 0, time.UTC)
-	if IsAfterHours(ex, now) {
-		t.Fatalf("after_hours only applies during the open window")
+	if !IsAfterHours(ex, now) {
+		t.Fatalf("naturally-closed exchange must flag after-hours")
+	}
+}
+
+func TestIsOpen_ClosedOverride(t *testing.T) {
+	ex := nyse()
+	ex.ClosedOverride = true
+	// Wed 14:00 NY — naturally open, but force-closed must win.
+	now := time.Date(2026, 4, 22, 19, 0, 0, 0, time.UTC)
+	if IsOpen(ex, now) {
+		t.Fatalf("closed_override must force IsOpen=false even during open hours")
+	}
+}
+
+func TestIsOpen_ClosedOverrideBeatsOpenOverride(t *testing.T) {
+	ex := nyse()
+	ex.ClosedOverride = true
+	ex.OpenOverride = true
+	// closed_override is checked first; the two should never both be true in
+	// practice, but if they are, force-closed wins.
+	now := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC) // Saturday
+	if IsOpen(ex, now) {
+		t.Fatalf("closed_override must beat open_override")
+	}
+}
+
+func TestIsAfterHours_ClosedOverride(t *testing.T) {
+	ex := nyse()
+	ex.ClosedOverride = true
+	// Even mid-session-clock, force-closed flags as after-hours so the
+	// executor applies the 30-min bonus when the supervisor reopens.
+	now := time.Date(2026, 4, 22, 19, 0, 0, 0, time.UTC)
+	if !IsAfterHours(ex, now) {
+		t.Fatalf("closed_override must flag after-hours")
 	}
 }
 

--- a/services/bank/internal/trading/models.go
+++ b/services/bank/internal/trading/models.go
@@ -56,7 +56,8 @@ type Exchange struct {
 	// gorm-specific time-of-day type.
 	OpenTime     string `gorm:"column:open_time;type:time;not null"`
 	CloseTime    string `gorm:"column:close_time;type:time;not null"`
-	OpenOverride bool   `gorm:"column:open_override;not null;default:false"`
+	OpenOverride   bool `gorm:"column:open_override;not null;default:false"`
+	ClosedOverride bool `gorm:"column:closed_override;not null;default:false"`
 }
 
 func (Exchange) TableName() string { return "exchanges" }

--- a/services/bank/internal/trading/orders_portal.go
+++ b/services/bank/internal/trading/orders_portal.go
@@ -238,6 +238,7 @@ func (s *Server) buildOrderDetail(tx *gorm.DB, o *Order, now time.Time) (*tradin
 		Margin:            o.Margin,
 		AllOrNone:         o.AllOrNone,
 		Commission:        o.Commission,
+		AfterHours:        o.AfterHours,
 	}
 	if o.ApprovedBy != nil {
 		detail.ApprovedBy = *o.ApprovedBy

--- a/services/bank/internal/trading/server.go
+++ b/services/bank/internal/trading/server.go
@@ -52,6 +52,7 @@ func exchangeToProto(r Exchange) *tradingpb.Exchange {
 		OpenTime:       r.OpenTime,
 		CloseTime:      r.CloseTime,
 		OpenOverride:   r.OpenOverride,
+		ClosedOverride: r.ClosedOverride,
 	}
 }
 
@@ -138,16 +139,10 @@ func (s *Server) CreateOrder(ctx context.Context, req *tradingpb.CreateOrderRequ
 
 	now := time.Now()
 	// after_hours is an exchange-clock concept; forex pairs have no exchange
-	// and always leave the flag false.
+	// and always leave the flag false. Closed-exchange market orders queue
+	// here and pick up the executor's 30-min after-hours bonus once IsOpen
+	// flips back (spec #46): the prior hard reject contradicted the spec.
 	afterHours := info.Exchange != nil && IsAfterHours(*info.Exchange, now)
-
-	// Market orders cannot be placed while the exchange is closed (spec p.57
-	// / issue #189): execution has no quote to fill against. Limit/stop
-	// variants are allowed outside hours because they wait for a trigger.
-	// Forex has no exchange and is always tradable.
-	if orderType == OrderMarket && info.Exchange != nil && !IsOpen(*info.Exchange, now) {
-		return nil, status.Error(codes.FailedPrecondition, "exchange is closed; market orders cannot be placed")
-	}
 
 	// Approximate-price inputs (spec p.57). We keep PricePerUnit=0 on market
 	// orders so the execution engine (#189) re-reads the quote at fill time,
@@ -342,6 +337,33 @@ func (s *Server) SetExchangeOpenOverride(_ context.Context, req *tradingpb.SetEx
 	exch.OpenOverride = req.OpenOverride
 
 	return &tradingpb.SetExchangeOpenOverrideResponse{Exchange: exchangeToProto(exch)}, nil
+}
+
+// SetExchangeClosedOverride mirrors SetExchangeOpenOverride for the inverse
+// toggle: closed_override forces IsOpen=false regardless of clock and
+// open_override. Lets cypress drive closed-market flows during NY business
+// hours (#46) without time-control.
+func (s *Server) SetExchangeClosedOverride(_ context.Context, req *tradingpb.SetExchangeClosedOverrideRequest) (*tradingpb.SetExchangeClosedOverrideResponse, error) {
+	if req.ExchangeId <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "exchange_id required")
+	}
+	if !callerIsSupervisor(s.db, req.CallerEmail) {
+		return nil, status.Error(codes.PermissionDenied, "only admins and supervisors may toggle closed_override")
+	}
+
+	var exch Exchange
+	if err := s.db.First(&exch, req.ExchangeId).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.NotFound, "exchange not found")
+		}
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	if err := s.db.Model(&exch).Update("closed_override", req.ClosedOverride).Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
+	exch.ClosedOverride = req.ClosedOverride
+
+	return &tradingpb.SetExchangeClosedOverrideResponse{Exchange: exchangeToProto(exch)}, nil
 }
 
 // callerIsSupervisor checks whether the given employee email has `admin` or

--- a/services/gateway/internal/gateway/exchange.go
+++ b/services/gateway/internal/gateway/exchange.go
@@ -51,6 +51,10 @@ type setExchangeOpenOverrideBody struct {
 	OpenOverride *bool `json:"open_override" binding:"required"`
 }
 
+type setExchangeClosedOverrideBody struct {
+	ClosedOverride *bool `json:"closed_override" binding:"required"`
+}
+
 // SetExchangeOpenOverride flips the open_override flag on an exchange.
 // Supervisor-only — route is gated at `secured("supervisor")` and the trading
 // RPC re-checks the caller's permissions against employee_permissions.
@@ -81,19 +85,40 @@ func (s *Server) SetExchangeOpenOverride(c *gin.Context) {
 		return
 	}
 
-	ex := resp.Exchange
-	c.JSON(http.StatusOK, gin.H{
-		"id":               ex.Id,
-		"name":             ex.Name,
-		"acronym":          ex.Acronym,
-		"mic_code":         ex.MicCode,
-		"polity":           ex.Polity,
-		"currency":         ex.Currency,
-		"time_zone_offset": ex.TimeZoneOffset,
-		"open_time":        ex.OpenTime,
-		"close_time":       ex.CloseTime,
-		"open_override":    ex.OpenOverride,
+	c.JSON(http.StatusOK, exchangeToJSON(resp.Exchange))
+}
+
+// SetExchangeClosedOverride is the inverse toggle — force-closes an exchange
+// regardless of clock and open_override (spec #46 / cypress closed-market
+// flows). Same supervisor gating as SetExchangeOpenOverride.
+func (s *Server) SetExchangeClosedOverride(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "exchange id must be a positive integer"})
+		return
+	}
+
+	var body setExchangeClosedOverrideBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		writeBindError(c, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.TradingClient.SetExchangeClosedOverride(ctx, &tradingpb.SetExchangeClosedOverrideRequest{
+		ExchangeId:     id,
+		ClosedOverride: *body.ClosedOverride,
+		CallerEmail:    c.GetString("email"),
 	})
+	if err != nil {
+		writeGRPCError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, exchangeToJSON(resp.Exchange))
 }
 
 func (s *Server) ConvertMoney(c *gin.Context) {

--- a/services/gateway/internal/gateway/handlers.go
+++ b/services/gateway/internal/gateway/handlers.go
@@ -208,6 +208,7 @@ func SetupApi(router *gin.Engine, server *Server) {
 	// market hours (see spec p.40 and issue #194). Admin bypass still applies
 	// through `secured("supervisor")`.
 	api.PATCH("/exchanges/:id/open-override", auth, secured("supervisor"), server.SetExchangeOpenOverride)
+	api.PATCH("/exchanges/:id/closed-override", auth, secured("supervisor"), server.SetExchangeClosedOverride)
 
 	// Supervisor tax portal (spec p.63 / #209). Manual "Pokreni obračun"
 	// button + the per-user dugovanja listing. Supervisor-only at the

--- a/services/gateway/internal/gateway/listings.go
+++ b/services/gateway/internal/gateway/listings.go
@@ -50,6 +50,7 @@ func exchangeToJSON(e *tradingpb.Exchange) gin.H {
 		"open_time":        e.OpenTime,
 		"close_time":       e.CloseTime,
 		"open_override":    e.OpenOverride,
+		"closed_override":  e.ClosedOverride,
 	}
 }
 

--- a/services/gateway/internal/gateway/orders.go
+++ b/services/gateway/internal/gateway/orders.go
@@ -84,6 +84,7 @@ func orderDetailToJSON(o *tradingpb.OrderDetail) gin.H {
 		"margin":             o.Margin,
 		"all_or_none":        o.AllOrNone,
 		"commission":         o.Commission,
+		"after_hours":        o.AfterHours,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Lifts cypress orders-creation skip #46: spec p.57 says a market order placed while the exchange is closed should be queued with delayed execution, not rejected. Backend was hard-rejecting with FailedPrecondition.
- Adds a new `closed_override` boolean on exchanges (supervisor toggle that force-closes regardless of clock and `open_override`). Required because `open_override=false` falls back to wall clock — cypress during NY business hours would otherwise see NASDAQ naturally open and the test would get no signal.
- `IsAfterHours` now flags both `closed_override` and naturally-closed exchanges so the executor's 30-min bonus applies when the market reopens. `IsOpen` checks `closed_override` first.
- Drops the hard-reject for closed-market market orders — `executor.go:242` already postpones until `IsOpen`, which is exactly the spec's queued-with-delay behavior.
- `OrderDetail` proto + `orderDetailToProto` + `orderDetailToJSON` now surface `after_hours` (was missing from the supervisor list response).
- New `PATCH /exchanges/:id/closed-override` endpoint (mirrors open-override).

## Test plan
- [x] `make test` for the bank module: existing trading tests + new `hours_test` cases (closed_override beats clock and open_override; naturally-closed flags after-hours) + new `executor_test` cases that pin the `IsAfterHours -> nextDelay` chain under closed_override and weekend.
- [x] Full Celina3 cypress suite passes 72/70/2/0 (only #60 + #71 remain pending) against this branch + the matching frontend PR.