### PR TITLE
fix(trading): price-history chart — accept YYYY-MM-DD date range

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -2221,17 +2221,16 @@
           },
           {
             "name": "from",
+            "description": "Plain YYYY-MM-DD strings (the FE binds these from its date range\npicker / isoNDaysAgo). A google.protobuf.Timestamp here cannot be\nbound from a bare date query param through grpc-gateway — the\nwhole request 400s (\"cannot parse … as RFC3339\") so the price\nhistory chart never received data. Empty means unbounded.",
             "in": "query",
             "required": false,
-            "type": "string",
-            "format": "date-time"
+            "type": "string"
           },
           {
             "name": "to",
             "in": "query",
             "required": false,
-            "type": "string",
-            "format": "date-time"
+            "type": "string"
           }
         ],
         "tags": [

--- a/gen/proto/trading/v1/trading.pb.go
+++ b/gen/proto/trading/v1/trading.pb.go
@@ -2796,10 +2796,15 @@ func (x *GetListingRequest) GetId() string {
 }
 
 type GetListingDailyHistoryRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ListingId     string                 `protobuf:"bytes,1,opt,name=listing_id,json=listingId,proto3" json:"listing_id,omitempty"`
-	From          *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=from,proto3" json:"from,omitempty"`
-	To            *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	ListingId string                 `protobuf:"bytes,1,opt,name=listing_id,json=listingId,proto3" json:"listing_id,omitempty"`
+	// Plain YYYY-MM-DD strings (the FE binds these from its date range
+	// picker / isoNDaysAgo). A google.protobuf.Timestamp here cannot be
+	// bound from a bare date query param through grpc-gateway — the
+	// whole request 400s ("cannot parse … as RFC3339") so the price
+	// history chart never received data. Empty means unbounded.
+	From          string `protobuf:"bytes,2,opt,name=from,proto3" json:"from,omitempty"`
+	To            string `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2841,18 +2846,18 @@ func (x *GetListingDailyHistoryRequest) GetListingId() string {
 	return ""
 }
 
-func (x *GetListingDailyHistoryRequest) GetFrom() *timestamppb.Timestamp {
+func (x *GetListingDailyHistoryRequest) GetFrom() string {
 	if x != nil {
 		return x.From
 	}
-	return nil
+	return ""
 }
 
-func (x *GetListingDailyHistoryRequest) GetTo() *timestamppb.Timestamp {
+func (x *GetListingDailyHistoryRequest) GetTo() string {
 	if x != nil {
 		return x.To
 	}
-	return nil
+	return ""
 }
 
 type ListingDailyPrice struct {
@@ -8846,12 +8851,12 @@ const file_trading_v1_trading_proto_rawDesc = "" +
 	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\x12\x14\n" +
 	"\x05total\x18\x04 \x01(\x03R\x05total\"-\n" +
 	"\x11GetListingRequest\x12\x18\n" +
-	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\xa4\x01\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\"l\n" +
 	"\x1dGetListingDailyHistoryRequest\x12'\n" +
 	"\n" +
-	"listing_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\tlistingId\x12.\n" +
-	"\x04from\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x04from\x12*\n" +
-	"\x02to\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x02to\"\xb4\x01\n" +
+	"listing_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\tlistingId\x12\x12\n" +
+	"\x04from\x18\x02 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x03 \x01(\tR\x02to\"\xb4\x01\n" +
 	"\x11ListingDailyPrice\x12.\n" +
 	"\x04date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04date\x12\x14\n" +
 	"\x05price\x18\x02 \x01(\tR\x05price\x12\x10\n" +
@@ -9664,218 +9669,216 @@ var file_trading_v1_trading_proto_depIdxs = []int32{
 	116, // 31: banka.trading.v1.Listing.created_at:type_name -> google.protobuf.Timestamp
 	1,   // 32: banka.trading.v1.ListListingsRequest.type:type_name -> banka.trading.v1.SecurityType
 	30,  // 33: banka.trading.v1.ListListingsResponse.items:type_name -> banka.trading.v1.SecurityWithListing
-	116, // 34: banka.trading.v1.GetListingDailyHistoryRequest.from:type_name -> google.protobuf.Timestamp
-	116, // 35: banka.trading.v1.GetListingDailyHistoryRequest.to:type_name -> google.protobuf.Timestamp
-	116, // 36: banka.trading.v1.ListingDailyPrice.date:type_name -> google.protobuf.Timestamp
-	38,  // 37: banka.trading.v1.GetListingDailyHistoryResponse.rows:type_name -> banka.trading.v1.ListingDailyPrice
-	116, // 38: banka.trading.v1.GetOptionChainRequest.settlement_date:type_name -> google.protobuf.Timestamp
-	26,  // 39: banka.trading.v1.OptionChainRow.call:type_name -> banka.trading.v1.Security
-	26,  // 40: banka.trading.v1.OptionChainRow.put:type_name -> banka.trading.v1.Security
-	116, // 41: banka.trading.v1.OptionChainGroup.settlement_date:type_name -> google.protobuf.Timestamp
-	41,  // 42: banka.trading.v1.OptionChainGroup.rows:type_name -> banka.trading.v1.OptionChainRow
-	42,  // 43: banka.trading.v1.GetOptionChainResponse.groups:type_name -> banka.trading.v1.OptionChainGroup
-	7,   // 44: banka.trading.v1.Order.user_kind:type_name -> banka.trading.v1.UserKind
-	3,   // 45: banka.trading.v1.Order.order_type:type_name -> banka.trading.v1.OrderType
-	4,   // 46: banka.trading.v1.Order.direction:type_name -> banka.trading.v1.Direction
-	5,   // 47: banka.trading.v1.Order.status:type_name -> banka.trading.v1.OrderStatus
-	116, // 48: banka.trading.v1.Order.approved_at:type_name -> google.protobuf.Timestamp
-	116, // 49: banka.trading.v1.Order.last_modification:type_name -> google.protobuf.Timestamp
-	116, // 50: banka.trading.v1.Order.created_at:type_name -> google.protobuf.Timestamp
-	7,   // 51: banka.trading.v1.Order.actor_kind:type_name -> banka.trading.v1.UserKind
-	3,   // 52: banka.trading.v1.CreateOrderRequest.order_type:type_name -> banka.trading.v1.OrderType
-	4,   // 53: banka.trading.v1.CreateOrderRequest.direction:type_name -> banka.trading.v1.Direction
-	44,  // 54: banka.trading.v1.CreateOrderResponse.order:type_name -> banka.trading.v1.Order
-	7,   // 55: banka.trading.v1.ListOrdersRequest.user_kind:type_name -> banka.trading.v1.UserKind
-	44,  // 56: banka.trading.v1.ListOrdersResponse.orders:type_name -> banka.trading.v1.Order
-	7,   // 57: banka.trading.v1.Holding.user_kind:type_name -> banka.trading.v1.UserKind
-	26,  // 58: banka.trading.v1.Holding.security:type_name -> banka.trading.v1.Security
-	116, // 59: banka.trading.v1.Holding.acquired_at:type_name -> google.protobuf.Timestamp
-	116, // 60: banka.trading.v1.Holding.updated_at:type_name -> google.protobuf.Timestamp
-	7,   // 61: banka.trading.v1.ListHoldingsRequest.user_kind:type_name -> banka.trading.v1.UserKind
-	1,   // 62: banka.trading.v1.ListHoldingsRequest.type:type_name -> banka.trading.v1.SecurityType
-	53,  // 63: banka.trading.v1.ListHoldingsResponse.holdings:type_name -> banka.trading.v1.Holding
-	53,  // 64: banka.trading.v1.ExerciseOptionResponse.option_holding:type_name -> banka.trading.v1.Holding
-	53,  // 65: banka.trading.v1.ExerciseOptionResponse.underlying_holding:type_name -> banka.trading.v1.Holding
-	0,   // 66: banka.trading.v1.ExerciseOptionResponse.realized_gain_currency:type_name -> banka.trading.v1.Currency
-	7,   // 67: banka.trading.v1.TaxPosition.user_kind:type_name -> banka.trading.v1.UserKind
-	7,   // 68: banka.trading.v1.ListTaxPositionsRequest.user_kind:type_name -> banka.trading.v1.UserKind
-	59,  // 69: banka.trading.v1.ListTaxPositionsResponse.positions:type_name -> banka.trading.v1.TaxPosition
-	7,   // 70: banka.trading.v1.RunTaxRequest.user_kind:type_name -> banka.trading.v1.UserKind
-	116, // 71: banka.trading.v1.RealizedPnLRow.sale_at:type_name -> google.protobuf.Timestamp
-	0,   // 72: banka.trading.v1.RealizedPnLRow.currency:type_name -> banka.trading.v1.Currency
-	116, // 73: banka.trading.v1.RealizedPnLRow.taxed_at:type_name -> google.protobuf.Timestamp
-	7,   // 74: banka.trading.v1.ListRealizedPnLRequest.user_kind:type_name -> banka.trading.v1.UserKind
-	116, // 75: banka.trading.v1.ListRealizedPnLRequest.from:type_name -> google.protobuf.Timestamp
-	116, // 76: banka.trading.v1.ListRealizedPnLRequest.to:type_name -> google.protobuf.Timestamp
-	64,  // 77: banka.trading.v1.ListRealizedPnLResponse.rows:type_name -> banka.trading.v1.RealizedPnLRow
-	7,   // 78: banka.trading.v1.PublicHoldingItem.seller_kind:type_name -> banka.trading.v1.UserKind
-	26,  // 79: banka.trading.v1.PublicHoldingItem.security:type_name -> banka.trading.v1.Security
-	0,   // 80: banka.trading.v1.PublicHoldingItem.currency:type_name -> banka.trading.v1.Currency
-	116, // 81: banka.trading.v1.PublicHoldingItem.last_updated:type_name -> google.protobuf.Timestamp
-	67,  // 82: banka.trading.v1.ListPublicHoldingsResponse.items:type_name -> banka.trading.v1.PublicHoldingItem
-	7,   // 83: banka.trading.v1.OTCOffer.buyer_kind:type_name -> banka.trading.v1.UserKind
-	7,   // 84: banka.trading.v1.OTCOffer.seller_kind:type_name -> banka.trading.v1.UserKind
-	0,   // 85: banka.trading.v1.OTCOffer.currency:type_name -> banka.trading.v1.Currency
-	116, // 86: banka.trading.v1.OTCOffer.settlement_date:type_name -> google.protobuf.Timestamp
-	8,   // 87: banka.trading.v1.OTCOffer.status:type_name -> banka.trading.v1.OTCStatus
-	116, // 88: banka.trading.v1.OTCOffer.created_at:type_name -> google.protobuf.Timestamp
-	116, // 89: banka.trading.v1.OTCOffer.updated_at:type_name -> google.protobuf.Timestamp
-	116, // 90: banka.trading.v1.CreateOTCOfferRequest.settlement_date:type_name -> google.protobuf.Timestamp
-	116, // 91: banka.trading.v1.CounterOfferOTCRequest.settlement_date:type_name -> google.protobuf.Timestamp
-	7,   // 92: banka.trading.v1.ListOTCThreadsRequest.party_user_kind:type_name -> banka.trading.v1.UserKind
-	70,  // 93: banka.trading.v1.ListOTCThreadsResponse.threads:type_name -> banka.trading.v1.OTCOffer
-	70,  // 94: banka.trading.v1.GetOTCThreadResponse.iterations:type_name -> banka.trading.v1.OTCOffer
-	80,  // 95: banka.trading.v1.GetOTCThreadResponse.contract:type_name -> banka.trading.v1.OTCContract
-	80,  // 96: banka.trading.v1.AcceptOTCOfferResponse.contract:type_name -> banka.trading.v1.OTCContract
-	7,   // 97: banka.trading.v1.OTCContract.buyer_kind:type_name -> banka.trading.v1.UserKind
-	7,   // 98: banka.trading.v1.OTCContract.seller_kind:type_name -> banka.trading.v1.UserKind
-	0,   // 99: banka.trading.v1.OTCContract.currency:type_name -> banka.trading.v1.Currency
-	116, // 100: banka.trading.v1.OTCContract.settlement_date:type_name -> google.protobuf.Timestamp
-	9,   // 101: banka.trading.v1.OTCContract.status:type_name -> banka.trading.v1.OTCContractStatus
-	116, // 102: banka.trading.v1.OTCContract.exercised_at:type_name -> google.protobuf.Timestamp
-	116, // 103: banka.trading.v1.OTCContract.created_at:type_name -> google.protobuf.Timestamp
-	116, // 104: banka.trading.v1.OTCContract.updated_at:type_name -> google.protobuf.Timestamp
-	7,   // 105: banka.trading.v1.ListOTCContractsRequest.party_user_kind:type_name -> banka.trading.v1.UserKind
-	80,  // 106: banka.trading.v1.ListOTCContractsResponse.contracts:type_name -> banka.trading.v1.OTCContract
-	80,  // 107: banka.trading.v1.ExerciseOTCContractResponse.contract:type_name -> banka.trading.v1.OTCContract
-	10,  // 108: banka.trading.v1.Fund.status:type_name -> banka.trading.v1.FundStatus
-	116, // 109: banka.trading.v1.Fund.created_at:type_name -> google.protobuf.Timestamp
-	116, // 110: banka.trading.v1.Fund.updated_at:type_name -> google.protobuf.Timestamp
-	26,  // 111: banka.trading.v1.FundHolding.security:type_name -> banka.trading.v1.Security
-	0,   // 112: banka.trading.v1.FundHolding.currency:type_name -> banka.trading.v1.Currency
-	116, // 113: banka.trading.v1.FundHolding.acquired_at:type_name -> google.protobuf.Timestamp
-	116, // 114: banka.trading.v1.FundHolding.updated_at:type_name -> google.protobuf.Timestamp
-	116, // 115: banka.trading.v1.FundPosition.created_at:type_name -> google.protobuf.Timestamp
-	116, // 116: banka.trading.v1.FundPosition.updated_at:type_name -> google.protobuf.Timestamp
-	11,  // 117: banka.trading.v1.FundTransaction.status:type_name -> banka.trading.v1.FundTransactionStatus
-	116, // 118: banka.trading.v1.FundTransaction.created_at:type_name -> google.protobuf.Timestamp
-	116, // 119: banka.trading.v1.FundTransaction.updated_at:type_name -> google.protobuf.Timestamp
-	116, // 120: banka.trading.v1.FundPerformanceSnapshot.snapshot_at:type_name -> google.protobuf.Timestamp
-	86,  // 121: banka.trading.v1.ListFundsResponse.funds:type_name -> banka.trading.v1.Fund
-	86,  // 122: banka.trading.v1.GetFundResponse.fund:type_name -> banka.trading.v1.Fund
-	87,  // 123: banka.trading.v1.GetFundResponse.holdings:type_name -> banka.trading.v1.FundHolding
-	88,  // 124: banka.trading.v1.GetFundResponse.position:type_name -> banka.trading.v1.FundPosition
-	89,  // 125: banka.trading.v1.FundTransactionResponse.transaction:type_name -> banka.trading.v1.FundTransaction
-	88,  // 126: banka.trading.v1.ListFundPositionsResponse.positions:type_name -> banka.trading.v1.FundPosition
-	90,  // 127: banka.trading.v1.GetFundPerformanceResponse.snapshots:type_name -> banka.trading.v1.FundPerformanceSnapshot
-	89,  // 128: banka.trading.v1.ListFundTransactionsResponse.transactions:type_name -> banka.trading.v1.FundTransaction
-	2,   // 129: banka.trading.v1.ActuaryPerformance.type:type_name -> banka.trading.v1.ActuaryType
-	105, // 130: banka.trading.v1.ListActuaryPerformancesResponse.rows:type_name -> banka.trading.v1.ActuaryPerformance
-	88,  // 131: banka.trading.v1.BankFundPosition.position:type_name -> banka.trading.v1.FundPosition
-	108, // 132: banka.trading.v1.ListBankFundPositionsResponse.rows:type_name -> banka.trading.v1.BankFundPosition
-	116, // 133: banka.trading.v1.GetBankProfitTimeseriesRequest.from:type_name -> google.protobuf.Timestamp
-	116, // 134: banka.trading.v1.GetBankProfitTimeseriesRequest.to:type_name -> google.protobuf.Timestamp
-	116, // 135: banka.trading.v1.BankProfitBucket.period_start:type_name -> google.protobuf.Timestamp
-	112, // 136: banka.trading.v1.GetBankProfitTimeseriesResponse.buckets:type_name -> banka.trading.v1.BankProfitBucket
-	13,  // 137: banka.trading.v1.TradingService.GetActuaryInfo:input_type -> banka.trading.v1.GetActuaryInfoRequest
-	14,  // 138: banka.trading.v1.TradingService.ListActuaries:input_type -> banka.trading.v1.ListActuariesRequest
-	16,  // 139: banka.trading.v1.TradingService.UpsertActuaryInfo:input_type -> banka.trading.v1.UpsertActuaryInfoRequest
-	17,  // 140: banka.trading.v1.TradingService.UpdateActuaryLimit:input_type -> banka.trading.v1.UpdateActuaryLimitRequest
-	18,  // 141: banka.trading.v1.TradingService.ResetActuaryUsedLimit:input_type -> banka.trading.v1.ResetActuaryUsedLimitRequest
-	19,  // 142: banka.trading.v1.TradingService.SetActuaryNeedApproval:input_type -> banka.trading.v1.SetActuaryNeedApprovalRequest
-	117, // 143: banka.trading.v1.TradingService.RunDailyResetActuaries:input_type -> google.protobuf.Empty
-	22,  // 144: banka.trading.v1.TradingService.ListExchanges:input_type -> banka.trading.v1.ListExchangesRequest
-	24,  // 145: banka.trading.v1.TradingService.UpsertExchange:input_type -> banka.trading.v1.UpsertExchangeRequest
-	25,  // 146: banka.trading.v1.TradingService.SetExchangeOverride:input_type -> banka.trading.v1.SetExchangeOverrideRequest
-	27,  // 147: banka.trading.v1.TradingService.UpsertSecurity:input_type -> banka.trading.v1.UpsertSecurityRequest
-	28,  // 148: banka.trading.v1.TradingService.ListSecurities:input_type -> banka.trading.v1.ListSecuritiesRequest
-	31,  // 149: banka.trading.v1.TradingService.GetSecurity:input_type -> banka.trading.v1.GetSecurityRequest
-	33,  // 150: banka.trading.v1.TradingService.UpsertListing:input_type -> banka.trading.v1.UpsertListingRequest
-	34,  // 151: banka.trading.v1.TradingService.ListListings:input_type -> banka.trading.v1.ListListingsRequest
-	36,  // 152: banka.trading.v1.TradingService.GetListing:input_type -> banka.trading.v1.GetListingRequest
-	40,  // 153: banka.trading.v1.TradingService.GetOptionChain:input_type -> banka.trading.v1.GetOptionChainRequest
-	37,  // 154: banka.trading.v1.TradingService.GetListingDailyHistory:input_type -> banka.trading.v1.GetListingDailyHistoryRequest
-	45,  // 155: banka.trading.v1.TradingService.CreateOrder:input_type -> banka.trading.v1.CreateOrderRequest
-	47,  // 156: banka.trading.v1.TradingService.ListOrders:input_type -> banka.trading.v1.ListOrdersRequest
-	49,  // 157: banka.trading.v1.TradingService.GetOrder:input_type -> banka.trading.v1.GetOrderRequest
-	50,  // 158: banka.trading.v1.TradingService.ApproveOrder:input_type -> banka.trading.v1.ApproveOrderRequest
-	51,  // 159: banka.trading.v1.TradingService.DeclineOrder:input_type -> banka.trading.v1.DeclineOrderRequest
-	52,  // 160: banka.trading.v1.TradingService.CancelOrder:input_type -> banka.trading.v1.CancelOrderRequest
-	54,  // 161: banka.trading.v1.TradingService.ListHoldings:input_type -> banka.trading.v1.ListHoldingsRequest
-	56,  // 162: banka.trading.v1.TradingService.SetPublicCount:input_type -> banka.trading.v1.SetPublicCountRequest
-	57,  // 163: banka.trading.v1.TradingService.ExerciseOption:input_type -> banka.trading.v1.ExerciseOptionRequest
-	60,  // 164: banka.trading.v1.TradingService.ListTaxPositions:input_type -> banka.trading.v1.ListTaxPositionsRequest
-	62,  // 165: banka.trading.v1.TradingService.RunTax:input_type -> banka.trading.v1.RunTaxRequest
-	65,  // 166: banka.trading.v1.TradingService.ListRealizedPnL:input_type -> banka.trading.v1.ListRealizedPnLRequest
-	68,  // 167: banka.trading.v1.TradingService.ListPublicHoldings:input_type -> banka.trading.v1.ListPublicHoldingsRequest
-	71,  // 168: banka.trading.v1.TradingService.CreateOTCOffer:input_type -> banka.trading.v1.CreateOTCOfferRequest
-	72,  // 169: banka.trading.v1.TradingService.CounterOfferOTC:input_type -> banka.trading.v1.CounterOfferOTCRequest
-	73,  // 170: banka.trading.v1.TradingService.WithdrawOTCOffer:input_type -> banka.trading.v1.WithdrawOTCOfferRequest
-	74,  // 171: banka.trading.v1.TradingService.ListOTCThreads:input_type -> banka.trading.v1.ListOTCThreadsRequest
-	76,  // 172: banka.trading.v1.TradingService.GetOTCThread:input_type -> banka.trading.v1.GetOTCThreadRequest
-	78,  // 173: banka.trading.v1.TradingService.AcceptOTCOffer:input_type -> banka.trading.v1.AcceptOTCOfferRequest
-	81,  // 174: banka.trading.v1.TradingService.ListOTCContracts:input_type -> banka.trading.v1.ListOTCContractsRequest
-	83,  // 175: banka.trading.v1.TradingService.GetOTCContract:input_type -> banka.trading.v1.GetOTCContractRequest
-	84,  // 176: banka.trading.v1.TradingService.ExerciseOTCContract:input_type -> banka.trading.v1.ExerciseOTCContractRequest
-	91,  // 177: banka.trading.v1.TradingService.ListFunds:input_type -> banka.trading.v1.ListFundsRequest
-	93,  // 178: banka.trading.v1.TradingService.GetFund:input_type -> banka.trading.v1.GetFundRequest
-	95,  // 179: banka.trading.v1.TradingService.CreateFund:input_type -> banka.trading.v1.CreateFundRequest
-	96,  // 180: banka.trading.v1.TradingService.InvestInFund:input_type -> banka.trading.v1.InvestInFundRequest
-	97,  // 181: banka.trading.v1.TradingService.WithdrawFromFund:input_type -> banka.trading.v1.WithdrawFromFundRequest
-	99,  // 182: banka.trading.v1.TradingService.ListFundPositions:input_type -> banka.trading.v1.ListFundPositionsRequest
-	101, // 183: banka.trading.v1.TradingService.GetFundPerformance:input_type -> banka.trading.v1.GetFundPerformanceRequest
-	103, // 184: banka.trading.v1.TradingService.ListFundTransactions:input_type -> banka.trading.v1.ListFundTransactionsRequest
-	106, // 185: banka.trading.v1.TradingService.ListActuaryPerformances:input_type -> banka.trading.v1.ListActuaryPerformancesRequest
-	109, // 186: banka.trading.v1.TradingService.ListBankFundPositions:input_type -> banka.trading.v1.ListBankFundPositionsRequest
-	111, // 187: banka.trading.v1.TradingService.GetBankProfitTimeseries:input_type -> banka.trading.v1.GetBankProfitTimeseriesRequest
-	114, // 188: banka.trading.v1.TradingService.ReassignSupervisorAssets:input_type -> banka.trading.v1.ReassignSupervisorAssetsRequest
-	12,  // 189: banka.trading.v1.TradingService.GetActuaryInfo:output_type -> banka.trading.v1.ActuaryInfo
-	15,  // 190: banka.trading.v1.TradingService.ListActuaries:output_type -> banka.trading.v1.ListActuariesResponse
-	12,  // 191: banka.trading.v1.TradingService.UpsertActuaryInfo:output_type -> banka.trading.v1.ActuaryInfo
-	12,  // 192: banka.trading.v1.TradingService.UpdateActuaryLimit:output_type -> banka.trading.v1.ActuaryInfo
-	12,  // 193: banka.trading.v1.TradingService.ResetActuaryUsedLimit:output_type -> banka.trading.v1.ActuaryInfo
-	12,  // 194: banka.trading.v1.TradingService.SetActuaryNeedApproval:output_type -> banka.trading.v1.ActuaryInfo
-	20,  // 195: banka.trading.v1.TradingService.RunDailyResetActuaries:output_type -> banka.trading.v1.RunDailyResetActuariesResponse
-	23,  // 196: banka.trading.v1.TradingService.ListExchanges:output_type -> banka.trading.v1.ListExchangesResponse
-	21,  // 197: banka.trading.v1.TradingService.UpsertExchange:output_type -> banka.trading.v1.Exchange
-	21,  // 198: banka.trading.v1.TradingService.SetExchangeOverride:output_type -> banka.trading.v1.Exchange
-	26,  // 199: banka.trading.v1.TradingService.UpsertSecurity:output_type -> banka.trading.v1.Security
-	29,  // 200: banka.trading.v1.TradingService.ListSecurities:output_type -> banka.trading.v1.ListSecuritiesResponse
-	30,  // 201: banka.trading.v1.TradingService.GetSecurity:output_type -> banka.trading.v1.SecurityWithListing
-	32,  // 202: banka.trading.v1.TradingService.UpsertListing:output_type -> banka.trading.v1.Listing
-	35,  // 203: banka.trading.v1.TradingService.ListListings:output_type -> banka.trading.v1.ListListingsResponse
-	32,  // 204: banka.trading.v1.TradingService.GetListing:output_type -> banka.trading.v1.Listing
-	43,  // 205: banka.trading.v1.TradingService.GetOptionChain:output_type -> banka.trading.v1.GetOptionChainResponse
-	39,  // 206: banka.trading.v1.TradingService.GetListingDailyHistory:output_type -> banka.trading.v1.GetListingDailyHistoryResponse
-	46,  // 207: banka.trading.v1.TradingService.CreateOrder:output_type -> banka.trading.v1.CreateOrderResponse
-	48,  // 208: banka.trading.v1.TradingService.ListOrders:output_type -> banka.trading.v1.ListOrdersResponse
-	44,  // 209: banka.trading.v1.TradingService.GetOrder:output_type -> banka.trading.v1.Order
-	44,  // 210: banka.trading.v1.TradingService.ApproveOrder:output_type -> banka.trading.v1.Order
-	44,  // 211: banka.trading.v1.TradingService.DeclineOrder:output_type -> banka.trading.v1.Order
-	44,  // 212: banka.trading.v1.TradingService.CancelOrder:output_type -> banka.trading.v1.Order
-	55,  // 213: banka.trading.v1.TradingService.ListHoldings:output_type -> banka.trading.v1.ListHoldingsResponse
-	53,  // 214: banka.trading.v1.TradingService.SetPublicCount:output_type -> banka.trading.v1.Holding
-	58,  // 215: banka.trading.v1.TradingService.ExerciseOption:output_type -> banka.trading.v1.ExerciseOptionResponse
-	61,  // 216: banka.trading.v1.TradingService.ListTaxPositions:output_type -> banka.trading.v1.ListTaxPositionsResponse
-	63,  // 217: banka.trading.v1.TradingService.RunTax:output_type -> banka.trading.v1.RunTaxResponse
-	66,  // 218: banka.trading.v1.TradingService.ListRealizedPnL:output_type -> banka.trading.v1.ListRealizedPnLResponse
-	69,  // 219: banka.trading.v1.TradingService.ListPublicHoldings:output_type -> banka.trading.v1.ListPublicHoldingsResponse
-	70,  // 220: banka.trading.v1.TradingService.CreateOTCOffer:output_type -> banka.trading.v1.OTCOffer
-	70,  // 221: banka.trading.v1.TradingService.CounterOfferOTC:output_type -> banka.trading.v1.OTCOffer
-	70,  // 222: banka.trading.v1.TradingService.WithdrawOTCOffer:output_type -> banka.trading.v1.OTCOffer
-	75,  // 223: banka.trading.v1.TradingService.ListOTCThreads:output_type -> banka.trading.v1.ListOTCThreadsResponse
-	77,  // 224: banka.trading.v1.TradingService.GetOTCThread:output_type -> banka.trading.v1.GetOTCThreadResponse
-	79,  // 225: banka.trading.v1.TradingService.AcceptOTCOffer:output_type -> banka.trading.v1.AcceptOTCOfferResponse
-	82,  // 226: banka.trading.v1.TradingService.ListOTCContracts:output_type -> banka.trading.v1.ListOTCContractsResponse
-	80,  // 227: banka.trading.v1.TradingService.GetOTCContract:output_type -> banka.trading.v1.OTCContract
-	85,  // 228: banka.trading.v1.TradingService.ExerciseOTCContract:output_type -> banka.trading.v1.ExerciseOTCContractResponse
-	92,  // 229: banka.trading.v1.TradingService.ListFunds:output_type -> banka.trading.v1.ListFundsResponse
-	94,  // 230: banka.trading.v1.TradingService.GetFund:output_type -> banka.trading.v1.GetFundResponse
-	86,  // 231: banka.trading.v1.TradingService.CreateFund:output_type -> banka.trading.v1.Fund
-	98,  // 232: banka.trading.v1.TradingService.InvestInFund:output_type -> banka.trading.v1.FundTransactionResponse
-	98,  // 233: banka.trading.v1.TradingService.WithdrawFromFund:output_type -> banka.trading.v1.FundTransactionResponse
-	100, // 234: banka.trading.v1.TradingService.ListFundPositions:output_type -> banka.trading.v1.ListFundPositionsResponse
-	102, // 235: banka.trading.v1.TradingService.GetFundPerformance:output_type -> banka.trading.v1.GetFundPerformanceResponse
-	104, // 236: banka.trading.v1.TradingService.ListFundTransactions:output_type -> banka.trading.v1.ListFundTransactionsResponse
-	107, // 237: banka.trading.v1.TradingService.ListActuaryPerformances:output_type -> banka.trading.v1.ListActuaryPerformancesResponse
-	110, // 238: banka.trading.v1.TradingService.ListBankFundPositions:output_type -> banka.trading.v1.ListBankFundPositionsResponse
-	113, // 239: banka.trading.v1.TradingService.GetBankProfitTimeseries:output_type -> banka.trading.v1.GetBankProfitTimeseriesResponse
-	115, // 240: banka.trading.v1.TradingService.ReassignSupervisorAssets:output_type -> banka.trading.v1.ReassignSupervisorAssetsResponse
-	189, // [189:241] is the sub-list for method output_type
-	137, // [137:189] is the sub-list for method input_type
-	137, // [137:137] is the sub-list for extension type_name
-	137, // [137:137] is the sub-list for extension extendee
-	0,   // [0:137] is the sub-list for field type_name
+	116, // 34: banka.trading.v1.ListingDailyPrice.date:type_name -> google.protobuf.Timestamp
+	38,  // 35: banka.trading.v1.GetListingDailyHistoryResponse.rows:type_name -> banka.trading.v1.ListingDailyPrice
+	116, // 36: banka.trading.v1.GetOptionChainRequest.settlement_date:type_name -> google.protobuf.Timestamp
+	26,  // 37: banka.trading.v1.OptionChainRow.call:type_name -> banka.trading.v1.Security
+	26,  // 38: banka.trading.v1.OptionChainRow.put:type_name -> banka.trading.v1.Security
+	116, // 39: banka.trading.v1.OptionChainGroup.settlement_date:type_name -> google.protobuf.Timestamp
+	41,  // 40: banka.trading.v1.OptionChainGroup.rows:type_name -> banka.trading.v1.OptionChainRow
+	42,  // 41: banka.trading.v1.GetOptionChainResponse.groups:type_name -> banka.trading.v1.OptionChainGroup
+	7,   // 42: banka.trading.v1.Order.user_kind:type_name -> banka.trading.v1.UserKind
+	3,   // 43: banka.trading.v1.Order.order_type:type_name -> banka.trading.v1.OrderType
+	4,   // 44: banka.trading.v1.Order.direction:type_name -> banka.trading.v1.Direction
+	5,   // 45: banka.trading.v1.Order.status:type_name -> banka.trading.v1.OrderStatus
+	116, // 46: banka.trading.v1.Order.approved_at:type_name -> google.protobuf.Timestamp
+	116, // 47: banka.trading.v1.Order.last_modification:type_name -> google.protobuf.Timestamp
+	116, // 48: banka.trading.v1.Order.created_at:type_name -> google.protobuf.Timestamp
+	7,   // 49: banka.trading.v1.Order.actor_kind:type_name -> banka.trading.v1.UserKind
+	3,   // 50: banka.trading.v1.CreateOrderRequest.order_type:type_name -> banka.trading.v1.OrderType
+	4,   // 51: banka.trading.v1.CreateOrderRequest.direction:type_name -> banka.trading.v1.Direction
+	44,  // 52: banka.trading.v1.CreateOrderResponse.order:type_name -> banka.trading.v1.Order
+	7,   // 53: banka.trading.v1.ListOrdersRequest.user_kind:type_name -> banka.trading.v1.UserKind
+	44,  // 54: banka.trading.v1.ListOrdersResponse.orders:type_name -> banka.trading.v1.Order
+	7,   // 55: banka.trading.v1.Holding.user_kind:type_name -> banka.trading.v1.UserKind
+	26,  // 56: banka.trading.v1.Holding.security:type_name -> banka.trading.v1.Security
+	116, // 57: banka.trading.v1.Holding.acquired_at:type_name -> google.protobuf.Timestamp
+	116, // 58: banka.trading.v1.Holding.updated_at:type_name -> google.protobuf.Timestamp
+	7,   // 59: banka.trading.v1.ListHoldingsRequest.user_kind:type_name -> banka.trading.v1.UserKind
+	1,   // 60: banka.trading.v1.ListHoldingsRequest.type:type_name -> banka.trading.v1.SecurityType
+	53,  // 61: banka.trading.v1.ListHoldingsResponse.holdings:type_name -> banka.trading.v1.Holding
+	53,  // 62: banka.trading.v1.ExerciseOptionResponse.option_holding:type_name -> banka.trading.v1.Holding
+	53,  // 63: banka.trading.v1.ExerciseOptionResponse.underlying_holding:type_name -> banka.trading.v1.Holding
+	0,   // 64: banka.trading.v1.ExerciseOptionResponse.realized_gain_currency:type_name -> banka.trading.v1.Currency
+	7,   // 65: banka.trading.v1.TaxPosition.user_kind:type_name -> banka.trading.v1.UserKind
+	7,   // 66: banka.trading.v1.ListTaxPositionsRequest.user_kind:type_name -> banka.trading.v1.UserKind
+	59,  // 67: banka.trading.v1.ListTaxPositionsResponse.positions:type_name -> banka.trading.v1.TaxPosition
+	7,   // 68: banka.trading.v1.RunTaxRequest.user_kind:type_name -> banka.trading.v1.UserKind
+	116, // 69: banka.trading.v1.RealizedPnLRow.sale_at:type_name -> google.protobuf.Timestamp
+	0,   // 70: banka.trading.v1.RealizedPnLRow.currency:type_name -> banka.trading.v1.Currency
+	116, // 71: banka.trading.v1.RealizedPnLRow.taxed_at:type_name -> google.protobuf.Timestamp
+	7,   // 72: banka.trading.v1.ListRealizedPnLRequest.user_kind:type_name -> banka.trading.v1.UserKind
+	116, // 73: banka.trading.v1.ListRealizedPnLRequest.from:type_name -> google.protobuf.Timestamp
+	116, // 74: banka.trading.v1.ListRealizedPnLRequest.to:type_name -> google.protobuf.Timestamp
+	64,  // 75: banka.trading.v1.ListRealizedPnLResponse.rows:type_name -> banka.trading.v1.RealizedPnLRow
+	7,   // 76: banka.trading.v1.PublicHoldingItem.seller_kind:type_name -> banka.trading.v1.UserKind
+	26,  // 77: banka.trading.v1.PublicHoldingItem.security:type_name -> banka.trading.v1.Security
+	0,   // 78: banka.trading.v1.PublicHoldingItem.currency:type_name -> banka.trading.v1.Currency
+	116, // 79: banka.trading.v1.PublicHoldingItem.last_updated:type_name -> google.protobuf.Timestamp
+	67,  // 80: banka.trading.v1.ListPublicHoldingsResponse.items:type_name -> banka.trading.v1.PublicHoldingItem
+	7,   // 81: banka.trading.v1.OTCOffer.buyer_kind:type_name -> banka.trading.v1.UserKind
+	7,   // 82: banka.trading.v1.OTCOffer.seller_kind:type_name -> banka.trading.v1.UserKind
+	0,   // 83: banka.trading.v1.OTCOffer.currency:type_name -> banka.trading.v1.Currency
+	116, // 84: banka.trading.v1.OTCOffer.settlement_date:type_name -> google.protobuf.Timestamp
+	8,   // 85: banka.trading.v1.OTCOffer.status:type_name -> banka.trading.v1.OTCStatus
+	116, // 86: banka.trading.v1.OTCOffer.created_at:type_name -> google.protobuf.Timestamp
+	116, // 87: banka.trading.v1.OTCOffer.updated_at:type_name -> google.protobuf.Timestamp
+	116, // 88: banka.trading.v1.CreateOTCOfferRequest.settlement_date:type_name -> google.protobuf.Timestamp
+	116, // 89: banka.trading.v1.CounterOfferOTCRequest.settlement_date:type_name -> google.protobuf.Timestamp
+	7,   // 90: banka.trading.v1.ListOTCThreadsRequest.party_user_kind:type_name -> banka.trading.v1.UserKind
+	70,  // 91: banka.trading.v1.ListOTCThreadsResponse.threads:type_name -> banka.trading.v1.OTCOffer
+	70,  // 92: banka.trading.v1.GetOTCThreadResponse.iterations:type_name -> banka.trading.v1.OTCOffer
+	80,  // 93: banka.trading.v1.GetOTCThreadResponse.contract:type_name -> banka.trading.v1.OTCContract
+	80,  // 94: banka.trading.v1.AcceptOTCOfferResponse.contract:type_name -> banka.trading.v1.OTCContract
+	7,   // 95: banka.trading.v1.OTCContract.buyer_kind:type_name -> banka.trading.v1.UserKind
+	7,   // 96: banka.trading.v1.OTCContract.seller_kind:type_name -> banka.trading.v1.UserKind
+	0,   // 97: banka.trading.v1.OTCContract.currency:type_name -> banka.trading.v1.Currency
+	116, // 98: banka.trading.v1.OTCContract.settlement_date:type_name -> google.protobuf.Timestamp
+	9,   // 99: banka.trading.v1.OTCContract.status:type_name -> banka.trading.v1.OTCContractStatus
+	116, // 100: banka.trading.v1.OTCContract.exercised_at:type_name -> google.protobuf.Timestamp
+	116, // 101: banka.trading.v1.OTCContract.created_at:type_name -> google.protobuf.Timestamp
+	116, // 102: banka.trading.v1.OTCContract.updated_at:type_name -> google.protobuf.Timestamp
+	7,   // 103: banka.trading.v1.ListOTCContractsRequest.party_user_kind:type_name -> banka.trading.v1.UserKind
+	80,  // 104: banka.trading.v1.ListOTCContractsResponse.contracts:type_name -> banka.trading.v1.OTCContract
+	80,  // 105: banka.trading.v1.ExerciseOTCContractResponse.contract:type_name -> banka.trading.v1.OTCContract
+	10,  // 106: banka.trading.v1.Fund.status:type_name -> banka.trading.v1.FundStatus
+	116, // 107: banka.trading.v1.Fund.created_at:type_name -> google.protobuf.Timestamp
+	116, // 108: banka.trading.v1.Fund.updated_at:type_name -> google.protobuf.Timestamp
+	26,  // 109: banka.trading.v1.FundHolding.security:type_name -> banka.trading.v1.Security
+	0,   // 110: banka.trading.v1.FundHolding.currency:type_name -> banka.trading.v1.Currency
+	116, // 111: banka.trading.v1.FundHolding.acquired_at:type_name -> google.protobuf.Timestamp
+	116, // 112: banka.trading.v1.FundHolding.updated_at:type_name -> google.protobuf.Timestamp
+	116, // 113: banka.trading.v1.FundPosition.created_at:type_name -> google.protobuf.Timestamp
+	116, // 114: banka.trading.v1.FundPosition.updated_at:type_name -> google.protobuf.Timestamp
+	11,  // 115: banka.trading.v1.FundTransaction.status:type_name -> banka.trading.v1.FundTransactionStatus
+	116, // 116: banka.trading.v1.FundTransaction.created_at:type_name -> google.protobuf.Timestamp
+	116, // 117: banka.trading.v1.FundTransaction.updated_at:type_name -> google.protobuf.Timestamp
+	116, // 118: banka.trading.v1.FundPerformanceSnapshot.snapshot_at:type_name -> google.protobuf.Timestamp
+	86,  // 119: banka.trading.v1.ListFundsResponse.funds:type_name -> banka.trading.v1.Fund
+	86,  // 120: banka.trading.v1.GetFundResponse.fund:type_name -> banka.trading.v1.Fund
+	87,  // 121: banka.trading.v1.GetFundResponse.holdings:type_name -> banka.trading.v1.FundHolding
+	88,  // 122: banka.trading.v1.GetFundResponse.position:type_name -> banka.trading.v1.FundPosition
+	89,  // 123: banka.trading.v1.FundTransactionResponse.transaction:type_name -> banka.trading.v1.FundTransaction
+	88,  // 124: banka.trading.v1.ListFundPositionsResponse.positions:type_name -> banka.trading.v1.FundPosition
+	90,  // 125: banka.trading.v1.GetFundPerformanceResponse.snapshots:type_name -> banka.trading.v1.FundPerformanceSnapshot
+	89,  // 126: banka.trading.v1.ListFundTransactionsResponse.transactions:type_name -> banka.trading.v1.FundTransaction
+	2,   // 127: banka.trading.v1.ActuaryPerformance.type:type_name -> banka.trading.v1.ActuaryType
+	105, // 128: banka.trading.v1.ListActuaryPerformancesResponse.rows:type_name -> banka.trading.v1.ActuaryPerformance
+	88,  // 129: banka.trading.v1.BankFundPosition.position:type_name -> banka.trading.v1.FundPosition
+	108, // 130: banka.trading.v1.ListBankFundPositionsResponse.rows:type_name -> banka.trading.v1.BankFundPosition
+	116, // 131: banka.trading.v1.GetBankProfitTimeseriesRequest.from:type_name -> google.protobuf.Timestamp
+	116, // 132: banka.trading.v1.GetBankProfitTimeseriesRequest.to:type_name -> google.protobuf.Timestamp
+	116, // 133: banka.trading.v1.BankProfitBucket.period_start:type_name -> google.protobuf.Timestamp
+	112, // 134: banka.trading.v1.GetBankProfitTimeseriesResponse.buckets:type_name -> banka.trading.v1.BankProfitBucket
+	13,  // 135: banka.trading.v1.TradingService.GetActuaryInfo:input_type -> banka.trading.v1.GetActuaryInfoRequest
+	14,  // 136: banka.trading.v1.TradingService.ListActuaries:input_type -> banka.trading.v1.ListActuariesRequest
+	16,  // 137: banka.trading.v1.TradingService.UpsertActuaryInfo:input_type -> banka.trading.v1.UpsertActuaryInfoRequest
+	17,  // 138: banka.trading.v1.TradingService.UpdateActuaryLimit:input_type -> banka.trading.v1.UpdateActuaryLimitRequest
+	18,  // 139: banka.trading.v1.TradingService.ResetActuaryUsedLimit:input_type -> banka.trading.v1.ResetActuaryUsedLimitRequest
+	19,  // 140: banka.trading.v1.TradingService.SetActuaryNeedApproval:input_type -> banka.trading.v1.SetActuaryNeedApprovalRequest
+	117, // 141: banka.trading.v1.TradingService.RunDailyResetActuaries:input_type -> google.protobuf.Empty
+	22,  // 142: banka.trading.v1.TradingService.ListExchanges:input_type -> banka.trading.v1.ListExchangesRequest
+	24,  // 143: banka.trading.v1.TradingService.UpsertExchange:input_type -> banka.trading.v1.UpsertExchangeRequest
+	25,  // 144: banka.trading.v1.TradingService.SetExchangeOverride:input_type -> banka.trading.v1.SetExchangeOverrideRequest
+	27,  // 145: banka.trading.v1.TradingService.UpsertSecurity:input_type -> banka.trading.v1.UpsertSecurityRequest
+	28,  // 146: banka.trading.v1.TradingService.ListSecurities:input_type -> banka.trading.v1.ListSecuritiesRequest
+	31,  // 147: banka.trading.v1.TradingService.GetSecurity:input_type -> banka.trading.v1.GetSecurityRequest
+	33,  // 148: banka.trading.v1.TradingService.UpsertListing:input_type -> banka.trading.v1.UpsertListingRequest
+	34,  // 149: banka.trading.v1.TradingService.ListListings:input_type -> banka.trading.v1.ListListingsRequest
+	36,  // 150: banka.trading.v1.TradingService.GetListing:input_type -> banka.trading.v1.GetListingRequest
+	40,  // 151: banka.trading.v1.TradingService.GetOptionChain:input_type -> banka.trading.v1.GetOptionChainRequest
+	37,  // 152: banka.trading.v1.TradingService.GetListingDailyHistory:input_type -> banka.trading.v1.GetListingDailyHistoryRequest
+	45,  // 153: banka.trading.v1.TradingService.CreateOrder:input_type -> banka.trading.v1.CreateOrderRequest
+	47,  // 154: banka.trading.v1.TradingService.ListOrders:input_type -> banka.trading.v1.ListOrdersRequest
+	49,  // 155: banka.trading.v1.TradingService.GetOrder:input_type -> banka.trading.v1.GetOrderRequest
+	50,  // 156: banka.trading.v1.TradingService.ApproveOrder:input_type -> banka.trading.v1.ApproveOrderRequest
+	51,  // 157: banka.trading.v1.TradingService.DeclineOrder:input_type -> banka.trading.v1.DeclineOrderRequest
+	52,  // 158: banka.trading.v1.TradingService.CancelOrder:input_type -> banka.trading.v1.CancelOrderRequest
+	54,  // 159: banka.trading.v1.TradingService.ListHoldings:input_type -> banka.trading.v1.ListHoldingsRequest
+	56,  // 160: banka.trading.v1.TradingService.SetPublicCount:input_type -> banka.trading.v1.SetPublicCountRequest
+	57,  // 161: banka.trading.v1.TradingService.ExerciseOption:input_type -> banka.trading.v1.ExerciseOptionRequest
+	60,  // 162: banka.trading.v1.TradingService.ListTaxPositions:input_type -> banka.trading.v1.ListTaxPositionsRequest
+	62,  // 163: banka.trading.v1.TradingService.RunTax:input_type -> banka.trading.v1.RunTaxRequest
+	65,  // 164: banka.trading.v1.TradingService.ListRealizedPnL:input_type -> banka.trading.v1.ListRealizedPnLRequest
+	68,  // 165: banka.trading.v1.TradingService.ListPublicHoldings:input_type -> banka.trading.v1.ListPublicHoldingsRequest
+	71,  // 166: banka.trading.v1.TradingService.CreateOTCOffer:input_type -> banka.trading.v1.CreateOTCOfferRequest
+	72,  // 167: banka.trading.v1.TradingService.CounterOfferOTC:input_type -> banka.trading.v1.CounterOfferOTCRequest
+	73,  // 168: banka.trading.v1.TradingService.WithdrawOTCOffer:input_type -> banka.trading.v1.WithdrawOTCOfferRequest
+	74,  // 169: banka.trading.v1.TradingService.ListOTCThreads:input_type -> banka.trading.v1.ListOTCThreadsRequest
+	76,  // 170: banka.trading.v1.TradingService.GetOTCThread:input_type -> banka.trading.v1.GetOTCThreadRequest
+	78,  // 171: banka.trading.v1.TradingService.AcceptOTCOffer:input_type -> banka.trading.v1.AcceptOTCOfferRequest
+	81,  // 172: banka.trading.v1.TradingService.ListOTCContracts:input_type -> banka.trading.v1.ListOTCContractsRequest
+	83,  // 173: banka.trading.v1.TradingService.GetOTCContract:input_type -> banka.trading.v1.GetOTCContractRequest
+	84,  // 174: banka.trading.v1.TradingService.ExerciseOTCContract:input_type -> banka.trading.v1.ExerciseOTCContractRequest
+	91,  // 175: banka.trading.v1.TradingService.ListFunds:input_type -> banka.trading.v1.ListFundsRequest
+	93,  // 176: banka.trading.v1.TradingService.GetFund:input_type -> banka.trading.v1.GetFundRequest
+	95,  // 177: banka.trading.v1.TradingService.CreateFund:input_type -> banka.trading.v1.CreateFundRequest
+	96,  // 178: banka.trading.v1.TradingService.InvestInFund:input_type -> banka.trading.v1.InvestInFundRequest
+	97,  // 179: banka.trading.v1.TradingService.WithdrawFromFund:input_type -> banka.trading.v1.WithdrawFromFundRequest
+	99,  // 180: banka.trading.v1.TradingService.ListFundPositions:input_type -> banka.trading.v1.ListFundPositionsRequest
+	101, // 181: banka.trading.v1.TradingService.GetFundPerformance:input_type -> banka.trading.v1.GetFundPerformanceRequest
+	103, // 182: banka.trading.v1.TradingService.ListFundTransactions:input_type -> banka.trading.v1.ListFundTransactionsRequest
+	106, // 183: banka.trading.v1.TradingService.ListActuaryPerformances:input_type -> banka.trading.v1.ListActuaryPerformancesRequest
+	109, // 184: banka.trading.v1.TradingService.ListBankFundPositions:input_type -> banka.trading.v1.ListBankFundPositionsRequest
+	111, // 185: banka.trading.v1.TradingService.GetBankProfitTimeseries:input_type -> banka.trading.v1.GetBankProfitTimeseriesRequest
+	114, // 186: banka.trading.v1.TradingService.ReassignSupervisorAssets:input_type -> banka.trading.v1.ReassignSupervisorAssetsRequest
+	12,  // 187: banka.trading.v1.TradingService.GetActuaryInfo:output_type -> banka.trading.v1.ActuaryInfo
+	15,  // 188: banka.trading.v1.TradingService.ListActuaries:output_type -> banka.trading.v1.ListActuariesResponse
+	12,  // 189: banka.trading.v1.TradingService.UpsertActuaryInfo:output_type -> banka.trading.v1.ActuaryInfo
+	12,  // 190: banka.trading.v1.TradingService.UpdateActuaryLimit:output_type -> banka.trading.v1.ActuaryInfo
+	12,  // 191: banka.trading.v1.TradingService.ResetActuaryUsedLimit:output_type -> banka.trading.v1.ActuaryInfo
+	12,  // 192: banka.trading.v1.TradingService.SetActuaryNeedApproval:output_type -> banka.trading.v1.ActuaryInfo
+	20,  // 193: banka.trading.v1.TradingService.RunDailyResetActuaries:output_type -> banka.trading.v1.RunDailyResetActuariesResponse
+	23,  // 194: banka.trading.v1.TradingService.ListExchanges:output_type -> banka.trading.v1.ListExchangesResponse
+	21,  // 195: banka.trading.v1.TradingService.UpsertExchange:output_type -> banka.trading.v1.Exchange
+	21,  // 196: banka.trading.v1.TradingService.SetExchangeOverride:output_type -> banka.trading.v1.Exchange
+	26,  // 197: banka.trading.v1.TradingService.UpsertSecurity:output_type -> banka.trading.v1.Security
+	29,  // 198: banka.trading.v1.TradingService.ListSecurities:output_type -> banka.trading.v1.ListSecuritiesResponse
+	30,  // 199: banka.trading.v1.TradingService.GetSecurity:output_type -> banka.trading.v1.SecurityWithListing
+	32,  // 200: banka.trading.v1.TradingService.UpsertListing:output_type -> banka.trading.v1.Listing
+	35,  // 201: banka.trading.v1.TradingService.ListListings:output_type -> banka.trading.v1.ListListingsResponse
+	32,  // 202: banka.trading.v1.TradingService.GetListing:output_type -> banka.trading.v1.Listing
+	43,  // 203: banka.trading.v1.TradingService.GetOptionChain:output_type -> banka.trading.v1.GetOptionChainResponse
+	39,  // 204: banka.trading.v1.TradingService.GetListingDailyHistory:output_type -> banka.trading.v1.GetListingDailyHistoryResponse
+	46,  // 205: banka.trading.v1.TradingService.CreateOrder:output_type -> banka.trading.v1.CreateOrderResponse
+	48,  // 206: banka.trading.v1.TradingService.ListOrders:output_type -> banka.trading.v1.ListOrdersResponse
+	44,  // 207: banka.trading.v1.TradingService.GetOrder:output_type -> banka.trading.v1.Order
+	44,  // 208: banka.trading.v1.TradingService.ApproveOrder:output_type -> banka.trading.v1.Order
+	44,  // 209: banka.trading.v1.TradingService.DeclineOrder:output_type -> banka.trading.v1.Order
+	44,  // 210: banka.trading.v1.TradingService.CancelOrder:output_type -> banka.trading.v1.Order
+	55,  // 211: banka.trading.v1.TradingService.ListHoldings:output_type -> banka.trading.v1.ListHoldingsResponse
+	53,  // 212: banka.trading.v1.TradingService.SetPublicCount:output_type -> banka.trading.v1.Holding
+	58,  // 213: banka.trading.v1.TradingService.ExerciseOption:output_type -> banka.trading.v1.ExerciseOptionResponse
+	61,  // 214: banka.trading.v1.TradingService.ListTaxPositions:output_type -> banka.trading.v1.ListTaxPositionsResponse
+	63,  // 215: banka.trading.v1.TradingService.RunTax:output_type -> banka.trading.v1.RunTaxResponse
+	66,  // 216: banka.trading.v1.TradingService.ListRealizedPnL:output_type -> banka.trading.v1.ListRealizedPnLResponse
+	69,  // 217: banka.trading.v1.TradingService.ListPublicHoldings:output_type -> banka.trading.v1.ListPublicHoldingsResponse
+	70,  // 218: banka.trading.v1.TradingService.CreateOTCOffer:output_type -> banka.trading.v1.OTCOffer
+	70,  // 219: banka.trading.v1.TradingService.CounterOfferOTC:output_type -> banka.trading.v1.OTCOffer
+	70,  // 220: banka.trading.v1.TradingService.WithdrawOTCOffer:output_type -> banka.trading.v1.OTCOffer
+	75,  // 221: banka.trading.v1.TradingService.ListOTCThreads:output_type -> banka.trading.v1.ListOTCThreadsResponse
+	77,  // 222: banka.trading.v1.TradingService.GetOTCThread:output_type -> banka.trading.v1.GetOTCThreadResponse
+	79,  // 223: banka.trading.v1.TradingService.AcceptOTCOffer:output_type -> banka.trading.v1.AcceptOTCOfferResponse
+	82,  // 224: banka.trading.v1.TradingService.ListOTCContracts:output_type -> banka.trading.v1.ListOTCContractsResponse
+	80,  // 225: banka.trading.v1.TradingService.GetOTCContract:output_type -> banka.trading.v1.OTCContract
+	85,  // 226: banka.trading.v1.TradingService.ExerciseOTCContract:output_type -> banka.trading.v1.ExerciseOTCContractResponse
+	92,  // 227: banka.trading.v1.TradingService.ListFunds:output_type -> banka.trading.v1.ListFundsResponse
+	94,  // 228: banka.trading.v1.TradingService.GetFund:output_type -> banka.trading.v1.GetFundResponse
+	86,  // 229: banka.trading.v1.TradingService.CreateFund:output_type -> banka.trading.v1.Fund
+	98,  // 230: banka.trading.v1.TradingService.InvestInFund:output_type -> banka.trading.v1.FundTransactionResponse
+	98,  // 231: banka.trading.v1.TradingService.WithdrawFromFund:output_type -> banka.trading.v1.FundTransactionResponse
+	100, // 232: banka.trading.v1.TradingService.ListFundPositions:output_type -> banka.trading.v1.ListFundPositionsResponse
+	102, // 233: banka.trading.v1.TradingService.GetFundPerformance:output_type -> banka.trading.v1.GetFundPerformanceResponse
+	104, // 234: banka.trading.v1.TradingService.ListFundTransactions:output_type -> banka.trading.v1.ListFundTransactionsResponse
+	107, // 235: banka.trading.v1.TradingService.ListActuaryPerformances:output_type -> banka.trading.v1.ListActuaryPerformancesResponse
+	110, // 236: banka.trading.v1.TradingService.ListBankFundPositions:output_type -> banka.trading.v1.ListBankFundPositionsResponse
+	113, // 237: banka.trading.v1.TradingService.GetBankProfitTimeseries:output_type -> banka.trading.v1.GetBankProfitTimeseriesResponse
+	115, // 238: banka.trading.v1.TradingService.ReassignSupervisorAssets:output_type -> banka.trading.v1.ReassignSupervisorAssetsResponse
+	187, // [187:239] is the sub-list for method output_type
+	135, // [135:187] is the sub-list for method input_type
+	135, // [135:135] is the sub-list for extension type_name
+	135, // [135:135] is the sub-list for extension extendee
+	0,   // [0:135] is the sub-list for field type_name
 }
 
 func init() { file_trading_v1_trading_proto_init() }

--- a/proto/trading/v1/trading.proto
+++ b/proto/trading/v1/trading.proto
@@ -822,9 +822,14 @@ message GetListingRequest {
 }
 
 message GetListingDailyHistoryRequest {
-  string                    listing_id = 1 [(buf.validate.field).string.uuid = true];
-  google.protobuf.Timestamp from       = 2;
-  google.protobuf.Timestamp to         = 3;
+  string listing_id = 1 [(buf.validate.field).string.uuid = true];
+  // Plain YYYY-MM-DD strings (the FE binds these from its date range
+  // picker / isoNDaysAgo). A google.protobuf.Timestamp here cannot be
+  // bound from a bare date query param through grpc-gateway — the
+  // whole request 400s ("cannot parse … as RFC3339") so the price
+  // history chart never received data. Empty means unbounded.
+  string from = 2;
+  string to   = 3;
 }
 
 message ListingDailyPrice {

--- a/services/trading/internal/server/listings.go
+++ b/services/trading/internal/server/listings.go
@@ -2,12 +2,25 @@ package server
 
 import (
 	"context"
+	"time"
 
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/store"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// parseHistoryDate turns an optional YYYY-MM-DD string into a time.Time.
+// Empty → zero time (the store treats a zero bound as unbounded). The
+// FE sends bare dates from its range picker; a google.protobuf.Timestamp
+// proto field can't be bound from that through grpc-gateway.
+func parseHistoryDate(v string) (time.Time, error) {
+	if v == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse("2006-01-02", v)
+}
 
 func (s *Server) UpsertListing(ctx context.Context, in *tradingpb.UpsertListingRequest) (*tradingpb.Listing, error) {
 	l, err := s.Svc.UpsertListing(ctx, &domain.Listing{
@@ -64,7 +77,19 @@ func (s *Server) ListListings(ctx context.Context, in *tradingpb.ListListingsReq
 }
 
 func (s *Server) GetListingDailyHistory(ctx context.Context, in *tradingpb.GetListingDailyHistoryRequest) (*tradingpb.GetListingDailyHistoryResponse, error) {
-	rows, err := s.Svc.GetListingDailyHistory(ctx, in.GetListingId(), in.GetFrom().AsTime(), in.GetTo().AsTime())
+	from, err := parseHistoryDate(in.GetFrom())
+	if err != nil {
+		return nil, apperr.Validation("from: očekivan format YYYY-MM-DD")
+	}
+	to, err := parseHistoryDate(in.GetTo())
+	if err != nil {
+		return nil, apperr.Validation("to: očekivan format YYYY-MM-DD")
+	}
+	if !to.IsZero() {
+		// Inclusive upper bound: cover the whole "to" day.
+		to = to.Add(24*time.Hour - time.Second)
+	}
+	rows, err := s.Svc.GetListingDailyHistory(ctx, in.GetListingId(), from, to)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
QA C3 journal S18/S19 "Ne radi, fali graf istorije cene" + TODO "Dodati graf za istoriju cene na svim hartijama".

## Root cause
The FE chart is fully wired (ListingDetail.tsx → getListingHistory → PriceHistoryChart) and `trading.listing_daily_price_info` is populated (146 rows seeded/fed). But `GetListingDailyHistoryRequest.from/to` were `google.protobuf.Timestamp`, and the FE sends bare `YYYY-MM-DD` from its date range picker. grpc-gateway can't bind a bare date to a Timestamp query param — the request 400s before the handler (`cannot parse "2026-04-01" as RFC3339`). So `history.data.rows` was always empty and the chart rendered "Nema istorije za izabrani period."

## Fix (backend only)
`from`/`to` → `string` (YYYY-MM-DD), parsed server-side. Empty = unbounded; `to` treated as an inclusive end-of-day bound so the last day's row shows. Invalid input → clean validation error instead of a gateway 400.

## Verified live through the gateway
`from=2026-04-01&to=2026-05-18` → **35 rows** (previously a hard 400), no params → 46 rows, `from=nope` → `400 from: očekivan format YYYY-MM-DD`. The data was always there; only the binding was broken. FE already sends YYYY-MM-DD and renders the rows — no FE change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
