### PR TITLE
seed: ITM put holding for cypress portfolio #71

### DIFF
--- a/scripts/db/seed.sql
+++ b/scripts/db/seed.sql
@@ -1037,3 +1037,40 @@ CROSS JOIN (VALUES
 ) AS sd(settle)
 CROSS JOIN generate_series(-5, 5) AS step
 ON CONFLICT (ticker) DO NOTHING;
+
+-------------------------------------------------------------------------------
+-- Cypress portfolio #71 (TestoviCelina3 scenario 71): seed an ITM put on
+-- MSFT held by the agent, so the test can verify the exercise flow end to
+-- end. Strike 63000 vs MSFT spot 42000 makes this comfortably in-the-money
+-- regardless of small spot drift; +30d settlement keeps it pre-expiry.
+-- Dedicated ticker so the cypress row selector stays trivial.
+-- Agent placer is upserted here too — the runtime CreateOrder path also
+-- lazily creates one, but this lets the holding seed run before any order
+-- has been placed.
+-------------------------------------------------------------------------------
+INSERT INTO order_placers (employee_id)
+SELECT e.id FROM employees e WHERE e.email = 'agent@banka.raf'
+ON CONFLICT (employee_id) WHERE employee_id IS NOT NULL DO NOTHING;
+
+INSERT INTO options (ticker, name, stock_id, option_type, strike_price, premium, implied_volatility, open_interest, settlement_date)
+SELECT
+    'MSFT_CY71_PUT_ITM',
+    'MSFT cypress #71 put @ 63000',
+    s.id,
+    'put'::option_type,
+    63000,
+    1000,
+    1.0,
+    0,
+    (CURRENT_DATE + 30)::date
+FROM stocks s WHERE s.ticker = 'MSFT'
+ON CONFLICT (ticker) DO NOTHING;
+
+INSERT INTO holdings (placer_id, option_id, account_id, amount, avg_cost)
+SELECT p.id, o.id, a.id, 5, 1000
+FROM order_placers p
+JOIN employees e ON e.id = p.employee_id
+JOIN options o ON o.ticker = 'MSFT_CY71_PUT_ITM'
+JOIN accounts a ON a.number = '333000100000000420'
+WHERE e.email = 'agent@banka.raf'
+ON CONFLICT (placer_id, option_id) WHERE option_id IS NOT NULL DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds an `order_placer` for `agent@banka.raf`, a dedicated `MSFT_CY71_PUT_ITM` option (PUT, strike 63000 vs MSFT spot 42000, premium 1000, settlement +30d), and a holding row tying them.
- Lets the cypress regression cover TestoviCelina3 scenario 71 (actuary exercises ITM put) **without any backend code change** — the existing `ExerciseOption` RPC at `services/bank/internal/trading/portfolio.go` already handles the ITM check, payout-at-strike, FX conversion, and holding deletion.

## Why
Skipped scenario from the Celina 3 cypress suite (`portfolio.cy.js #71`). The skip taxonomy previously suggested a proto extension (strike_price/option_type/settlement_date on `Holding`), but reading the spec carefully shows scenario 71 only asserts that the action is permitted and settles at strike — no UI ITM rendering required. So a seed-only change is sufficient.

The companion frontend PR un-skips the test and rips out a separate cosmetic ITM-coloring bug on the portfolio page (unrelated to this scenario, but worth removing since it was actively misleading).

## Test plan
- [x] `make nuke && make schema && make seed` succeeds.
- [x] `MSFT_CY71_PUT_ITM` row exists with expected strike/premium/settlement.
- [x] Holding row exists for the agent placer with amount=5, avg_cost=premium.
- [x] Frontend cypress portfolio spec passes 7/7 (verified locally with the companion frontend branch).
- [x] Full Celina 3 cypress suite passes 72/72/0/0 via `Banka-3-Frontend/front.sh`.