### PR TITLE
feat(trading): audit write-sites for limit/order/tax (S40,S41,S43)

### DIFF
--- a/services/trading/internal/app/user_client.go
+++ b/services/trading/internal/app/user_client.go
@@ -51,6 +51,30 @@ func (a *userResolverAdapter) DisplayName(ctx context.Context, userID string, ki
 	}
 }
 
+// RecordAudit forwards one audit entry to user-svc. The transport uses
+// the same internal admin principal as the other adapter methods (the
+// RecordAuditEntry RPC has no permission gate), but the actor_id /
+// actor_kind carried in the request body are the real caller resolved
+// trading-side, so the persisted audit row attributes the action to the
+// supervisor/admin who actually performed it rather than the sentinel.
+func (a *userResolverAdapter) RecordAudit(ctx context.Context, action, actorID, actorKind, targetID, targetLabel, oldVal, newVal, note string) error {
+	ctx = withUserAdmin(ctx)
+	_, err := a.c.RecordAuditEntry(ctx, &userpb.RecordAuditEntryRequest{
+		Action:      action,
+		ActorId:     actorID,
+		ActorKind:   actorKind,
+		TargetId:    targetID,
+		TargetLabel: targetLabel,
+		OldValue:    oldVal,
+		NewValue:    newVal,
+		Note:        note,
+	})
+	if err != nil {
+		return fmt.Errorf("user.RecordAuditEntry: %w", err)
+	}
+	return nil
+}
+
 func (a *userResolverAdapter) EmployeePermissions(ctx context.Context, userID string) ([]string, error) {
 	ctx = withUserAdmin(ctx)
 	resp, err := a.c.GetEmployee(ctx, &userpb.GetEmployeeRequest{Id: userID})

--- a/services/trading/internal/service/actuaries.go
+++ b/services/trading/internal/service/actuaries.go
@@ -123,7 +123,20 @@ func (s *Service) UpdateActuaryLimit(ctx context.Context, employeeID, dailyLimit
 	if money.Cmp(newLimit, usedLimit) < 0 {
 		return nil, apperr.FailedPrecondition("novi limit ne sme biti manji od trenutno iskorišćenog limita")
 	}
-	return s.Store.UpdateActuaryLimit(ctx, employeeID, dailyLimit)
+	out, err := s.Store.UpdateActuaryLimit(ctx, employeeID, dailyLimit)
+	if err != nil {
+		return nil, err
+	}
+	// S40 "promena limita agentu": record the limit change against the
+	// agent, with the old + new daily limit. Best-effort; never fails the op.
+	label := employeeID
+	if s.Users != nil {
+		if name, derr := s.Users.DisplayName(ctx, employeeID, domain.KindEmployee); derr == nil && name != "" {
+			label = name
+		}
+	}
+	s.recordAudit(ctx, "limit.change", employeeID, label, cur.DailyLimit, dailyLimit, "")
+	return out, nil
 }
 
 // ResetActuaryUsedLimit zeroes used_limit for the given agent.

--- a/services/trading/internal/service/integration_test.go
+++ b/services/trading/internal/service/integration_test.go
@@ -1696,6 +1696,10 @@ func (s *stubUsers) EmployeePermissions(_ context.Context, userID string) ([]str
 	return nil, nil
 }
 
+func (s *stubUsers) RecordAudit(_ context.Context, _, _, _, _, _, _, _, _ string) error {
+	return nil
+}
+
 // writeRealizedGainAt seeds a realized_gain row at a chosen wall-clock
 // time so date-range filtering can be exercised. realized_at defaults
 // to now() when omitted; the integration tests below pin it explicitly.

--- a/services/trading/internal/service/orders.go
+++ b/services/trading/internal/service/orders.go
@@ -373,6 +373,8 @@ func (s *Service) ApproveOrder(ctx context.Context, id string) (*domain.Order, e
 	}
 	// S21: supervisor approved the order.
 	s.notifyOrderApproved(ctx, out)
+	// S41 "odobravanje ordera": record the approval against the order id.
+	s.recordAudit(ctx, "order.approve", id, "", "", "", "")
 	return out, nil
 }
 
@@ -392,6 +394,9 @@ func (s *Service) DeclineOrder(ctx context.Context, id, reason string) (*domain.
 	}
 	// S22: supervisor declined the order.
 	s.notifyOrderDeclined(ctx, out)
+	// S41 "odbijanje ordera": record the decline against the order id;
+	// carry the reason (if any) as the note.
+	s.recordAudit(ctx, "order.decline", id, "", "", "", reason)
 	return out, nil
 }
 

--- a/services/trading/internal/service/service.go
+++ b/services/trading/internal/service/service.go
@@ -83,6 +83,14 @@ type UserResolver interface {
 	// manager override is actually a supervisor (spec p.74). Errors
 	// when the id does not resolve to an employee.
 	EmployeePermissions(ctx context.Context, userID string) ([]string, error)
+	// RecordAudit appends one entry to the cross-cutting audit log
+	// owned by user-svc (todoSpec S40/S41/S43 trading write sites).
+	// actorID/actorKind identify the real caller (supervisor/admin)
+	// resolved from the request principal, so the audit shows the real
+	// person rather than the admin sentinel the adapter uses for
+	// transport. Best-effort: implementations must not fail the
+	// underlying trading operation on a delivery error.
+	RecordAudit(ctx context.Context, action, actorID, actorKind, targetID, targetLabel, oldVal, newVal, note string) error
 }
 
 // MarginChecker reads the funding-source state needed by spec p.55
@@ -429,4 +437,25 @@ func (s *Service) requireSupervisor(ctx context.Context) (auth.Principal, error)
 		return p, nil
 	}
 	return auth.Principal{}, apperr.PermissionDenied("nedovoljne permisije")
+}
+
+// recordAudit best-effort records one audit entry against user-svc for a
+// trading write action (todoSpec S40/S41/S43). The actor is the real
+// request principal (the supervisor/admin who performed the action),
+// resolved from ctx and passed explicitly so the audit shows the real
+// person, not the admin sentinel the transport adapter attaches. Nil-safe
+// (s.Users may be unset on a minimal dev stack) and never fails the
+// underlying operation — delivery errors are logged and swallowed.
+func (s *Service) recordAudit(ctx context.Context, action, targetID, targetLabel, oldVal, newVal, note string) {
+	if s.Users == nil {
+		return
+	}
+	var actorID, actorKind string
+	if p, ok := auth.PrincipalFrom(ctx); ok {
+		actorID = p.UserID
+		actorKind = string(p.UserKind)
+	}
+	if err := s.Users.RecordAudit(ctx, action, actorID, actorKind, targetID, targetLabel, oldVal, newVal, note); err != nil {
+		s.Log.Warn("audit-log write failed", "action", action, "target_id", targetID, "err", err.Error())
+	}
 }

--- a/services/trading/internal/service/tax.go
+++ b/services/trading/internal/service/tax.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"math/big"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -186,12 +187,17 @@ type RunTaxResult struct {
 // MarkRealizedGainsTaxed didn't) re-derives the same op_id; bank
 // no-ops, MarkRealizedGainsTaxed converges. No double-charge.
 func (s *Service) RunTax(ctx context.Context, in RunTaxInput) (*RunTaxResult, error) {
-	if _, err := s.requireSupervisor(ctx); err != nil {
+	p, err := s.requireSupervisor(ctx)
+	if err != nil {
 		return nil, err
 	}
 	if s.TaxSettler == nil {
 		return nil, apperr.FailedPrecondition("bank tax settler not wired")
 	}
+	// S43 "ručni obračun poreza": only a manual run by a real supervisor
+	// is audited. The monthly cron stamps the synthetic admin sentinel via
+	// TaxCronContext, so a sentinel actor means cron — skip the audit.
+	isManual := p.UserID != taxCronSentinelID
 
 	// Resolve the candidate set. With UserID set we limit to that one;
 	// otherwise we walk every aggregate row with non-zero unpaid.
@@ -231,10 +237,18 @@ func (s *Service) RunTax(ctx context.Context, in RunTaxInput) (*RunTaxResult, er
 			total = money.Add(total, collected)
 		}
 	}
-	return &RunTaxResult{
+	result := &RunTaxResult{
 		UsersTaxed:        taxed,
 		TotalCollectedRSD: money.FormatAmount(total),
-	}, nil
+	}
+	if isManual {
+		// note: users taxed / total collected (RSD). Best-effort.
+		note := "korisnika oporezovano: " + strconv.Itoa(int(result.UsersTaxed)) +
+			", ukupno naplaćeno: " + result.TotalCollectedRSD + " RSD"
+		target := in.UserID // empty when the run covered every user
+		s.recordAudit(ctx, "tax.run", target, "", "", "", note)
+	}
+	return result, nil
 }
 
 // runTaxForUser pulls all unpaid gains for one user, groups by
@@ -314,12 +328,18 @@ func (s *Service) runTaxForUser(ctx context.Context, userID string, kind domain.
 	return collected, nil
 }
 
+// taxCronSentinelID is the synthetic admin principal id stamped by
+// TaxCronContext on the monthly-cron path. RunTax compares the request
+// principal against it to tell a cron run from a real supervisor's
+// manual run — only the latter is audited (todoSpec S43).
+const taxCronSentinelID = "00000000-0000-0000-0000-00000000fffd"
+
 // TaxCronContext returns a ctx with an admin principal so the
 // monthly-cron path passes requireSupervisor without needing a real
 // supervisor session. Same idiom as the daily limit reset cron.
 func TaxCronContext(ctx context.Context) context.Context {
 	return auth.WithPrincipal(ctx, auth.Principal{
-		UserID:      "00000000-0000-0000-0000-00000000fffd",
+		UserID:      taxCronSentinelID,
 		UserKind:    auth.KindEmployee,
 		Permissions: []string{permissions.Admin},
 	})


### PR DESCRIPTION
Records trading admin actions to the audit log via the existing user-svc RecordAuditEntry (reusing the wired Users adapter — no app.go edit): agent limit change (S40, old/new), order approve/decline (S41), and MANUAL tax runs only (S43, cron excluded via the TaxCronContext sentinel). Actor = real principal. Best-effort/nil-safe. No proto/migration.

todoSpec: S40, S41, S43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)