### PR TITLE
feat(interbank): per-partner outbound X-Api-Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,13 +144,20 @@ STOCK_BIDASK_SPREAD=0.001
 # the partner banks we talk to. Empty means no cross-bank outbound — the
 # trading service then nil-checks PartnerOTC at every call site.
 #
-# INTERBANK_API_KEY is the shared secret on every X-Api-Key header,
-# both directions (gateway rejects partners without it; trading sends
-# it on every outbound call). The dev value lets the mock-partner
-# container talk back without extra setup; rotate in prod.
+# INTERBANK_API_KEY is the key the gateway validates on INBOUND partner
+# calls (the key WE issued — partners send it), and the default trading
+# uses OUTBOUND when a partner has no specific key below. The dev value
+# lets the mock-partner container talk back without extra setup.
+#
+# INTERBANK_PARTNER_KEYS is an optional comma-separated list of
+# "code:key" pairs giving the X-Api-Key each partner expects from us on
+# OUTBOUND (the key THEY issued). Overrides INTERBANK_API_KEY per bank,
+# so our inbound key and each partner's outbound key can differ. Example:
+#   INTERBANK_PARTNER_KEYS=444:bank4-secret-key
 BANK_ROUTING_NUMBER=333
 INTERBANK_ROUTES=
 INTERBANK_API_KEY=dev-outbound-banka3
+INTERBANK_PARTNER_KEYS=
 
 # Scheduler service — the single non-replicatable driver of every
 # cluster-wide cron + worker. It calls the bank/trading/exchange trigger

--- a/services/trading/internal/app/app.go
+++ b/services/trading/internal/app/app.go
@@ -200,6 +200,7 @@ func Run() error {
 			client := interbank.New(interbank.Config{
 				Routes:           routes,
 				APIKey:           config.String("INTERBANK_API_KEY", ""),
+				PartnerKeys:      interbank.ParsePartnerKeys(config.String("INTERBANK_PARTNER_KEYS", "")),
 				OwnRoutingNumber: config.String("BANK_ROUTING_NUMBER", "333"),
 			}, log)
 			svc.PartnerOTC = client

--- a/services/trading/internal/external/interbank/client.go
+++ b/services/trading/internal/external/interbank/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -37,9 +38,14 @@ const (
 type Config struct {
 	// Routes maps partner bank codes to base URLs.
 	Routes Routes
-	// APIKey is sent as X-Api-Key on every outbound request to a
-	// partner. Set from INTERBANK_API_KEY.
+	// APIKey is the default X-Api-Key on outbound requests, used when a
+	// partner has no per-bank key in PartnerKeys. Set from INTERBANK_API_KEY.
 	APIKey string
+	// PartnerKeys maps a partner bank code to the X-Api-Key that partner
+	// expects from us (the key THEY issued). Takes precedence over APIKey
+	// for that bank. Set from INTERBANK_PARTNER_KEYS. Lets each peer use a
+	// distinct outbound key, independent of our inbound key.
+	PartnerKeys map[string]string
 	// OwnRoutingNumber identifies this bank to the partner (echoed in
 	// request payloads so partners can populate their remote_bank_code).
 	OwnRoutingNumber string
@@ -73,6 +79,24 @@ func (c *Client) baseURL(bankCode string) string {
 		return ""
 	}
 	return c.cfg.Routes[bankCode]
+}
+
+// apiKeyForURL returns the X-Api-Key to send on an outbound request to the
+// given URL. It reverse-matches the URL to a configured route so a
+// per-partner key (PartnerKeys) can be used; falls back to the default
+// APIKey when the partner has no specific key (or the URL isn't a known
+// route). Resolving by URL keeps the low-level request helpers from having
+// to thread the bank code through every call site.
+func (c *Client) apiKeyForURL(url string) string {
+	for code, base := range c.cfg.Routes {
+		if base != "" && strings.HasPrefix(url, base) {
+			if k := c.cfg.PartnerKeys[code]; k != "" {
+				return k
+			}
+			break
+		}
+	}
+	return c.cfg.APIKey
 }
 
 // Protocol returns the cached protocol for a partner, probing it on
@@ -115,8 +139,10 @@ func (c *Client) probeOK(ctx context.Context, method, url string, withAPIKey boo
 	if err != nil {
 		return false
 	}
-	if withAPIKey && c.cfg.APIKey != "" {
-		req.Header.Set("X-Api-Key", c.cfg.APIKey)
+	if withAPIKey {
+		if k := c.apiKeyForURL(url); k != "" {
+			req.Header.Set("X-Api-Key", k)
+		}
 	}
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
@@ -148,8 +174,8 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any) (int,
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if c.cfg.APIKey != "" {
-		req.Header.Set("X-Api-Key", c.cfg.APIKey)
+	if k := c.apiKeyForURL(url); k != "" {
+		req.Header.Set("X-Api-Key", k)
 	}
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {

--- a/services/trading/internal/external/interbank/client_test.go
+++ b/services/trading/internal/external/interbank/client_test.go
@@ -1,0 +1,44 @@
+package interbank
+
+import "testing"
+
+func TestParsePartnerKeys(t *testing.T) {
+	got := ParsePartnerKeys("444:bank4-secret-key, 999:mockkey ,bad,:nokey,777:")
+	if len(got) != 2 {
+		t.Fatalf("want 2 keys, got %d: %v", len(got), got)
+	}
+	if got["444"] != "bank4-secret-key" {
+		t.Errorf("444: want bank4-secret-key, got %q", got["444"])
+	}
+	if got["999"] != "mockkey" {
+		t.Errorf("999: want mockkey, got %q", got["999"])
+	}
+	if _, ok := got["777"]; ok {
+		t.Errorf("777 had empty key, should be dropped")
+	}
+}
+
+func TestAPIKeyForURL(t *testing.T) {
+	c := New(Config{
+		Routes:      Routes{"444": "http://rafsi.davidovic.io:8083", "999": "http://mock-partner:9099"},
+		APIKey:      "default-inbound-key",
+		PartnerKeys: map[string]string{"444": "bank4-secret-key"},
+	}, nil)
+
+	cases := []struct {
+		url, want string
+	}{
+		// 444 has a per-partner key — used for every path under its base.
+		{"http://rafsi.davidovic.io:8083/interbank/public-stock", "bank4-secret-key"},
+		{"http://rafsi.davidovic.io:8083/interbank", "bank4-secret-key"},
+		// 999 has no per-partner key — falls back to the default.
+		{"http://mock-partner:9099/bank/api/v1/otc/public", "default-inbound-key"},
+		// Unknown host — falls back to the default.
+		{"http://somewhere-else/x", "default-inbound-key"},
+	}
+	for _, tc := range cases {
+		if got := c.apiKeyForURL(tc.url); got != tc.want {
+			t.Errorf("apiKeyForURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}

--- a/services/trading/internal/external/interbank/payments.go
+++ b/services/trading/internal/external/interbank/payments.go
@@ -417,8 +417,8 @@ func (c *Client) doJSONWithHeaders(ctx context.Context, method, url string, body
 		return 0, nil, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if c.cfg.APIKey != "" {
-		req.Header.Set("X-Api-Key", c.cfg.APIKey)
+	if k := c.apiKeyForURL(url); k != "" {
+		req.Header.Set("X-Api-Key", k)
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)

--- a/services/trading/internal/external/interbank/routes.go
+++ b/services/trading/internal/external/interbank/routes.go
@@ -42,6 +42,34 @@ func ParseRoutes(raw string) Routes {
 	return out
 }
 
+// ParsePartnerKeys parses an INTERBANK_PARTNER_KEYS value of the form
+// "code:key,code:key,..." into a code→outbound-X-Api-Key map. Each bank
+// we call may expect a different key (the key THEY issued to us), distinct
+// from the key we validate on inbound (INTERBANK_API_KEY). Keys never
+// contain ':' (bank codes are numeric), so a first-':' cut is safe.
+// Malformed entries are dropped; the per-route key simply isn't set and
+// the client falls back to INTERBANK_API_KEY.
+func ParsePartnerKeys(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		code, key, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		code = strings.TrimSpace(code)
+		key = strings.TrimSpace(key)
+		if code == "" || key == "" {
+			continue
+		}
+		out[code] = key
+	}
+	return out
+}
+
 // BankCodes returns the configured partner bank codes in
 // non-deterministic order. Used by Discover to fan out.
 func (r Routes) BankCodes() []string {


### PR DESCRIPTION
Each partner bank expects a different key from us (the key **they** issued), distinct from the key we validate on inbound (`INTERBANK_API_KEY`, the key **we** issued — e.g. our deployed `4CJYwLN…`).

## Change
- Add `INTERBANK_PARTNER_KEYS` (`"code:key,..."`) parsed into `Config.PartnerKeys`.
- Outbound client resolves the X-Api-Key by matching the request URL to a configured route; falls back to `INTERBANK_API_KEY` when a partner has no specific key.
- Documented in `.env.example`; unit-tested (`ParsePartnerKeys`, `apiKeyForURL`).

## Why
Banka-4 expects `bank4-secret-key` on calls from us, while our gateway validates our own `4CJYwLN…` on their calls to us. With this, set `INTERBANK_PARTNER_KEYS=444:bank4-secret-key` on the trading deployment.

Scope: trading outbound only; gateway inbound unchanged. `go build` + tests green.