### PR TITLE
Add Spark analytics on Kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !go.work.sum
 !go.mod
 !go.sum
+!analytics/
 !pkg/
 !services/
 !proto/

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ INFLUX_BUCKET=market-data
 INFLUX_TOKEN=banka-influx-token
 INFLUX_USERNAME=banka
 INFLUX_PASSWORD=banka_secret
+ANALYTICS_LOOKBACK_DAYS=90
+ANALYTICS_TOP_N=5
+SPARK_ANALYTICS_IMAGE=banka-analytics-spark:latest
 
 # Seed data emails (passwords are fixed: Admin123! for admin, Test1234! for client)
 ADMIN_EMAIL=admin@banka.raf

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ export
 
 GO_IMAGE := golang:1.25
 GO_RUN   := docker run --rm -v $(PWD):/app -w /app $(GO_IMAGE)
+SPARK_ANALYTICS_IMAGE ?= banka-analytics-spark:latest
 
 ADMIN_EMAIL  ?= admin@banka.raf
 CLIENT_EMAIL ?= petar@primer.raf
@@ -22,7 +23,7 @@ TARGET_DIR := $(if $(TARGET),$(foreach t,$(TARGET),$(call module_path,$(t))),$(M
 $(NAMES):
 	@:
 
-.PHONY: all up down down-v proto schema seed nuke refresh-partitions verify-replica verify-partitions verify-indexes lint lint-l build build-l test test-l test-integration test-integration-l fmt fmt-l $(NAMES)
+.PHONY: all up down down-v proto schema seed nuke refresh-partitions verify-replica verify-partitions verify-indexes verify-spark-analytics spark-analytics-image spark-analytics-local lint lint-l build build-l test test-l test-integration test-integration-l fmt fmt-l $(NAMES)
 
 all: proto up schema seed
 
@@ -65,6 +66,15 @@ verify-partitions:
 
 verify-indexes:
 	docker compose exec -T postgres psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) < scripts/db/verify_indexes.sql
+
+verify-spark-analytics:
+	docker compose exec -T postgres psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) < scripts/db/verify_spark_analytics.sql
+
+spark-analytics-image:
+	docker build -t $(SPARK_ANALYTICS_IMAGE) -f analytics/spark/Dockerfile .
+
+spark-analytics-local:
+	docker compose run --rm spark_analytics
 
 lint:
 	@for m in $(TARGET_DIR); do \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aktuelni stack u `newestbackend` sada ukljucuje:
 - hash-particionisane Celina 5 interbank audit tabele po `sender_routing_number`
 - dodatni read-heavy indeksi za transaction history, kreditne cron upite i trading/OTC portale
 - InfluxDB za time-series berzanske podatke
+- Spark analytics pipeline koji cita sa read replike i pise dnevne agregate nazad u Postgres, sa Kubernetes `ScheduledSparkApplication` manifestima
 
 ## API
 
@@ -49,6 +50,9 @@ pokretanje (potreban Go na sistemu).
 | `make verify-replica` | Proveri da li je replica u recovery/read-only modu |
 | `make verify-partitions` | Ispisi aktivne particije za bonus tabele |
 | `make verify-indexes` | Ispisi dodatne read-heavy indekse za DB tuning |
+| `make spark-analytics-image` | Builduj Spark analytics image |
+| `make spark-analytics-local` | Pokreni Spark analytics lokalno preko docker compose profila |
+| `make verify-spark-analytics` | Ispisi poslednje Spark analytics agregate iz Postgresa |
 | `make nuke`    | Obrisi sve i ucitaj schema i seed            |
 | `make build`   | Builduj sve servise (Docker)                 |
 | `make build-l` | Builduj sve servise (lokalno)                |
@@ -74,6 +78,33 @@ Dodatni tuning je fokusiran na query obrasce koji vec postoje u kodu:
 - `loans` / `loan_request`: cron i pregled zahteva po statusu i datumu
 - `orders`: execution queue + portal listing po statusu / placeru
 - `external_otc_*`: korisnicki thread/contract listing sa status filterom
+
+## Spark analytics
+
+Analytics sloj je izdvojen u `analytics/spark/` i koristi isti read/write split
+kao aplikacioni servisi:
+- raw podaci se citaju sa `postgres_replica`
+- kurirani agregati se upisuju na `postgres`
+
+PySpark job racuna dnevne operativne metrike za:
+- payments / transfers
+- orders / order fills
+- external OTC contracts
+- top listings po dnevnom prometu
+
+Lokalni dry-run ide preko compose profila:
+
+```bash
+make spark-analytics-local
+make verify-spark-analytics
+```
+
+Za Kubernetes deployment dodate su dve putanje:
+- `analytics/spark/k8s/`: `ScheduledSparkApplication` za klastere sa Spark operatorom
+- `analytics/spark/k8s/vanilla/`: obican Kubernetes `CronJob` / `Job` koji vrti Spark pod bez dodatnog operatora
+
+To omogucava i strogu demonstraciju zahteva "Spark podignut na Kubernetesu"
+i praktican lokalni run na Docker Desktop Kubernetes-u.
 
 ## CI
 

--- a/analytics/spark/Dockerfile
+++ b/analytics/spark/Dockerfile
@@ -1,0 +1,11 @@
+FROM spark:python3
+
+USER root
+
+ADD https://jdbc.postgresql.org/download/postgresql-42.7.5.jar /tmp/postgresql-42.7.5.jar
+RUN cp /tmp/postgresql-42.7.5.jar /opt/spark/jars/postgresql-42.7.5.jar \
+    && chmod 644 /opt/spark/jars/postgresql-42.7.5.jar
+
+USER spark
+
+COPY analytics/spark/jobs /opt/banka-analytics/jobs

--- a/analytics/spark/README.md
+++ b/analytics/spark/README.md
@@ -1,0 +1,66 @@
+# Spark analytics
+
+Ovaj direktorijum sadrzi batch analytics pipeline za `newestbackend`.
+
+Pipeline:
+- cita operativne tabele sa PostgreSQL read replike preko JDBC
+- racuna dnevne KPI agregate za payments, transfers, orders, fills i OTC contracts
+- upisuje kurirane rezultate nazad na primary u:
+  - `analytics_daily_platform_metrics`
+  - `analytics_daily_top_listings`
+
+## Lokalni dry-run
+
+Dok je docker-compose stack podignut:
+
+```bash
+make spark-analytics-local
+make verify-spark-analytics
+```
+
+`spark_analytics` koristi isti PySpark job kao Kubernetes deployment, ali ga
+pokrece u `local[2]` modu da bi pipeline mogao da se proveri bez klastera.
+
+## Kubernetes
+
+Postoje dve Kubernetes varijante:
+
+1. `analytics/spark/k8s/`
+: Spark Operator varijanta sa `ScheduledSparkApplication`
+
+2. `analytics/spark/k8s/vanilla/`
+: obican Kubernetes `CronJob` / `Job` koji vrti `spark-submit` u Spark podu,
+  bez dodatne operator instalacije. Ovo je prakticniji put za Docker Desktop
+  Kubernetes i lokalnu demonstraciju.
+
+### Vanilla Kubernetes putanja
+
+1. ukljuci Docker Desktop Kubernetes
+2. build image lokalno:
+
+```bash
+docker compose build spark_analytics
+```
+
+3. proveri ili prilagodi `db-secret.template.yaml`
+4. deploy cron varijantu:
+
+```bash
+kubectl apply -k analytics/spark/k8s/vanilla
+```
+
+5. za jednokratni run:
+
+```bash
+kubectl apply -f analytics/spark/k8s/vanilla/job-once.yaml
+kubectl get jobs -n banka-analytics
+kubectl logs -n banka-analytics job/banka-trading-analytics-once
+```
+
+### Spark Operator putanja
+
+Ako u klasteru vec postoji `spark-operator`, moze i jaca varijanta:
+
+```bash
+kubectl apply -k analytics/spark/k8s
+```

--- a/analytics/spark/jobs/trading_analytics.py
+++ b/analytics/spark/jobs/trading_analytics.py
@@ -1,0 +1,291 @@
+import os
+from datetime import date, timedelta
+
+from pyspark.sql import DataFrame, SparkSession, Window
+from pyspark.sql import functions as F
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required environment variable: {name}")
+    return value
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return int(raw)
+
+
+def jdbc_reader(spark: SparkSession, jdbc_url: str, user: str, password: str, query: str) -> DataFrame:
+    return (
+        spark.read.format("jdbc")
+        .option("url", jdbc_url)
+        .option("user", user)
+        .option("password", password)
+        .option("driver", "org.postgresql.Driver")
+        .option("dbtable", f"({query}) AS src")
+        .load()
+    )
+
+
+def overwrite_table(frame: DataFrame, jdbc_url: str, user: str, password: str, table_name: str) -> None:
+    (
+        frame.coalesce(1)
+        .write.format("jdbc")
+        .option("url", jdbc_url)
+        .option("user", user)
+        .option("password", password)
+        .option("driver", "org.postgresql.Driver")
+        .option("dbtable", table_name)
+        .option("truncate", "true")
+        .mode("overwrite")
+        .save()
+    )
+
+
+def build_metrics(
+    spark: SparkSession,
+    read_url: str,
+    user: str,
+    password: str,
+    cutoff_date: date,
+) -> DataFrame:
+    cutoff_literal = cutoff_date.isoformat()
+
+    payments = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT timestamp, start_amount
+        FROM payments
+        WHERE timestamp >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("timestamp")).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("payments_count"),
+        F.coalesce(F.sum("start_amount"), F.lit(0)).cast("long").alias("payments_volume"),
+    )
+
+    transfers = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT timestamp, start_amount
+        FROM transfers
+        WHERE timestamp >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("timestamp")).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("transfers_count"),
+        F.coalesce(F.sum("start_amount"), F.lit(0)).cast("long").alias("transfers_volume"),
+    )
+
+    orders = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT created_at, status
+        FROM orders
+        WHERE created_at >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("created_at")).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("orders_created"),
+        F.sum(F.when(F.col("status") == F.lit("done"), F.lit(1)).otherwise(F.lit(0))).cast("long").alias(
+            "orders_completed"
+        ),
+    )
+
+    fills = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT
+            f.created_at,
+            f.portions,
+            f.price_per_unit,
+            o.contract_size
+        FROM order_fills f
+        JOIN orders o ON o.id = f.order_id
+        WHERE f.created_at >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("created_at")).withColumn(
+        "fill_notional", F.col("portions") * F.col("price_per_unit") * F.col("contract_size")
+    ).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("fills_count"),
+        F.coalesce(F.sum("portions"), F.lit(0)).cast("long").alias("filled_quantity"),
+        F.coalesce(F.sum("fill_notional"), F.lit(0)).cast("long").alias("fills_notional"),
+    )
+
+    otc_created = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT created_at
+        FROM external_otc_contracts
+        WHERE created_at >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("created_at")).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("otc_contracts_created")
+    )
+
+    otc_exercised = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT exercised_at
+        FROM external_otc_contracts
+        WHERE exercised_at IS NOT NULL
+          AND exercised_at >= DATE '{cutoff_literal}'
+        """,
+    ).withColumn("metric_date", F.to_date("exercised_at")).groupBy("metric_date").agg(
+        F.count("*").cast("long").alias("otc_contracts_exercised")
+    )
+
+    all_dates = (
+        payments.select("metric_date")
+        .unionByName(transfers.select("metric_date"))
+        .unionByName(orders.select("metric_date"))
+        .unionByName(fills.select("metric_date"))
+        .unionByName(otc_created.select("metric_date"))
+        .unionByName(otc_exercised.select("metric_date"))
+        .distinct()
+    )
+
+    metrics = (
+        all_dates.join(payments, "metric_date", "left")
+        .join(transfers, "metric_date", "left")
+        .join(orders, "metric_date", "left")
+        .join(fills, "metric_date", "left")
+        .join(otc_created, "metric_date", "left")
+        .join(otc_exercised, "metric_date", "left")
+        .fillna(0)
+        .withColumn("generated_at", F.current_timestamp())
+        .orderBy("metric_date")
+    )
+    return metrics
+
+
+def build_top_listings(
+    spark: SparkSession,
+    read_url: str,
+    user: str,
+    password: str,
+    cutoff_date: date,
+    top_n: int,
+) -> DataFrame:
+    cutoff_literal = cutoff_date.isoformat()
+
+    listings = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        """
+        SELECT
+            l.id AS listing_id,
+            COALESCE(s.ticker, f.ticker) AS ticker,
+            COALESCE(s.name, f.name) AS security_name
+        FROM listings l
+        LEFT JOIN stocks s ON s.id = l.stock_id
+        LEFT JOIN futures f ON f.id = l.future_id
+        """,
+    )
+
+    fills = jdbc_reader(
+        spark,
+        read_url,
+        user,
+        password,
+        f"""
+        SELECT
+            f.created_at,
+            o.listing_id,
+            f.portions,
+            f.price_per_unit,
+            o.contract_size
+        FROM order_fills f
+        JOIN orders o ON o.id = f.order_id
+        WHERE o.listing_id IS NOT NULL
+          AND f.created_at >= DATE '{cutoff_literal}'
+        """,
+    )
+
+    ranked = (
+        fills.withColumn("metric_date", F.to_date("created_at"))
+        .withColumn("traded_notional", F.col("portions") * F.col("price_per_unit") * F.col("contract_size"))
+        .groupBy("metric_date", "listing_id")
+        .agg(
+            F.count("*").cast("long").alias("fills_count"),
+            F.coalesce(F.sum("portions"), F.lit(0)).cast("long").alias("traded_quantity"),
+            F.coalesce(F.sum("traded_notional"), F.lit(0)).cast("long").alias("traded_notional"),
+        )
+        .join(listings, "listing_id", "inner")
+        .withColumn(
+            "rank",
+            F.row_number().over(
+                Window.partitionBy("metric_date").orderBy(
+                    F.col("traded_notional").desc(),
+                    F.col("fills_count").desc(),
+                    F.col("listing_id").asc(),
+                )
+            ),
+        )
+        .filter(F.col("rank") <= F.lit(top_n))
+        .withColumn("generated_at", F.current_timestamp())
+        .select(
+            "metric_date",
+            "rank",
+            "listing_id",
+            "ticker",
+            "security_name",
+            "fills_count",
+            "traded_quantity",
+            "traded_notional",
+            "generated_at",
+        )
+        .orderBy("metric_date", "rank")
+    )
+    return ranked
+
+
+def main() -> None:
+    read_url = require_env("ANALYTICS_DB_READ_URL")
+    write_url = require_env("ANALYTICS_DB_WRITE_URL")
+    db_user = require_env("ANALYTICS_DB_USER")
+    db_password = require_env("ANALYTICS_DB_PASSWORD")
+    lookback_days = env_int("ANALYTICS_LOOKBACK_DAYS", 90)
+    top_n = env_int("ANALYTICS_TOP_N", 5)
+
+    spark = (
+        SparkSession.builder.appName("banka-trading-analytics")
+        .config("spark.sql.session.timeZone", "UTC")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel(os.getenv("SPARK_LOG_LEVEL", "WARN"))
+
+    cutoff_date = date.today() - timedelta(days=lookback_days)
+
+    metrics = build_metrics(spark, read_url, db_user, db_password, cutoff_date)
+    top_listings = build_top_listings(spark, read_url, db_user, db_password, cutoff_date, top_n)
+
+    overwrite_table(metrics, write_url, db_user, db_password, "analytics_daily_platform_metrics")
+    overwrite_table(top_listings, write_url, db_user, db_password, "analytics_daily_top_listings")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/spark/k8s/db-secret.template.yaml
+++ b/analytics/spark/k8s/db-secret.template.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banka-analytics-db
+  namespace: banka-analytics
+type: Opaque
+stringData:
+  ANALYTICS_DB_READ_URL: jdbc:postgresql://postgres-replica.banka.svc.cluster.local:5432/banka
+  ANALYTICS_DB_WRITE_URL: jdbc:postgresql://postgres-primary.banka.svc.cluster.local:5432/banka
+  ANALYTICS_DB_USER: banka
+  ANALYTICS_DB_PASSWORD: change-me
+  ANALYTICS_LOOKBACK_DAYS: "90"
+  ANALYTICS_TOP_N: "5"

--- a/analytics/spark/k8s/driver-rbac.yaml
+++ b/analytics/spark/k8s/driver-rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-analytics-driver
+  namespace: banka-analytics
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "configmaps"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-analytics-driver
+  namespace: banka-analytics
+subjects:
+  - kind: ServiceAccount
+    name: spark-analytics
+    namespace: banka-analytics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spark-analytics-driver

--- a/analytics/spark/k8s/kustomization.yaml
+++ b/analytics/spark/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: banka-analytics
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - driver-rbac.yaml
+  - db-secret.template.yaml
+  - scheduled-sparkapplication.yaml

--- a/analytics/spark/k8s/namespace.yaml
+++ b/analytics/spark/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: banka-analytics

--- a/analytics/spark/k8s/scheduled-sparkapplication.yaml
+++ b/analytics/spark/k8s/scheduled-sparkapplication.yaml
@@ -1,0 +1,38 @@
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: ScheduledSparkApplication
+metadata:
+  name: banka-trading-analytics
+  namespace: banka-analytics
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  template:
+    type: Python
+    mode: cluster
+    sparkVersion: "4.1.2"
+    image: banka-analytics-spark:latest
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: local:///opt/banka-analytics/jobs/trading_analytics.py
+    restartPolicy:
+      type: Never
+    timeToLiveSeconds: 900
+    sparkConf:
+      spark.sql.session.timeZone: UTC
+      spark.kubernetes.container.image.pullPolicy: IfNotPresent
+      spark.jars: local:///opt/spark/jars/postgresql-42.7.5.jar
+      spark.driver.extraClassPath: /opt/spark/jars/postgresql-42.7.5.jar
+      spark.executor.extraClassPath: /opt/spark/jars/postgresql-42.7.5.jar
+    driver:
+      serviceAccount: spark-analytics
+      cores: 1
+      memory: 1g
+      envFrom:
+        - secretRef:
+            name: banka-analytics-db
+    executor:
+      instances: 2
+      cores: 1
+      memory: 1g
+      envFrom:
+        - secretRef:
+            name: banka-analytics-db

--- a/analytics/spark/k8s/serviceaccount.yaml
+++ b/analytics/spark/k8s/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-analytics
+  namespace: banka-analytics

--- a/analytics/spark/k8s/vanilla/cronjob.yaml
+++ b/analytics/spark/k8s/vanilla/cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: banka-trading-analytics
+  namespace: banka-analytics
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: banka-trading-analytics
+        spec:
+          serviceAccountName: spark-analytics
+          restartPolicy: Never
+          containers:
+            - name: spark-analytics
+              image: banka-analytics-spark:latest
+              imagePullPolicy: Never
+              envFrom:
+                - secretRef:
+                    name: banka-analytics-db
+              command:
+                - /opt/spark/bin/spark-submit
+              args:
+                - --master
+                - local[2]
+                - --jars
+                - /opt/spark/jars/postgresql-42.7.5.jar
+                - --conf
+                - spark.driver.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+                - --conf
+                - spark.executor.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+                - local:///opt/banka-analytics/jobs/trading_analytics.py
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "1Gi"
+                limits:
+                  cpu: "2"
+                  memory: "2Gi"

--- a/analytics/spark/k8s/vanilla/db-secret.template.yaml
+++ b/analytics/spark/k8s/vanilla/db-secret.template.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: banka-analytics-db
+  namespace: banka-analytics
+type: Opaque
+stringData:
+  ANALYTICS_DB_READ_URL: jdbc:postgresql://host.docker.internal:5433/banka
+  ANALYTICS_DB_WRITE_URL: jdbc:postgresql://host.docker.internal:5432/banka
+  ANALYTICS_DB_USER: banka
+  ANALYTICS_DB_PASSWORD: banka_secret
+  ANALYTICS_LOOKBACK_DAYS: "90"
+  ANALYTICS_TOP_N: "5"

--- a/analytics/spark/k8s/vanilla/job-once.yaml
+++ b/analytics/spark/k8s/vanilla/job-once.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: banka-trading-analytics-once
+  namespace: banka-analytics
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: banka-trading-analytics
+    spec:
+      serviceAccountName: spark-analytics
+      restartPolicy: Never
+      containers:
+        - name: spark-analytics
+          image: banka-analytics-spark:latest
+          imagePullPolicy: Never
+          envFrom:
+            - secretRef:
+                name: banka-analytics-db
+          command:
+            - /opt/spark/bin/spark-submit
+          args:
+            - --master
+            - local[2]
+            - --jars
+            - /opt/spark/jars/postgresql-42.7.5.jar
+            - --conf
+            - spark.driver.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+            - --conf
+            - spark.executor.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+            - local:///opt/banka-analytics/jobs/trading_analytics.py
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"

--- a/analytics/spark/k8s/vanilla/kustomization.yaml
+++ b/analytics/spark/k8s/vanilla/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: banka-analytics
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - db-secret.template.yaml
+  - cronjob.yaml

--- a/analytics/spark/k8s/vanilla/namespace.yaml
+++ b/analytics/spark/k8s/vanilla/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: banka-analytics

--- a/analytics/spark/k8s/vanilla/serviceaccount.yaml
+++ b/analytics/spark/k8s/vanilla/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-analytics
+  namespace: banka-analytics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,38 @@ services:
       - exchange
     networks: [banka]
 
+  spark_analytics:
+    profiles: ["analytics"]
+    build:
+      context: .
+      dockerfile: analytics/spark/Dockerfile
+    environment:
+      ANALYTICS_DB_READ_URL: "jdbc:postgresql://postgres_replica:5432/${POSTGRES_DB}"
+      ANALYTICS_DB_WRITE_URL: "jdbc:postgresql://postgres:5432/${POSTGRES_DB}"
+      ANALYTICS_DB_USER: ${POSTGRES_USER}
+      ANALYTICS_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      ANALYTICS_LOOKBACK_DAYS: ${ANALYTICS_LOOKBACK_DAYS:-90}
+      ANALYTICS_TOP_N: ${ANALYTICS_TOP_N:-5}
+      SPARK_DRIVER_MEMORY: 1g
+      SPARK_EXECUTOR_MEMORY: 1g
+    command:
+      - /opt/spark/bin/spark-submit
+      - --master
+      - local[2]
+      - --jars
+      - /opt/spark/jars/postgresql-42.7.5.jar
+      - --conf
+      - spark.driver.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+      - --conf
+      - spark.executor.extraClassPath=/opt/spark/jars/postgresql-42.7.5.jar
+      - local:///opt/banka-analytics/jobs/trading_analytics.py
+    depends_on:
+      postgres:
+        condition: service_healthy
+      postgres_replica:
+        condition: service_healthy
+    networks: [banka]
+
 volumes:
   pgdata:
   pgreplicadata:

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -829,3 +829,36 @@ CREATE INDEX IF NOT EXISTS external_otc_contracts_local_user_status_idx
     ON external_otc_contracts (local_user_id, status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS external_otc_contracts_thread_idx
     ON external_otc_contracts (thread_id);
+
+-- Spark analytics snapshots. The Spark job reads operational data from the
+-- physical read replica and writes curated daily aggregates back to primary.
+CREATE TABLE IF NOT EXISTS analytics_daily_platform_metrics (
+    metric_date             DATE        PRIMARY KEY,
+    payments_count          BIGINT      NOT NULL DEFAULT 0,
+    payments_volume         BIGINT      NOT NULL DEFAULT 0,
+    transfers_count         BIGINT      NOT NULL DEFAULT 0,
+    transfers_volume        BIGINT      NOT NULL DEFAULT 0,
+    orders_created          BIGINT      NOT NULL DEFAULT 0,
+    orders_completed        BIGINT      NOT NULL DEFAULT 0,
+    fills_count             BIGINT      NOT NULL DEFAULT 0,
+    filled_quantity         BIGINT      NOT NULL DEFAULT 0,
+    fills_notional          BIGINT      NOT NULL DEFAULT 0,
+    otc_contracts_created   BIGINT      NOT NULL DEFAULT 0,
+    otc_contracts_exercised BIGINT      NOT NULL DEFAULT 0,
+    generated_at            TIMESTAMP   NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS analytics_daily_top_listings (
+    metric_date      DATE         NOT NULL,
+    rank             SMALLINT     NOT NULL CHECK (rank > 0),
+    listing_id       BIGINT       NOT NULL REFERENCES listings(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    ticker           VARCHAR(32)  NOT NULL,
+    security_name    VARCHAR(127) NOT NULL,
+    fills_count      BIGINT       NOT NULL DEFAULT 0,
+    traded_quantity  BIGINT       NOT NULL DEFAULT 0,
+    traded_notional  BIGINT       NOT NULL DEFAULT 0,
+    generated_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (metric_date, rank)
+);
+CREATE INDEX IF NOT EXISTS idx_analytics_daily_top_listings_listing
+    ON analytics_daily_top_listings (listing_id, metric_date DESC);

--- a/scripts/db/verify_spark_analytics.sql
+++ b/scripts/db/verify_spark_analytics.sql
@@ -1,0 +1,23 @@
+SELECT
+    metric_date,
+    payments_count,
+    transfers_count,
+    orders_created,
+    fills_count,
+    otc_contracts_created,
+    generated_at
+FROM analytics_daily_platform_metrics
+ORDER BY metric_date DESC
+LIMIT 10;
+
+SELECT
+    metric_date,
+    rank,
+    listing_id,
+    ticker,
+    traded_notional,
+    traded_quantity,
+    generated_at
+FROM analytics_daily_top_listings
+ORDER BY metric_date DESC, rank ASC
+LIMIT 20;


### PR DESCRIPTION
Implemented Spark-based analytics in newestbackend/Banka-3-Backend by adding a PySpark batch job that reads operational data from PostgreSQL, computes daily platform metrics and top traded listings, and writes curated analytics back into Postgres; the solution includes a local Docker dry-run path, Kubernetes manifests for both a Spark Operator ScheduledSparkApplication and a vanilla Kubernetes Job/CronJob, plus supporting schema, verification SQL, and documentation, and it was runtime-verified by executing the Spark job on Kubernetes and confirming analytics output was written successfully to the new analytics tables.