### PR TITLE
fix(bank): expose counterparty account numbers on transactions

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -7637,6 +7637,13 @@
         "createdAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "fromAccountNumber": {
+          "type": "string",
+          "description": "The 18-digit account numbers behind from/to_account_id, resolved\nserver-side. The FE renders these in the \"Drugi račun\" column — a\nclient can't (and mustn't be able to) resolve a counterparty\naccount UUID it doesn't own. Empty when the leg's account isn't a\nlocally-held bank account (e.g. a future c5 inter-bank peer)."
+        },
+        "toAccountNumber": {
+          "type": "string"
         }
       },
       "description": "Transaction is one ledger leg. UX-level operations (a payment, a\ntransfer) are reconstructed by grouping on op_id."

--- a/gen/proto/bank/v1/bank.pb.go
+++ b/gen/proto/bank/v1/bank.pb.go
@@ -3069,6 +3069,13 @@ type Transaction struct {
 	InitiatorClientId string                 `protobuf:"bytes,14,opt,name=initiator_client_id,json=initiatorClientId,proto3" json:"initiator_client_id,omitempty"`
 	Status            TransactionStatus      `protobuf:"varint,15,opt,name=status,proto3,enum=banka.bank.v1.TransactionStatus" json:"status,omitempty"`
 	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// The 18-digit account numbers behind from/to_account_id, resolved
+	// server-side. The FE renders these in the "Drugi račun" column — a
+	// client can't (and mustn't be able to) resolve a counterparty
+	// account UUID it doesn't own. Empty when the leg's account isn't a
+	// locally-held bank account (e.g. a future c5 inter-bank peer).
+	FromAccountNumber string `protobuf:"bytes,17,opt,name=from_account_number,json=fromAccountNumber,proto3" json:"from_account_number,omitempty"`
+	ToAccountNumber   string `protobuf:"bytes,18,opt,name=to_account_number,json=toAccountNumber,proto3" json:"to_account_number,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -3213,6 +3220,20 @@ func (x *Transaction) GetCreatedAt() *timestamppb.Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *Transaction) GetFromAccountNumber() string {
+	if x != nil {
+		return x.FromAccountNumber
+	}
+	return ""
+}
+
+func (x *Transaction) GetToAccountNumber() string {
+	if x != nil {
+		return x.ToAccountNumber
+	}
+	return ""
 }
 
 type CreatePaymentRequest struct {
@@ -6220,7 +6241,7 @@ const file_bank_v1_bank_proto_rawDesc = "" +
 	"\apurpose\x18\a \x01(\tR\apurpose\"u\n" +
 	"\x1eTransferBetweenClientsResponse\x12\x13\n" +
 	"\x05op_id\x18\x01 \x01(\tR\x04opId\x12>\n" +
-	"\ftransactions\x18\x02 \x03(\v2\x1a.banka.bank.v1.TransactionR\ftransactions\"\xd5\x04\n" +
+	"\ftransactions\x18\x02 \x03(\v2\x1a.banka.bank.v1.TransactionR\ftransactions\"\xb1\x05\n" +
 	"\vTransaction\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x13\n" +
 	"\x05op_id\x18\x02 \x01(\tR\x04opId\x122\n" +
@@ -6240,7 +6261,9 @@ const file_bank_v1_bank_proto_rawDesc = "" +
 	"\x13initiator_client_id\x18\x0e \x01(\tR\x11initiatorClientId\x128\n" +
 	"\x06status\x18\x0f \x01(\x0e2 .banka.bank.v1.TransactionStatusR\x06status\x129\n" +
 	"\n" +
-	"created_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xd0\x03\n" +
+	"created_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12.\n" +
+	"\x13from_account_number\x18\x11 \x01(\tR\x11fromAccountNumber\x12*\n" +
+	"\x11to_account_number\x18\x12 \x01(\tR\x0ftoAccountNumber\"\xd0\x03\n" +
 	"\x14CreatePaymentRequest\x120\n" +
 	"\x0ffrom_account_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\rfromAccountId\x12>\n" +
 	"\x11to_account_number\x18\x02 \x01(\tB\x12\xbaH\x0fr\r2\v^[0-9]{18}$R\x0ftoAccountNumber\x12X\n" +

--- a/proto/bank/v1/bank.proto
+++ b/proto/bank/v1/bank.proto
@@ -736,6 +736,13 @@ message Transaction {
   string            initiator_client_id = 14;
   TransactionStatus status              = 15;
   google.protobuf.Timestamp created_at  = 16;
+  // The 18-digit account numbers behind from/to_account_id, resolved
+  // server-side. The FE renders these in the "Drugi račun" column — a
+  // client can't (and mustn't be able to) resolve a counterparty
+  // account UUID it doesn't own. Empty when the leg's account isn't a
+  // locally-held bank account (e.g. a future c5 inter-bank peer).
+  string            from_account_number = 17;
+  string            to_account_number   = 18;
 }
 
 message CreatePaymentRequest {

--- a/services/bank/internal/domain/payments.go
+++ b/services/bank/internal/domain/payments.go
@@ -78,6 +78,12 @@ type Transaction struct {
 	InitiatorClientID string
 	Status            TransactionStatus
 	CreatedAt         time.Time
+	// Resolved 18-digit numbers for From/ToAccountID. Populated only by
+	// the read paths (ListTransactions / GetTransactionsByOpID); the
+	// INSERT...RETURNING path leaves them empty (no counterparty join
+	// at write time, and nobody reads them there).
+	FromAccountNumber string
+	ToAccountNumber   string
 }
 
 // TransactionFilter narrows a ListTransactions call.

--- a/services/bank/internal/server/payments.go
+++ b/services/bank/internal/server/payments.go
@@ -251,6 +251,8 @@ func transactionToProto(t *domain.Transaction) *bankpb.Transaction {
 		InitiatorClientId: t.InitiatorClientID,
 		Status:            txStatusToProto(t.Status),
 		CreatedAt:         timestamppb.New(t.CreatedAt),
+		FromAccountNumber: t.FromAccountNumber,
+		ToAccountNumber:   t.ToAccountNumber,
 	}
 }
 

--- a/services/bank/internal/store/transactions.go
+++ b/services/bank/internal/store/transactions.go
@@ -41,6 +41,52 @@ func scanTransaction(row interface{ Scan(...any) error }) (*domain.Transaction, 
 	return &t, nil
 }
 
+// transactionReadColumns mirrors transactionColumns but qualified to
+// the "t" alias and with the two resolved counterparty account numbers
+// appended (LEFT JOINed via fa/ta — see transactionReadFrom). The read
+// paths use this so the FE can render the 18-digit "Drugi račun"
+// instead of a raw account UUID; the INSERT...RETURNING path keeps the
+// unqualified transactionColumns (RETURNING can't join).
+const transactionReadColumns = `
+    t.id, t.op_id, t.op_kind, t.leg_index,
+    t.from_account_id, t.to_account_id,
+    t.from_amount::text, t.to_amount::text,
+    coalesce(t.rate::text, '') as rate,
+    coalesce(t.recipient_name, ''),
+    coalesce(t.payment_code, ''),
+    coalesce(t.reference_number, ''),
+    coalesce(t.purpose, ''),
+    coalesce(t.initiator_client_id::text, ''),
+    t.status, t.created_at,
+    coalesce(fa.number, ''),
+    coalesce(ta.number, '')
+`
+
+const transactionReadFrom = `
+    from "bank".transactions t
+    left join "bank".accounts fa on fa.id = t.from_account_id
+    left join "bank".accounts ta on ta.id = t.to_account_id
+`
+
+func scanTransactionWithNumbers(row interface{ Scan(...any) error }) (*domain.Transaction, error) {
+	var t domain.Transaction
+	var kind, status string
+	if err := row.Scan(
+		&t.ID, &t.OpID, &kind, &t.LegIndex,
+		&t.FromAccountID, &t.ToAccountID,
+		&t.FromAmount, &t.ToAmount, &t.Rate,
+		&t.RecipientName, &t.PaymentCode, &t.ReferenceNumber, &t.Purpose,
+		&t.InitiatorClientID,
+		&status, &t.CreatedAt,
+		&t.FromAccountNumber, &t.ToAccountNumber,
+	); err != nil {
+		return nil, err
+	}
+	t.Kind = domain.TransactionKind(kind)
+	t.Status = domain.TransactionStatus(status)
+	return &t, nil
+}
+
 // ExecuteAtomic runs fn inside a serialized transaction. Used to guard
 // the multi-step "debit source, credit destination, write ledger row"
 // invariant of every payment/transfer.
@@ -227,21 +273,24 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 	}
 	var conds []string
 	var args []any
+	// Conditions are qualified to the "t" alias: the read query LEFT
+	// JOINs "bank".accounts (which also has a `status` column), so an
+	// unqualified `status`/`number` would be ambiguous.
 	if f.AccountID != "" {
 		args = append(args, f.AccountID)
-		conds = append(conds, fmt.Sprintf("(from_account_id = $%d or to_account_id = $%d)", len(args), len(args)))
+		conds = append(conds, fmt.Sprintf("(t.from_account_id = $%d or t.to_account_id = $%d)", len(args), len(args)))
 	}
 	if f.OpKind != "" {
 		args = append(args, f.OpKind)
-		conds = append(conds, fmt.Sprintf("op_kind = $%d", len(args)))
+		conds = append(conds, fmt.Sprintf("t.op_kind = $%d", len(args)))
 	}
 	if f.Status != "" {
 		args = append(args, f.Status)
-		conds = append(conds, fmt.Sprintf("status = $%d", len(args)))
+		conds = append(conds, fmt.Sprintf("t.status = $%d", len(args)))
 	}
 	if f.InitiatorClientID != "" {
 		args = append(args, f.InitiatorClientID)
-		conds = append(conds, fmt.Sprintf("initiator_client_id = $%d", len(args)))
+		conds = append(conds, fmt.Sprintf("t.initiator_client_id = $%d", len(args)))
 	}
 	where := ""
 	if len(conds) > 0 {
@@ -249,14 +298,14 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 	}
 
 	var total int64
-	if err := s.Pool.QueryRow(ctx, `select count(*) from "bank".transactions`+where, args...).Scan(&total); err != nil {
+	if err := s.Pool.QueryRow(ctx, `select count(*) from "bank".transactions t`+where, args...).Scan(&total); err != nil {
 		return nil, 0, apperr.Internal("count transactions", err)
 	}
 
 	listArgs := append([]any{}, args...)
 	listArgs = append(listArgs, pageSize, (page-1)*pageSize)
-	listQ := `select ` + transactionColumns + ` from "bank".transactions` + where +
-		fmt.Sprintf(" order by created_at desc, leg_index limit $%d offset $%d", len(args)+1, len(args)+2)
+	listQ := `select ` + transactionReadColumns + transactionReadFrom + where +
+		fmt.Sprintf(" order by t.created_at desc, t.leg_index limit $%d offset $%d", len(args)+1, len(args)+2)
 
 	rows, err := s.Pool.Query(ctx, listQ, listArgs...)
 	if err != nil {
@@ -265,7 +314,7 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 	defer rows.Close()
 	var out []*domain.Transaction
 	for rows.Next() {
-		t, err := scanTransaction(rows)
+		t, err := scanTransactionWithNumbers(rows)
 		if err != nil {
 			return nil, 0, apperr.Internal("scan transaction", err)
 		}
@@ -278,7 +327,7 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 // payment / transfer / trade). Empty result is not an error — caller
 // distinguishes "not yet settled" from "no rows".
 func (s *Store) GetTransactionsByOpID(ctx context.Context, opID string) ([]*domain.Transaction, error) {
-	q := `select ` + transactionColumns + ` from "bank".transactions where op_id = $1 order by leg_index`
+	q := `select ` + transactionReadColumns + transactionReadFrom + ` where t.op_id = $1 order by t.leg_index`
 	rows, err := s.Pool.Query(ctx, q, opID)
 	if err != nil {
 		return nil, apperr.Internal("transactions by op", err)
@@ -286,7 +335,7 @@ func (s *Store) GetTransactionsByOpID(ctx context.Context, opID string) ([]*doma
 	defer rows.Close()
 	var out []*domain.Transaction
 	for rows.Next() {
-		t, err := scanTransaction(rows)
+		t, err := scanTransactionWithNumbers(rows)
 		if err != nil {
 			return nil, apperr.Internal("scan tx by op", err)
 		}


### PR DESCRIPTION
QA C3 journal: *"Na detaljnom prikazu računa, lista transakcija polje drugi račun prikazuje primary key računa u bazi podataka umesto broja računa."*

## Root cause
The `Transaction` proto only carried `from/to_account_id` (account UUIDs / DB PKs). The FE rendered that UUID directly in the "Drugi račun" column. A client cannot — and must not be able to — resolve a counterparty account UUID it does not own, so the number must be resolved server-side.

## Fix
- `Transaction` proto: add `from_account_number` (17) + `to_account_number` (18).
- Resolve via `LEFT JOIN "bank".accounts` on the **read paths only** (`ListTransactions`, `GetTransactionsByOpID`). `INSERT...RETURNING` keeps the unqualified column list (RETURNING cannot join).
- Read-path predicates qualified to the `t` alias (joined `accounts` also has a `status` column → would be ambiguous).
- Empty string when the leg account is not locally held — forward-compatible with c5 inter-bank peers.

## Verification (live stack)
Rebuilt bank + gateway (gateway compiles the proto for JSON marshalling), then `GET /api/v1/transactions?accountId=…`:
```
from_id=b1927582 fromNo=333000136902094599  to_id=3bbefb26 toNo=333000176072044899
```
`cd services/bank && go build ./...` clean; `make proto` regenerated stubs + swagger.

FE counterpart: RAF-SI-2025/Banka-3-Frontend `fix/tx-list-show-account-number`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)