### PR TITLE
fix(exchange): refresh FX feed every 5 min so menjačnica stays populated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,15 @@ RESET_TTL=15m
 EXECUTION_TICK_INTERVAL=10s
 FX_COMMISSION=0.005
 
+# Menjačnica FX rate feed. The exchange service pulls mid rates from
+# open.er-api.com (free, no API key) into "exchange".fx_rates; the
+# first fetch runs at boot, then every FX_FEED_INTERVAL. Set 0 to
+# disable the background feed entirely. FX_FEED_SPREAD is the symmetric
+# bid/ask offset around the upstream mid (0.01 → ±1%); the bank's
+# profit is the commission, not the spread.
+FX_FEED_INTERVAL=5m
+FX_FEED_SPREAD=0.01
+
 # SAGA fault injection for cypress c4-tests. When true, the trading
 # service honours the X-Saga-Force-Fail / -Kind / -Compensate-Fail
 # request headers (forwarded by grpc-gateway as grpcgateway-x-saga-*

--- a/services/exchange/internal/app/app.go
+++ b/services/exchange/internal/app/app.go
@@ -63,9 +63,13 @@ func Run() error {
 		})
 	})
 
-	// Background FX feed: periodically pulls public mid rates and
-	// upserts X→RSD pairs. Disable with FX_FEED_INTERVAL=0.
-	feedInterval := config.Duration("FX_FEED_INTERVAL", time.Hour)
+	// Background FX feed: periodically pulls public mid rates from the
+	// keyless open.er-api.com endpoint and upserts X→RSD pairs. The
+	// first tick fires immediately on boot; the 5-minute cadence keeps
+	// the menjačnica board fresh without straining the free upstream
+	// (it refreshes its own data daily anyway). Disable with
+	// FX_FEED_INTERVAL=0.
+	feedInterval := config.Duration("FX_FEED_INTERVAL", 5*time.Minute)
 	if feedInterval > 0 {
 		feeder := &feed.Feeder{
 			Fetcher: &feed.OpenERAPI{BaseURL: config.String("FX_FEED_URL", "")},


### PR DESCRIPTION
QA C3 journal: *"Menjacnica ne radi — ne postoji kursna lista niti konverzije funkcionišu, možda je do API ključa?"*

## Root cause
The menjačnica is API-sourced and **works** — `feed.go` pulls mid rates from `open.er-api.com` (free, **keyless**) into `exchange.fx_rates`, and the bank service reads that for the kursna lista + quote. The failure was timing, not the API: `FX_FEED_INTERVAL` defaulted to **1h**, so after the boot tick the table went stale for up to an hour. A QA window opening in that gap (or right after a transient first fetch) saw an empty board / failing conversions. The QA author’s API-key suspicion was a red herring — no credentials are used (`EXCHANGE_RATE_API_KEY` in `.env` is dead config never read by the feed; `ALPHAVANTAGE_API_KEY` is for stock market data).

## Fix
- `FX_FEED_INTERVAL` default `1h` → **`5m`** (first tick still fires immediately on boot). open.er-api.com refreshes daily and is keyless, so 5m is well within polite use.
- Document `FX_FEED_INTERVAL` + `FX_FEED_SPREAD` in `.env.example`.

No DB-seeded constants — rates stay purely a cache of live API data, per design intent.

## Verification (live stack)
- Confirmed upstream keyless: `GET open.er-api.com/v6/latest/RSD` → `result: success`, USD/RSD ≈ 100.9999, EUR/RSD ≈ 117.4398.
- Rebuilt exchange: feed fetched 7 X→RSD pairs at boot; `exchange.fx_rates` fresh.
- `POST /api/v1/menjacnica/quote` EUR→USD 100 → `toAmount 115.6958` with commission.
- `cd services/exchange && go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)