### PR TITLE
feat(bank): forex forwards / terminski ugovori — backend (todoSpec C3)

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -1942,6 +1942,178 @@
         ]
       }
     },
+    "/api/v1/forex-forwards": {
+      "get": {
+        "summary": "ListForexForwards returns the caller's forward contracts.",
+        "operationId": "BankService_ListForexForwards",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListForexForwardsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "BankService"
+        ]
+      },
+      "post": {
+        "summary": "CreateForexForward concludes a forward: locks the rate, reserves the\nRSD obligation on the client's RSD account, charges the commission,\nand persists the contract as 'active'.",
+        "operationId": "BankService_CreateForexForward",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ForexForward"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateForexForwardRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BankService"
+        ]
+      }
+    },
+    "/api/v1/forex-forwards/quote": {
+      "post": {
+        "summary": "QuoteForexForward returns a side-effect-free preview of a prospective\nforward: the locked-in ForwardRate (= SpotAsk × (1 + days/365 ×\nspread)) plus the reserved obligation amount and commission.",
+        "operationId": "BankService_QuoteForexForward",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ForexForwardQuote"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1QuoteForexForwardRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BankService"
+        ]
+      }
+    },
+    "/api/v1/forex-forwards/spreads": {
+      "get": {
+        "summary": "GetForexForwardSpreads returns every configured pair's SpreadFactor.",
+        "operationId": "BankService_GetForexForwardSpreads",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetForexForwardSpreadsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "BankService"
+        ]
+      },
+      "put": {
+        "summary": "SetForexForwardSpread upserts a pair's SpreadFactor. Supervisor-only.",
+        "operationId": "BankService_SetForexForwardSpread",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ForexForwardSpread"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1SetForexForwardSpreadRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BankService"
+        ]
+      }
+    },
+    "/api/v1/forex-forwards/{id}": {
+      "delete": {
+        "summary": "CancelForexForward cancels a still-'active' contract and releases the\nreservation.",
+        "operationId": "BankService_CancelForexForward",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ForexForward"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "BankService"
+        ]
+      }
+    },
     "/api/v1/funds": {
       "get": {
         "summary": "ListFunds returns the fund discovery list (spec p.71). Supervisors\nand clients with funds.read.* can browse; rows include total_value,\nprofit, and minimum_contribution for sorting/filtering.",
@@ -6929,6 +7101,21 @@
         }
       }
     },
+    "v1CreateForexForwardRequest": {
+      "type": "object",
+      "properties": {
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "notional": {
+          "type": "string"
+        },
+        "settlementDate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "v1CreateFundRequest": {
       "type": "object",
       "properties": {
@@ -7722,6 +7909,143 @@
       },
       "description": "ExternalPublicHolding is one row in the discovery aggregation —\nflattened across partner banks."
     },
+    "v1ForexForward": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency",
+          "title": "notional currency (bought forward)"
+        },
+        "quoteCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency",
+          "title": "settlement leg (RSD)"
+        },
+        "notional": {
+          "type": "string"
+        },
+        "forwardRate": {
+          "type": "string",
+          "title": "locked quote-per-1-base"
+        },
+        "spotAskRate": {
+          "type": "string"
+        },
+        "spreadFactor": {
+          "type": "string"
+        },
+        "daysToSettlement": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "commission": {
+          "type": "string"
+        },
+        "reservationId": {
+          "type": "string"
+        },
+        "fromAccountId": {
+          "type": "string",
+          "title": "client RSD account, debited at settlement"
+        },
+        "toAccountId": {
+          "type": "string",
+          "title": "client base-currency account, credited at settlement"
+        },
+        "settlementDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/v1ForexForwardStatus"
+        },
+        "failureReason": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "settledAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "description": "ForexForward is one concluded forward contract."
+    },
+    "v1ForexForwardQuote": {
+      "type": "object",
+      "properties": {
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "quoteCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "notional": {
+          "type": "string"
+        },
+        "spotAskRate": {
+          "type": "string"
+        },
+        "spreadFactor": {
+          "type": "string"
+        },
+        "daysToSettlement": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "forwardRate": {
+          "type": "string"
+        },
+        "quoteAmount": {
+          "type": "string",
+          "title": "forward_rate × notional (reserved at conclusion)"
+        },
+        "commission": {
+          "type": "string"
+        }
+      },
+      "description": "ForexForwardQuote is the side-effect-free preview returned by\nQuoteForexForward."
+    },
+    "v1ForexForwardSpread": {
+      "type": "object",
+      "properties": {
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "quoteCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "spreadFactor": {
+          "type": "string"
+        },
+        "updatedBy": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "description": "ForexForwardSpread is the per-pair annualised spread factor."
+    },
+    "v1ForexForwardStatus": {
+      "type": "string",
+      "enum": [
+        "FOREX_FORWARD_STATUS_UNSPECIFIED",
+        "FOREX_FORWARD_STATUS_ACTIVE",
+        "FOREX_FORWARD_STATUS_SETTLED",
+        "FOREX_FORWARD_STATUS_CANCELLED",
+        "FOREX_FORWARD_STATUS_FAILED"
+      ],
+      "default": "FOREX_FORWARD_STATUS_UNSPECIFIED"
+    },
     "v1Fund": {
       "type": "object",
       "properties": {
@@ -8046,6 +8370,18 @@
         },
         "contract": {
           "$ref": "#/definitions/v1ExternalOTCContract"
+        }
+      }
+    },
+    "v1GetForexForwardSpreadsResponse": {
+      "type": "object",
+      "properties": {
+        "spreads": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ForexForwardSpread"
+          }
         }
       }
     },
@@ -8442,6 +8778,18 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/v1ExternalPublicHolding"
+          }
+        }
+      }
+    },
+    "v1ListForexForwardsResponse": {
+      "type": "object",
+      "properties": {
+        "forexForwards": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ForexForward"
           }
         }
       }
@@ -9798,6 +10146,22 @@
         }
       }
     },
+    "v1QuoteForexForwardRequest": {
+      "type": "object",
+      "properties": {
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "notional": {
+          "type": "string"
+        },
+        "settlementDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "YYYY-MM-DD settlement date in the future."
+        }
+      }
+    },
     "v1Rate": {
       "type": "object",
       "properties": {
@@ -10442,6 +10806,20 @@
         }
       },
       "description": "SecurityWithListing collapses (security, listing) for the catalog\nportal so the FE doesn't need to round-trip per row."
+    },
+    "v1SetForexForwardSpreadRequest": {
+      "type": "object",
+      "properties": {
+        "baseCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "quoteCurrency": {
+          "$ref": "#/definitions/bankaBankV1Currency"
+        },
+        "spreadFactor": {
+          "type": "string"
+        }
+      }
     },
     "v1SubmitCrossBankPaymentRequest": {
       "type": "object",

--- a/gen/proto/bank/v1/bank.pb.go
+++ b/gen/proto/bank/v1/bank.pb.go
@@ -951,6 +951,61 @@ func (InstallmentStatus) EnumDescriptor() ([]byte, []int) {
 	return file_bank_v1_bank_proto_rawDescGZIP(), []int{15}
 }
 
+type ForexForwardStatus int32
+
+const (
+	ForexForwardStatus_FOREX_FORWARD_STATUS_UNSPECIFIED ForexForwardStatus = 0
+	ForexForwardStatus_FOREX_FORWARD_STATUS_ACTIVE      ForexForwardStatus = 1
+	ForexForwardStatus_FOREX_FORWARD_STATUS_SETTLED     ForexForwardStatus = 2
+	ForexForwardStatus_FOREX_FORWARD_STATUS_CANCELLED   ForexForwardStatus = 3
+	ForexForwardStatus_FOREX_FORWARD_STATUS_FAILED      ForexForwardStatus = 4
+)
+
+// Enum value maps for ForexForwardStatus.
+var (
+	ForexForwardStatus_name = map[int32]string{
+		0: "FOREX_FORWARD_STATUS_UNSPECIFIED",
+		1: "FOREX_FORWARD_STATUS_ACTIVE",
+		2: "FOREX_FORWARD_STATUS_SETTLED",
+		3: "FOREX_FORWARD_STATUS_CANCELLED",
+		4: "FOREX_FORWARD_STATUS_FAILED",
+	}
+	ForexForwardStatus_value = map[string]int32{
+		"FOREX_FORWARD_STATUS_UNSPECIFIED": 0,
+		"FOREX_FORWARD_STATUS_ACTIVE":      1,
+		"FOREX_FORWARD_STATUS_SETTLED":     2,
+		"FOREX_FORWARD_STATUS_CANCELLED":   3,
+		"FOREX_FORWARD_STATUS_FAILED":      4,
+	}
+)
+
+func (x ForexForwardStatus) Enum() *ForexForwardStatus {
+	p := new(ForexForwardStatus)
+	*p = x
+	return p
+}
+
+func (x ForexForwardStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ForexForwardStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_bank_v1_bank_proto_enumTypes[16].Descriptor()
+}
+
+func (ForexForwardStatus) Type() protoreflect.EnumType {
+	return &file_bank_v1_bank_proto_enumTypes[16]
+}
+
+func (x ForexForwardStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ForexForwardStatus.Descriptor instead.
+func (ForexForwardStatus) EnumDescriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{16}
+}
+
 type Company struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -6938,6 +6993,855 @@ func (x *RunSpentResetJobResponse) GetMonthly() int64 {
 	return 0
 }
 
+// ForexForward is one concluded forward contract.
+type ForexForward struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Id               string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	ClientId         string                 `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	BaseCurrency     Currency               `protobuf:"varint,3,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`    // notional currency (bought forward)
+	QuoteCurrency    Currency               `protobuf:"varint,4,opt,name=quote_currency,json=quoteCurrency,proto3,enum=banka.bank.v1.Currency" json:"quote_currency,omitempty"` // settlement leg (RSD)
+	Notional         string                 `protobuf:"bytes,5,opt,name=notional,proto3" json:"notional,omitempty"`
+	ForwardRate      string                 `protobuf:"bytes,6,opt,name=forward_rate,json=forwardRate,proto3" json:"forward_rate,omitempty"` // locked quote-per-1-base
+	SpotAskRate      string                 `protobuf:"bytes,7,opt,name=spot_ask_rate,json=spotAskRate,proto3" json:"spot_ask_rate,omitempty"`
+	SpreadFactor     string                 `protobuf:"bytes,8,opt,name=spread_factor,json=spreadFactor,proto3" json:"spread_factor,omitempty"`
+	DaysToSettlement int32                  `protobuf:"varint,9,opt,name=days_to_settlement,json=daysToSettlement,proto3" json:"days_to_settlement,omitempty"`
+	Commission       string                 `protobuf:"bytes,10,opt,name=commission,proto3" json:"commission,omitempty"`
+	ReservationId    string                 `protobuf:"bytes,11,opt,name=reservation_id,json=reservationId,proto3" json:"reservation_id,omitempty"`
+	FromAccountId    string                 `protobuf:"bytes,12,opt,name=from_account_id,json=fromAccountId,proto3" json:"from_account_id,omitempty"` // client RSD account, debited at settlement
+	ToAccountId      string                 `protobuf:"bytes,13,opt,name=to_account_id,json=toAccountId,proto3" json:"to_account_id,omitempty"`       // client base-currency account, credited at settlement
+	SettlementDate   *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	Status           ForexForwardStatus     `protobuf:"varint,15,opt,name=status,proto3,enum=banka.bank.v1.ForexForwardStatus" json:"status,omitempty"`
+	FailureReason    string                 `protobuf:"bytes,16,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	CreatedAt        *timestamppb.Timestamp `protobuf:"bytes,17,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	SettledAt        *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=settled_at,json=settledAt,proto3" json:"settled_at,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ForexForward) Reset() {
+	*x = ForexForward{}
+	mi := &file_bank_v1_bank_proto_msgTypes[82]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForexForward) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForexForward) ProtoMessage() {}
+
+func (x *ForexForward) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[82]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForexForward.ProtoReflect.Descriptor instead.
+func (*ForexForward) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{82}
+}
+
+func (x *ForexForward) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ForexForward) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *ForexForward) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForward) GetQuoteCurrency() Currency {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForward) GetNotional() string {
+	if x != nil {
+		return x.Notional
+	}
+	return ""
+}
+
+func (x *ForexForward) GetForwardRate() string {
+	if x != nil {
+		return x.ForwardRate
+	}
+	return ""
+}
+
+func (x *ForexForward) GetSpotAskRate() string {
+	if x != nil {
+		return x.SpotAskRate
+	}
+	return ""
+}
+
+func (x *ForexForward) GetSpreadFactor() string {
+	if x != nil {
+		return x.SpreadFactor
+	}
+	return ""
+}
+
+func (x *ForexForward) GetDaysToSettlement() int32 {
+	if x != nil {
+		return x.DaysToSettlement
+	}
+	return 0
+}
+
+func (x *ForexForward) GetCommission() string {
+	if x != nil {
+		return x.Commission
+	}
+	return ""
+}
+
+func (x *ForexForward) GetReservationId() string {
+	if x != nil {
+		return x.ReservationId
+	}
+	return ""
+}
+
+func (x *ForexForward) GetFromAccountId() string {
+	if x != nil {
+		return x.FromAccountId
+	}
+	return ""
+}
+
+func (x *ForexForward) GetToAccountId() string {
+	if x != nil {
+		return x.ToAccountId
+	}
+	return ""
+}
+
+func (x *ForexForward) GetSettlementDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return nil
+}
+
+func (x *ForexForward) GetStatus() ForexForwardStatus {
+	if x != nil {
+		return x.Status
+	}
+	return ForexForwardStatus_FOREX_FORWARD_STATUS_UNSPECIFIED
+}
+
+func (x *ForexForward) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+func (x *ForexForward) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *ForexForward) GetSettledAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SettledAt
+	}
+	return nil
+}
+
+// ForexForwardSpread is the per-pair annualised spread factor.
+type ForexForwardSpread struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency  Currency               `protobuf:"varint,1,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`
+	QuoteCurrency Currency               `protobuf:"varint,2,opt,name=quote_currency,json=quoteCurrency,proto3,enum=banka.bank.v1.Currency" json:"quote_currency,omitempty"`
+	SpreadFactor  string                 `protobuf:"bytes,3,opt,name=spread_factor,json=spreadFactor,proto3" json:"spread_factor,omitempty"`
+	UpdatedBy     string                 `protobuf:"bytes,4,opt,name=updated_by,json=updatedBy,proto3" json:"updated_by,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForexForwardSpread) Reset() {
+	*x = ForexForwardSpread{}
+	mi := &file_bank_v1_bank_proto_msgTypes[83]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForexForwardSpread) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForexForwardSpread) ProtoMessage() {}
+
+func (x *ForexForwardSpread) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[83]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForexForwardSpread.ProtoReflect.Descriptor instead.
+func (*ForexForwardSpread) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{83}
+}
+
+func (x *ForexForwardSpread) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForwardSpread) GetQuoteCurrency() Currency {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForwardSpread) GetSpreadFactor() string {
+	if x != nil {
+		return x.SpreadFactor
+	}
+	return ""
+}
+
+func (x *ForexForwardSpread) GetUpdatedBy() string {
+	if x != nil {
+		return x.UpdatedBy
+	}
+	return ""
+}
+
+func (x *ForexForwardSpread) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+// ForexForwardQuote is the side-effect-free preview returned by
+// QuoteForexForward.
+type ForexForwardQuote struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency     Currency               `protobuf:"varint,1,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`
+	QuoteCurrency    Currency               `protobuf:"varint,2,opt,name=quote_currency,json=quoteCurrency,proto3,enum=banka.bank.v1.Currency" json:"quote_currency,omitempty"`
+	Notional         string                 `protobuf:"bytes,3,opt,name=notional,proto3" json:"notional,omitempty"`
+	SpotAskRate      string                 `protobuf:"bytes,4,opt,name=spot_ask_rate,json=spotAskRate,proto3" json:"spot_ask_rate,omitempty"`
+	SpreadFactor     string                 `protobuf:"bytes,5,opt,name=spread_factor,json=spreadFactor,proto3" json:"spread_factor,omitempty"`
+	DaysToSettlement int32                  `protobuf:"varint,6,opt,name=days_to_settlement,json=daysToSettlement,proto3" json:"days_to_settlement,omitempty"`
+	ForwardRate      string                 `protobuf:"bytes,7,opt,name=forward_rate,json=forwardRate,proto3" json:"forward_rate,omitempty"`
+	QuoteAmount      string                 `protobuf:"bytes,8,opt,name=quote_amount,json=quoteAmount,proto3" json:"quote_amount,omitempty"` // forward_rate × notional (reserved at conclusion)
+	Commission       string                 `protobuf:"bytes,9,opt,name=commission,proto3" json:"commission,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ForexForwardQuote) Reset() {
+	*x = ForexForwardQuote{}
+	mi := &file_bank_v1_bank_proto_msgTypes[84]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForexForwardQuote) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForexForwardQuote) ProtoMessage() {}
+
+func (x *ForexForwardQuote) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[84]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForexForwardQuote.ProtoReflect.Descriptor instead.
+func (*ForexForwardQuote) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{84}
+}
+
+func (x *ForexForwardQuote) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForwardQuote) GetQuoteCurrency() Currency {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ForexForwardQuote) GetNotional() string {
+	if x != nil {
+		return x.Notional
+	}
+	return ""
+}
+
+func (x *ForexForwardQuote) GetSpotAskRate() string {
+	if x != nil {
+		return x.SpotAskRate
+	}
+	return ""
+}
+
+func (x *ForexForwardQuote) GetSpreadFactor() string {
+	if x != nil {
+		return x.SpreadFactor
+	}
+	return ""
+}
+
+func (x *ForexForwardQuote) GetDaysToSettlement() int32 {
+	if x != nil {
+		return x.DaysToSettlement
+	}
+	return 0
+}
+
+func (x *ForexForwardQuote) GetForwardRate() string {
+	if x != nil {
+		return x.ForwardRate
+	}
+	return ""
+}
+
+func (x *ForexForwardQuote) GetQuoteAmount() string {
+	if x != nil {
+		return x.QuoteAmount
+	}
+	return ""
+}
+
+func (x *ForexForwardQuote) GetCommission() string {
+	if x != nil {
+		return x.Commission
+	}
+	return ""
+}
+
+type QuoteForexForwardRequest struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency Currency               `protobuf:"varint,1,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`
+	Notional     string                 `protobuf:"bytes,2,opt,name=notional,proto3" json:"notional,omitempty"`
+	// YYYY-MM-DD settlement date in the future.
+	SettlementDate *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *QuoteForexForwardRequest) Reset() {
+	*x = QuoteForexForwardRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[85]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuoteForexForwardRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuoteForexForwardRequest) ProtoMessage() {}
+
+func (x *QuoteForexForwardRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[85]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuoteForexForwardRequest.ProtoReflect.Descriptor instead.
+func (*QuoteForexForwardRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{85}
+}
+
+func (x *QuoteForexForwardRequest) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *QuoteForexForwardRequest) GetNotional() string {
+	if x != nil {
+		return x.Notional
+	}
+	return ""
+}
+
+func (x *QuoteForexForwardRequest) GetSettlementDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return nil
+}
+
+type CreateForexForwardRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency   Currency               `protobuf:"varint,1,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`
+	Notional       string                 `protobuf:"bytes,2,opt,name=notional,proto3" json:"notional,omitempty"`
+	SettlementDate *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=settlement_date,json=settlementDate,proto3" json:"settlement_date,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CreateForexForwardRequest) Reset() {
+	*x = CreateForexForwardRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[86]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateForexForwardRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateForexForwardRequest) ProtoMessage() {}
+
+func (x *CreateForexForwardRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[86]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateForexForwardRequest.ProtoReflect.Descriptor instead.
+func (*CreateForexForwardRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{86}
+}
+
+func (x *CreateForexForwardRequest) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *CreateForexForwardRequest) GetNotional() string {
+	if x != nil {
+		return x.Notional
+	}
+	return ""
+}
+
+func (x *CreateForexForwardRequest) GetSettlementDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SettlementDate
+	}
+	return nil
+}
+
+type ListForexForwardsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListForexForwardsRequest) Reset() {
+	*x = ListForexForwardsRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[87]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListForexForwardsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListForexForwardsRequest) ProtoMessage() {}
+
+func (x *ListForexForwardsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[87]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListForexForwardsRequest.ProtoReflect.Descriptor instead.
+func (*ListForexForwardsRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{87}
+}
+
+type ListForexForwardsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ForexForwards []*ForexForward        `protobuf:"bytes,1,rep,name=forex_forwards,json=forexForwards,proto3" json:"forex_forwards,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListForexForwardsResponse) Reset() {
+	*x = ListForexForwardsResponse{}
+	mi := &file_bank_v1_bank_proto_msgTypes[88]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListForexForwardsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListForexForwardsResponse) ProtoMessage() {}
+
+func (x *ListForexForwardsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[88]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListForexForwardsResponse.ProtoReflect.Descriptor instead.
+func (*ListForexForwardsResponse) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{88}
+}
+
+func (x *ListForexForwardsResponse) GetForexForwards() []*ForexForward {
+	if x != nil {
+		return x.ForexForwards
+	}
+	return nil
+}
+
+type CancelForexForwardRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelForexForwardRequest) Reset() {
+	*x = CancelForexForwardRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[89]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelForexForwardRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelForexForwardRequest) ProtoMessage() {}
+
+func (x *CancelForexForwardRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[89]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelForexForwardRequest.ProtoReflect.Descriptor instead.
+func (*CancelForexForwardRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{89}
+}
+
+func (x *CancelForexForwardRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetForexForwardSpreadsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetForexForwardSpreadsRequest) Reset() {
+	*x = GetForexForwardSpreadsRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[90]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetForexForwardSpreadsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetForexForwardSpreadsRequest) ProtoMessage() {}
+
+func (x *GetForexForwardSpreadsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[90]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetForexForwardSpreadsRequest.ProtoReflect.Descriptor instead.
+func (*GetForexForwardSpreadsRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{90}
+}
+
+type GetForexForwardSpreadsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Spreads       []*ForexForwardSpread  `protobuf:"bytes,1,rep,name=spreads,proto3" json:"spreads,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetForexForwardSpreadsResponse) Reset() {
+	*x = GetForexForwardSpreadsResponse{}
+	mi := &file_bank_v1_bank_proto_msgTypes[91]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetForexForwardSpreadsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetForexForwardSpreadsResponse) ProtoMessage() {}
+
+func (x *GetForexForwardSpreadsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[91]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetForexForwardSpreadsResponse.ProtoReflect.Descriptor instead.
+func (*GetForexForwardSpreadsResponse) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{91}
+}
+
+func (x *GetForexForwardSpreadsResponse) GetSpreads() []*ForexForwardSpread {
+	if x != nil {
+		return x.Spreads
+	}
+	return nil
+}
+
+type SetForexForwardSpreadRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	BaseCurrency  Currency               `protobuf:"varint,1,opt,name=base_currency,json=baseCurrency,proto3,enum=banka.bank.v1.Currency" json:"base_currency,omitempty"`
+	QuoteCurrency Currency               `protobuf:"varint,2,opt,name=quote_currency,json=quoteCurrency,proto3,enum=banka.bank.v1.Currency" json:"quote_currency,omitempty"`
+	SpreadFactor  string                 `protobuf:"bytes,3,opt,name=spread_factor,json=spreadFactor,proto3" json:"spread_factor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetForexForwardSpreadRequest) Reset() {
+	*x = SetForexForwardSpreadRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[92]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetForexForwardSpreadRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetForexForwardSpreadRequest) ProtoMessage() {}
+
+func (x *SetForexForwardSpreadRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[92]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetForexForwardSpreadRequest.ProtoReflect.Descriptor instead.
+func (*SetForexForwardSpreadRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{92}
+}
+
+func (x *SetForexForwardSpreadRequest) GetBaseCurrency() Currency {
+	if x != nil {
+		return x.BaseCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *SetForexForwardSpreadRequest) GetQuoteCurrency() Currency {
+	if x != nil {
+		return x.QuoteCurrency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *SetForexForwardSpreadRequest) GetSpreadFactor() string {
+	if x != nil {
+		return x.SpreadFactor
+	}
+	return ""
+}
+
+type RunForexForwardSettlementRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunForexForwardSettlementRequest) Reset() {
+	*x = RunForexForwardSettlementRequest{}
+	mi := &file_bank_v1_bank_proto_msgTypes[93]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunForexForwardSettlementRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunForexForwardSettlementRequest) ProtoMessage() {}
+
+func (x *RunForexForwardSettlementRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[93]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunForexForwardSettlementRequest.ProtoReflect.Descriptor instead.
+func (*RunForexForwardSettlementRequest) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{93}
+}
+
+type RunForexForwardSettlementResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Processed     int32                  `protobuf:"varint,1,opt,name=processed,proto3" json:"processed,omitempty"`
+	Settled       int32                  `protobuf:"varint,2,opt,name=settled,proto3" json:"settled,omitempty"`
+	Failed        int32                  `protobuf:"varint,3,opt,name=failed,proto3" json:"failed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunForexForwardSettlementResponse) Reset() {
+	*x = RunForexForwardSettlementResponse{}
+	mi := &file_bank_v1_bank_proto_msgTypes[94]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunForexForwardSettlementResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunForexForwardSettlementResponse) ProtoMessage() {}
+
+func (x *RunForexForwardSettlementResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bank_v1_bank_proto_msgTypes[94]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunForexForwardSettlementResponse.ProtoReflect.Descriptor instead.
+func (*RunForexForwardSettlementResponse) Descriptor() ([]byte, []int) {
+	return file_bank_v1_bank_proto_rawDescGZIP(), []int{94}
+}
+
+func (x *RunForexForwardSettlementResponse) GetProcessed() int32 {
+	if x != nil {
+		return x.Processed
+	}
+	return 0
+}
+
+func (x *RunForexForwardSettlementResponse) GetSettled() int32 {
+	if x != nil {
+		return x.Settled
+	}
+	return 0
+}
+
+func (x *RunForexForwardSettlementResponse) GetFailed() int32 {
+	if x != nil {
+		return x.Failed
+	}
+	return 0
+}
+
 var File_bank_v1_bank_proto protoreflect.FileDescriptor
 
 const file_bank_v1_bank_proto_rawDesc = "" +
@@ -7490,7 +8394,76 @@ const file_bank_v1_bank_proto_rawDesc = "" +
 	"\x17RunSpentResetJobRequest\"J\n" +
 	"\x18RunSpentResetJobResponse\x12\x14\n" +
 	"\x05daily\x18\x01 \x01(\x03R\x05daily\x12\x18\n" +
-	"\amonthly\x18\x02 \x01(\x03R\amonthly*\xb4\x01\n" +
+	"\amonthly\x18\x02 \x01(\x03R\amonthly\"\x9f\x06\n" +
+	"\fForexForward\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12<\n" +
+	"\rbase_currency\x18\x03 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\fbaseCurrency\x12>\n" +
+	"\x0equote_currency\x18\x04 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\rquoteCurrency\x12\x1a\n" +
+	"\bnotional\x18\x05 \x01(\tR\bnotional\x12!\n" +
+	"\fforward_rate\x18\x06 \x01(\tR\vforwardRate\x12\"\n" +
+	"\rspot_ask_rate\x18\a \x01(\tR\vspotAskRate\x12#\n" +
+	"\rspread_factor\x18\b \x01(\tR\fspreadFactor\x12,\n" +
+	"\x12days_to_settlement\x18\t \x01(\x05R\x10daysToSettlement\x12\x1e\n" +
+	"\n" +
+	"commission\x18\n" +
+	" \x01(\tR\n" +
+	"commission\x12%\n" +
+	"\x0ereservation_id\x18\v \x01(\tR\rreservationId\x12&\n" +
+	"\x0ffrom_account_id\x18\f \x01(\tR\rfromAccountId\x12\"\n" +
+	"\rto_account_id\x18\r \x01(\tR\vtoAccountId\x12C\n" +
+	"\x0fsettlement_date\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0esettlementDate\x129\n" +
+	"\x06status\x18\x0f \x01(\x0e2!.banka.bank.v1.ForexForwardStatusR\x06status\x12%\n" +
+	"\x0efailure_reason\x18\x10 \x01(\tR\rfailureReason\x129\n" +
+	"\n" +
+	"created_at\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"settled_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\tsettledAt\"\x91\x02\n" +
+	"\x12ForexForwardSpread\x12<\n" +
+	"\rbase_currency\x18\x01 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\fbaseCurrency\x12>\n" +
+	"\x0equote_currency\x18\x02 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\rquoteCurrency\x12#\n" +
+	"\rspread_factor\x18\x03 \x01(\tR\fspreadFactor\x12\x1d\n" +
+	"\n" +
+	"updated_by\x18\x04 \x01(\tR\tupdatedBy\x129\n" +
+	"\n" +
+	"updated_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\x8a\x03\n" +
+	"\x11ForexForwardQuote\x12<\n" +
+	"\rbase_currency\x18\x01 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\fbaseCurrency\x12>\n" +
+	"\x0equote_currency\x18\x02 \x01(\x0e2\x17.banka.bank.v1.CurrencyR\rquoteCurrency\x12\x1a\n" +
+	"\bnotional\x18\x03 \x01(\tR\bnotional\x12\"\n" +
+	"\rspot_ask_rate\x18\x04 \x01(\tR\vspotAskRate\x12#\n" +
+	"\rspread_factor\x18\x05 \x01(\tR\fspreadFactor\x12,\n" +
+	"\x12days_to_settlement\x18\x06 \x01(\x05R\x10daysToSettlement\x12!\n" +
+	"\fforward_rate\x18\a \x01(\tR\vforwardRate\x12!\n" +
+	"\fquote_amount\x18\b \x01(\tR\vquoteAmount\x12\x1e\n" +
+	"\n" +
+	"commission\x18\t \x01(\tR\n" +
+	"commission\"\xd4\x01\n" +
+	"\x18QuoteForexForwardRequest\x12F\n" +
+	"\rbase_currency\x18\x01 \x01(\x0e2\x17.banka.bank.v1.CurrencyB\b\xbaH\x05\x82\x01\x02\x10\x01R\fbaseCurrency\x12#\n" +
+	"\bnotional\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\bnotional\x12K\n" +
+	"\x0fsettlement_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampB\x06\xbaH\x03\xc8\x01\x01R\x0esettlementDate\"\xd5\x01\n" +
+	"\x19CreateForexForwardRequest\x12F\n" +
+	"\rbase_currency\x18\x01 \x01(\x0e2\x17.banka.bank.v1.CurrencyB\b\xbaH\x05\x82\x01\x02\x10\x01R\fbaseCurrency\x12#\n" +
+	"\bnotional\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\bnotional\x12K\n" +
+	"\x0fsettlement_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampB\x06\xbaH\x03\xc8\x01\x01R\x0esettlementDate\"\x1a\n" +
+	"\x18ListForexForwardsRequest\"_\n" +
+	"\x19ListForexForwardsResponse\x12B\n" +
+	"\x0eforex_forwards\x18\x01 \x03(\v2\x1b.banka.bank.v1.ForexForwardR\rforexForwards\"5\n" +
+	"\x19CancelForexForwardRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\x1f\n" +
+	"\x1dGetForexForwardSpreadsRequest\"]\n" +
+	"\x1eGetForexForwardSpreadsResponse\x12;\n" +
+	"\aspreads\x18\x01 \x03(\v2!.banka.bank.v1.ForexForwardSpreadR\aspreads\"\xde\x01\n" +
+	"\x1cSetForexForwardSpreadRequest\x12F\n" +
+	"\rbase_currency\x18\x01 \x01(\x0e2\x17.banka.bank.v1.CurrencyB\b\xbaH\x05\x82\x01\x02\x10\x01R\fbaseCurrency\x12H\n" +
+	"\x0equote_currency\x18\x02 \x01(\x0e2\x17.banka.bank.v1.CurrencyB\b\xbaH\x05\x82\x01\x02\x10\x01R\rquoteCurrency\x12,\n" +
+	"\rspread_factor\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\fspreadFactor\"\"\n" +
+	" RunForexForwardSettlementRequest\"s\n" +
+	"!RunForexForwardSettlementResponse\x12\x1c\n" +
+	"\tprocessed\x18\x01 \x01(\x05R\tprocessed\x12\x18\n" +
+	"\asettled\x18\x02 \x01(\x05R\asettled\x12\x16\n" +
+	"\x06failed\x18\x03 \x01(\x05R\x06failed*\xb4\x01\n" +
 	"\bCurrency\x12\x18\n" +
 	"\x14CURRENCY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fCURRENCY_RSD\x10\x01\x12\x10\n" +
@@ -7603,7 +8576,13 @@ const file_bank_v1_bank_proto_rawDesc = "" +
 	"\x1eINSTALLMENT_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17INSTALLMENT_STATUS_PAID\x10\x01\x12\x1d\n" +
 	"\x19INSTALLMENT_STATUS_UNPAID\x10\x02\x12\x1e\n" +
-	"\x1aINSTALLMENT_STATUS_OVERDUE\x10\x032\xd7,\n" +
+	"\x1aINSTALLMENT_STATUS_OVERDUE\x10\x03*\xc2\x01\n" +
+	"\x12ForexForwardStatus\x12$\n" +
+	" FOREX_FORWARD_STATUS_UNSPECIFIED\x10\x00\x12\x1f\n" +
+	"\x1bFOREX_FORWARD_STATUS_ACTIVE\x10\x01\x12 \n" +
+	"\x1cFOREX_FORWARD_STATUS_SETTLED\x10\x02\x12\"\n" +
+	"\x1eFOREX_FORWARD_STATUS_CANCELLED\x10\x03\x12\x1f\n" +
+	"\x1bFOREX_FORWARD_STATUS_FAILED\x10\x042\xa24\n" +
 	"\vBankService\x12j\n" +
 	"\rCreateCompany\x12#.banka.bank.v1.CreateCompanyRequest\x1a\x16.banka.bank.v1.Company\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/api/v1/companies\x12u\n" +
 	"\rListCompanies\x12#.banka.bank.v1.ListCompaniesRequest\x1a$.banka.bank.v1.ListCompaniesResponse\"\x19\x82\xd3\xe4\x93\x02\x13\x12\x11/api/v1/companies\x12f\n" +
@@ -7654,7 +8633,14 @@ const file_bank_v1_bank_proto_rawDesc = "" +
 	"\x11RunInstallmentJob\x12'.banka.bank.v1.RunInstallmentJobRequest\x1a(.banka.bank.v1.RunInstallmentJobResponse\",\x82\xd3\xe4\x93\x02&:\x01*\"!/api/v1/loans/run-installment-job\x12\x99\x01\n" +
 	"\x12RunVariableRateJob\x12(.banka.bank.v1.RunVariableRateJobRequest\x1a).banka.bank.v1.RunVariableRateJobResponse\".\x82\xd3\xe4\x93\x02(:\x01*\"#/api/v1/loans/run-variable-rate-job\x12\xa4\x01\n" +
 	"\x14RunMaintenanceFeeJob\x12*.banka.bank.v1.RunMaintenanceFeeJobRequest\x1a+.banka.bank.v1.RunMaintenanceFeeJobResponse\"3\x82\xd3\xe4\x93\x02-:\x01*\"(/api/v1/accounts/run-maintenance-fee-job\x12\x94\x01\n" +
-	"\x10RunSpentResetJob\x12&.banka.bank.v1.RunSpentResetJobRequest\x1a'.banka.bank.v1.RunSpentResetJobResponse\"/\x82\xd3\xe4\x93\x02):\x01*\"$/api/v1/accounts/run-spent-reset-jobB\xb5\x01\n" +
+	"\x10RunSpentResetJob\x12&.banka.bank.v1.RunSpentResetJobRequest\x1a'.banka.bank.v1.RunSpentResetJobResponse\"/\x82\xd3\xe4\x93\x02):\x01*\"$/api/v1/accounts/run-spent-reset-job\x12\x87\x01\n" +
+	"\x11QuoteForexForward\x12'.banka.bank.v1.QuoteForexForwardRequest\x1a .banka.bank.v1.ForexForwardQuote\"'\x82\xd3\xe4\x93\x02!:\x01*\"\x1c/api/v1/forex-forwards/quote\x12~\n" +
+	"\x12CreateForexForward\x12(.banka.bank.v1.CreateForexForwardRequest\x1a\x1b.banka.bank.v1.ForexForward\"!\x82\xd3\xe4\x93\x02\x1b:\x01*\"\x16/api/v1/forex-forwards\x12\x86\x01\n" +
+	"\x11ListForexForwards\x12'.banka.bank.v1.ListForexForwardsRequest\x1a(.banka.bank.v1.ListForexForwardsResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/api/v1/forex-forwards\x12\x80\x01\n" +
+	"\x12CancelForexForward\x12(.banka.bank.v1.CancelForexForwardRequest\x1a\x1b.banka.bank.v1.ForexForward\"#\x82\xd3\xe4\x93\x02\x1d*\x1b/api/v1/forex-forwards/{id}\x12\x9d\x01\n" +
+	"\x16GetForexForwardSpreads\x12,.banka.bank.v1.GetForexForwardSpreadsRequest\x1a-.banka.bank.v1.GetForexForwardSpreadsResponse\"&\x82\xd3\xe4\x93\x02 \x12\x1e/api/v1/forex-forwards/spreads\x12\x92\x01\n" +
+	"\x15SetForexForwardSpread\x12+.banka.bank.v1.SetForexForwardSpreadRequest\x1a!.banka.bank.v1.ForexForwardSpread\")\x82\xd3\xe4\x93\x02#:\x01*\x1a\x1e/api/v1/forex-forwards/spreads\x12~\n" +
+	"\x19RunForexForwardSettlement\x12/.banka.bank.v1.RunForexForwardSettlementRequest\x1a0.banka.bank.v1.RunForexForwardSettlementResponseB\xb5\x01\n" +
 	"\x11com.banka.bank.v1B\tBankProtoP\x01Z?github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1;bankv1\xa2\x02\x03BBX\xaa\x02\rBanka.Bank.V1\xca\x02\rBanka\\Bank\\V1\xe2\x02\x19Banka\\Bank\\V1\\GPBMetadata\xea\x02\x0fBanka::Bank::V1b\x06proto3"
 
 var (
@@ -7669,301 +8655,348 @@ func file_bank_v1_bank_proto_rawDescGZIP() []byte {
 	return file_bank_v1_bank_proto_rawDescData
 }
 
-var file_bank_v1_bank_proto_enumTypes = make([]protoimpl.EnumInfo, 16)
-var file_bank_v1_bank_proto_msgTypes = make([]protoimpl.MessageInfo, 82)
+var file_bank_v1_bank_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
+var file_bank_v1_bank_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
 var file_bank_v1_bank_proto_goTypes = []any{
-	(Currency)(0),                           // 0: banka.bank.v1.Currency
-	(AccountKind)(0),                        // 1: banka.bank.v1.AccountKind
-	(AccountSubtype)(0),                     // 2: banka.bank.v1.AccountSubtype
-	(AccountStatus)(0),                      // 3: banka.bank.v1.AccountStatus
-	(TransactionStatus)(0),                  // 4: banka.bank.v1.TransactionStatus
-	(TransactionKind)(0),                    // 5: banka.bank.v1.TransactionKind
-	(ScheduledPaymentStatus)(0),             // 6: banka.bank.v1.ScheduledPaymentStatus
-	(CardBrand)(0),                          // 7: banka.bank.v1.CardBrand
-	(CardStatus)(0),                         // 8: banka.bank.v1.CardStatus
-	(Gender)(0),                             // 9: banka.bank.v1.Gender
-	(LoanType)(0),                           // 10: banka.bank.v1.LoanType
-	(InterestType)(0),                       // 11: banka.bank.v1.InterestType
-	(EmploymentStatus)(0),                   // 12: banka.bank.v1.EmploymentStatus
-	(LoanRequestStatus)(0),                  // 13: banka.bank.v1.LoanRequestStatus
-	(LoanStatus)(0),                         // 14: banka.bank.v1.LoanStatus
-	(InstallmentStatus)(0),                  // 15: banka.bank.v1.InstallmentStatus
-	(*Company)(nil),                         // 16: banka.bank.v1.Company
-	(*Account)(nil),                         // 17: banka.bank.v1.Account
-	(*CreateCompanyRequest)(nil),            // 18: banka.bank.v1.CreateCompanyRequest
-	(*ListCompaniesRequest)(nil),            // 19: banka.bank.v1.ListCompaniesRequest
-	(*ListCompaniesResponse)(nil),           // 20: banka.bank.v1.ListCompaniesResponse
-	(*GetCompanyRequest)(nil),               // 21: banka.bank.v1.GetCompanyRequest
-	(*UpdateCompanyRequest)(nil),            // 22: banka.bank.v1.UpdateCompanyRequest
-	(*CreateAccountRequest)(nil),            // 23: banka.bank.v1.CreateAccountRequest
-	(*ListAccountsRequest)(nil),             // 24: banka.bank.v1.ListAccountsRequest
-	(*ListAccountsResponse)(nil),            // 25: banka.bank.v1.ListAccountsResponse
-	(*GetAccountRequest)(nil),               // 26: banka.bank.v1.GetAccountRequest
-	(*UpdateAccountLimitsRequest)(nil),      // 27: banka.bank.v1.UpdateAccountLimitsRequest
-	(*UpdateAccountNameRequest)(nil),        // 28: banka.bank.v1.UpdateAccountNameRequest
-	(*SetAccountStatusRequest)(nil),         // 29: banka.bank.v1.SetAccountStatusRequest
-	(*GetSystemAccountRequest)(nil),         // 30: banka.bank.v1.GetSystemAccountRequest
-	(*CreateFundAccountRequest)(nil),        // 31: banka.bank.v1.CreateFundAccountRequest
-	(*SettleTradeRequest)(nil),              // 32: banka.bank.v1.SettleTradeRequest
-	(*SettleTradeResponse)(nil),             // 33: banka.bank.v1.SettleTradeResponse
-	(*SettleCapitalGainsTaxRequest)(nil),    // 34: banka.bank.v1.SettleCapitalGainsTaxRequest
-	(*SettleCapitalGainsTaxResponse)(nil),   // 35: banka.bank.v1.SettleCapitalGainsTaxResponse
-	(*SettleDividendRequest)(nil),           // 36: banka.bank.v1.SettleDividendRequest
-	(*SettleDividendResponse)(nil),          // 37: banka.bank.v1.SettleDividendResponse
-	(*SettleForexFillRequest)(nil),          // 38: banka.bank.v1.SettleForexFillRequest
-	(*SettleForexFillResponse)(nil),         // 39: banka.bank.v1.SettleForexFillResponse
-	(*ReserveFundsRequest)(nil),             // 40: banka.bank.v1.ReserveFundsRequest
-	(*ReserveFundsResponse)(nil),            // 41: banka.bank.v1.ReserveFundsResponse
-	(*ReleaseFundsRequest)(nil),             // 42: banka.bank.v1.ReleaseFundsRequest
-	(*ReleaseFundsResponse)(nil),            // 43: banka.bank.v1.ReleaseFundsResponse
-	(*CommitReservedFundsRequest)(nil),      // 44: banka.bank.v1.CommitReservedFundsRequest
-	(*CommitReservedFundsResponse)(nil),     // 45: banka.bank.v1.CommitReservedFundsResponse
-	(*TransferBetweenClientsRequest)(nil),   // 46: banka.bank.v1.TransferBetweenClientsRequest
-	(*TransferBetweenClientsResponse)(nil),  // 47: banka.bank.v1.TransferBetweenClientsResponse
-	(*Transaction)(nil),                     // 48: banka.bank.v1.Transaction
-	(*CreatePaymentRequest)(nil),            // 49: banka.bank.v1.CreatePaymentRequest
-	(*CreateTransferRequest)(nil),           // 50: banka.bank.v1.CreateTransferRequest
-	(*PaymentResult)(nil),                   // 51: banka.bank.v1.PaymentResult
-	(*QuoteExchangeRequest)(nil),            // 52: banka.bank.v1.QuoteExchangeRequest
-	(*QuoteExchangeResponse)(nil),           // 53: banka.bank.v1.QuoteExchangeResponse
-	(*ListTransactionsRequest)(nil),         // 54: banka.bank.v1.ListTransactionsRequest
-	(*ListTransactionsResponse)(nil),        // 55: banka.bank.v1.ListTransactionsResponse
-	(*PaymentRecipient)(nil),                // 56: banka.bank.v1.PaymentRecipient
-	(*CreatePaymentRecipientRequest)(nil),   // 57: banka.bank.v1.CreatePaymentRecipientRequest
-	(*ListPaymentRecipientsRequest)(nil),    // 58: banka.bank.v1.ListPaymentRecipientsRequest
-	(*ListPaymentRecipientsResponse)(nil),   // 59: banka.bank.v1.ListPaymentRecipientsResponse
-	(*UpdatePaymentRecipientRequest)(nil),   // 60: banka.bank.v1.UpdatePaymentRecipientRequest
-	(*DeletePaymentRecipientRequest)(nil),   // 61: banka.bank.v1.DeletePaymentRecipientRequest
-	(*ScheduledPayment)(nil),                // 62: banka.bank.v1.ScheduledPayment
-	(*SchedulePaymentRequest)(nil),          // 63: banka.bank.v1.SchedulePaymentRequest
-	(*ListScheduledPaymentsRequest)(nil),    // 64: banka.bank.v1.ListScheduledPaymentsRequest
-	(*ListScheduledPaymentsResponse)(nil),   // 65: banka.bank.v1.ListScheduledPaymentsResponse
-	(*CancelScheduledPaymentRequest)(nil),   // 66: banka.bank.v1.CancelScheduledPaymentRequest
-	(*RunDueScheduledPaymentsRequest)(nil),  // 67: banka.bank.v1.RunDueScheduledPaymentsRequest
-	(*RunDueScheduledPaymentsResponse)(nil), // 68: banka.bank.v1.RunDueScheduledPaymentsResponse
-	(*Card)(nil),                            // 69: banka.bank.v1.Card
-	(*CreateCardRequest)(nil),               // 70: banka.bank.v1.CreateCardRequest
-	(*ListCardsRequest)(nil),                // 71: banka.bank.v1.ListCardsRequest
-	(*ListCardsResponse)(nil),               // 72: banka.bank.v1.ListCardsResponse
-	(*SetCardStatusRequest)(nil),            // 73: banka.bank.v1.SetCardStatusRequest
-	(*UpdateCardLimitRequest)(nil),          // 74: banka.bank.v1.UpdateCardLimitRequest
-	(*AuthorizedPerson)(nil),                // 75: banka.bank.v1.AuthorizedPerson
-	(*CreateAuthorizedPersonRequest)(nil),   // 76: banka.bank.v1.CreateAuthorizedPersonRequest
-	(*ListAuthorizedPersonsRequest)(nil),    // 77: banka.bank.v1.ListAuthorizedPersonsRequest
-	(*ListAuthorizedPersonsResponse)(nil),   // 78: banka.bank.v1.ListAuthorizedPersonsResponse
-	(*LoanRequest)(nil),                     // 79: banka.bank.v1.LoanRequest
-	(*Loan)(nil),                            // 80: banka.bank.v1.Loan
-	(*LoanInstallment)(nil),                 // 81: banka.bank.v1.LoanInstallment
-	(*LoanWithInstallments)(nil),            // 82: banka.bank.v1.LoanWithInstallments
-	(*SubmitLoanRequestRequest)(nil),        // 83: banka.bank.v1.SubmitLoanRequestRequest
-	(*ListLoanRequestsRequest)(nil),         // 84: banka.bank.v1.ListLoanRequestsRequest
-	(*ListLoanRequestsResponse)(nil),        // 85: banka.bank.v1.ListLoanRequestsResponse
-	(*DecideLoanRequestRequest)(nil),        // 86: banka.bank.v1.DecideLoanRequestRequest
-	(*ListLoansRequest)(nil),                // 87: banka.bank.v1.ListLoansRequest
-	(*ListLoansResponse)(nil),               // 88: banka.bank.v1.ListLoansResponse
-	(*GetLoanRequest)(nil),                  // 89: banka.bank.v1.GetLoanRequest
-	(*RunInstallmentJobRequest)(nil),        // 90: banka.bank.v1.RunInstallmentJobRequest
-	(*RunInstallmentJobResponse)(nil),       // 91: banka.bank.v1.RunInstallmentJobResponse
-	(*RunVariableRateJobRequest)(nil),       // 92: banka.bank.v1.RunVariableRateJobRequest
-	(*RunVariableRateJobResponse)(nil),      // 93: banka.bank.v1.RunVariableRateJobResponse
-	(*RunMaintenanceFeeJobRequest)(nil),     // 94: banka.bank.v1.RunMaintenanceFeeJobRequest
-	(*RunMaintenanceFeeJobResponse)(nil),    // 95: banka.bank.v1.RunMaintenanceFeeJobResponse
-	(*RunSpentResetJobRequest)(nil),         // 96: banka.bank.v1.RunSpentResetJobRequest
-	(*RunSpentResetJobResponse)(nil),        // 97: banka.bank.v1.RunSpentResetJobResponse
-	(*timestamppb.Timestamp)(nil),           // 98: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                   // 99: google.protobuf.Empty
+	(Currency)(0),                             // 0: banka.bank.v1.Currency
+	(AccountKind)(0),                          // 1: banka.bank.v1.AccountKind
+	(AccountSubtype)(0),                       // 2: banka.bank.v1.AccountSubtype
+	(AccountStatus)(0),                        // 3: banka.bank.v1.AccountStatus
+	(TransactionStatus)(0),                    // 4: banka.bank.v1.TransactionStatus
+	(TransactionKind)(0),                      // 5: banka.bank.v1.TransactionKind
+	(ScheduledPaymentStatus)(0),               // 6: banka.bank.v1.ScheduledPaymentStatus
+	(CardBrand)(0),                            // 7: banka.bank.v1.CardBrand
+	(CardStatus)(0),                           // 8: banka.bank.v1.CardStatus
+	(Gender)(0),                               // 9: banka.bank.v1.Gender
+	(LoanType)(0),                             // 10: banka.bank.v1.LoanType
+	(InterestType)(0),                         // 11: banka.bank.v1.InterestType
+	(EmploymentStatus)(0),                     // 12: banka.bank.v1.EmploymentStatus
+	(LoanRequestStatus)(0),                    // 13: banka.bank.v1.LoanRequestStatus
+	(LoanStatus)(0),                           // 14: banka.bank.v1.LoanStatus
+	(InstallmentStatus)(0),                    // 15: banka.bank.v1.InstallmentStatus
+	(ForexForwardStatus)(0),                   // 16: banka.bank.v1.ForexForwardStatus
+	(*Company)(nil),                           // 17: banka.bank.v1.Company
+	(*Account)(nil),                           // 18: banka.bank.v1.Account
+	(*CreateCompanyRequest)(nil),              // 19: banka.bank.v1.CreateCompanyRequest
+	(*ListCompaniesRequest)(nil),              // 20: banka.bank.v1.ListCompaniesRequest
+	(*ListCompaniesResponse)(nil),             // 21: banka.bank.v1.ListCompaniesResponse
+	(*GetCompanyRequest)(nil),                 // 22: banka.bank.v1.GetCompanyRequest
+	(*UpdateCompanyRequest)(nil),              // 23: banka.bank.v1.UpdateCompanyRequest
+	(*CreateAccountRequest)(nil),              // 24: banka.bank.v1.CreateAccountRequest
+	(*ListAccountsRequest)(nil),               // 25: banka.bank.v1.ListAccountsRequest
+	(*ListAccountsResponse)(nil),              // 26: banka.bank.v1.ListAccountsResponse
+	(*GetAccountRequest)(nil),                 // 27: banka.bank.v1.GetAccountRequest
+	(*UpdateAccountLimitsRequest)(nil),        // 28: banka.bank.v1.UpdateAccountLimitsRequest
+	(*UpdateAccountNameRequest)(nil),          // 29: banka.bank.v1.UpdateAccountNameRequest
+	(*SetAccountStatusRequest)(nil),           // 30: banka.bank.v1.SetAccountStatusRequest
+	(*GetSystemAccountRequest)(nil),           // 31: banka.bank.v1.GetSystemAccountRequest
+	(*CreateFundAccountRequest)(nil),          // 32: banka.bank.v1.CreateFundAccountRequest
+	(*SettleTradeRequest)(nil),                // 33: banka.bank.v1.SettleTradeRequest
+	(*SettleTradeResponse)(nil),               // 34: banka.bank.v1.SettleTradeResponse
+	(*SettleCapitalGainsTaxRequest)(nil),      // 35: banka.bank.v1.SettleCapitalGainsTaxRequest
+	(*SettleCapitalGainsTaxResponse)(nil),     // 36: banka.bank.v1.SettleCapitalGainsTaxResponse
+	(*SettleDividendRequest)(nil),             // 37: banka.bank.v1.SettleDividendRequest
+	(*SettleDividendResponse)(nil),            // 38: banka.bank.v1.SettleDividendResponse
+	(*SettleForexFillRequest)(nil),            // 39: banka.bank.v1.SettleForexFillRequest
+	(*SettleForexFillResponse)(nil),           // 40: banka.bank.v1.SettleForexFillResponse
+	(*ReserveFundsRequest)(nil),               // 41: banka.bank.v1.ReserveFundsRequest
+	(*ReserveFundsResponse)(nil),              // 42: banka.bank.v1.ReserveFundsResponse
+	(*ReleaseFundsRequest)(nil),               // 43: banka.bank.v1.ReleaseFundsRequest
+	(*ReleaseFundsResponse)(nil),              // 44: banka.bank.v1.ReleaseFundsResponse
+	(*CommitReservedFundsRequest)(nil),        // 45: banka.bank.v1.CommitReservedFundsRequest
+	(*CommitReservedFundsResponse)(nil),       // 46: banka.bank.v1.CommitReservedFundsResponse
+	(*TransferBetweenClientsRequest)(nil),     // 47: banka.bank.v1.TransferBetweenClientsRequest
+	(*TransferBetweenClientsResponse)(nil),    // 48: banka.bank.v1.TransferBetweenClientsResponse
+	(*Transaction)(nil),                       // 49: banka.bank.v1.Transaction
+	(*CreatePaymentRequest)(nil),              // 50: banka.bank.v1.CreatePaymentRequest
+	(*CreateTransferRequest)(nil),             // 51: banka.bank.v1.CreateTransferRequest
+	(*PaymentResult)(nil),                     // 52: banka.bank.v1.PaymentResult
+	(*QuoteExchangeRequest)(nil),              // 53: banka.bank.v1.QuoteExchangeRequest
+	(*QuoteExchangeResponse)(nil),             // 54: banka.bank.v1.QuoteExchangeResponse
+	(*ListTransactionsRequest)(nil),           // 55: banka.bank.v1.ListTransactionsRequest
+	(*ListTransactionsResponse)(nil),          // 56: banka.bank.v1.ListTransactionsResponse
+	(*PaymentRecipient)(nil),                  // 57: banka.bank.v1.PaymentRecipient
+	(*CreatePaymentRecipientRequest)(nil),     // 58: banka.bank.v1.CreatePaymentRecipientRequest
+	(*ListPaymentRecipientsRequest)(nil),      // 59: banka.bank.v1.ListPaymentRecipientsRequest
+	(*ListPaymentRecipientsResponse)(nil),     // 60: banka.bank.v1.ListPaymentRecipientsResponse
+	(*UpdatePaymentRecipientRequest)(nil),     // 61: banka.bank.v1.UpdatePaymentRecipientRequest
+	(*DeletePaymentRecipientRequest)(nil),     // 62: banka.bank.v1.DeletePaymentRecipientRequest
+	(*ScheduledPayment)(nil),                  // 63: banka.bank.v1.ScheduledPayment
+	(*SchedulePaymentRequest)(nil),            // 64: banka.bank.v1.SchedulePaymentRequest
+	(*ListScheduledPaymentsRequest)(nil),      // 65: banka.bank.v1.ListScheduledPaymentsRequest
+	(*ListScheduledPaymentsResponse)(nil),     // 66: banka.bank.v1.ListScheduledPaymentsResponse
+	(*CancelScheduledPaymentRequest)(nil),     // 67: banka.bank.v1.CancelScheduledPaymentRequest
+	(*RunDueScheduledPaymentsRequest)(nil),    // 68: banka.bank.v1.RunDueScheduledPaymentsRequest
+	(*RunDueScheduledPaymentsResponse)(nil),   // 69: banka.bank.v1.RunDueScheduledPaymentsResponse
+	(*Card)(nil),                              // 70: banka.bank.v1.Card
+	(*CreateCardRequest)(nil),                 // 71: banka.bank.v1.CreateCardRequest
+	(*ListCardsRequest)(nil),                  // 72: banka.bank.v1.ListCardsRequest
+	(*ListCardsResponse)(nil),                 // 73: banka.bank.v1.ListCardsResponse
+	(*SetCardStatusRequest)(nil),              // 74: banka.bank.v1.SetCardStatusRequest
+	(*UpdateCardLimitRequest)(nil),            // 75: banka.bank.v1.UpdateCardLimitRequest
+	(*AuthorizedPerson)(nil),                  // 76: banka.bank.v1.AuthorizedPerson
+	(*CreateAuthorizedPersonRequest)(nil),     // 77: banka.bank.v1.CreateAuthorizedPersonRequest
+	(*ListAuthorizedPersonsRequest)(nil),      // 78: banka.bank.v1.ListAuthorizedPersonsRequest
+	(*ListAuthorizedPersonsResponse)(nil),     // 79: banka.bank.v1.ListAuthorizedPersonsResponse
+	(*LoanRequest)(nil),                       // 80: banka.bank.v1.LoanRequest
+	(*Loan)(nil),                              // 81: banka.bank.v1.Loan
+	(*LoanInstallment)(nil),                   // 82: banka.bank.v1.LoanInstallment
+	(*LoanWithInstallments)(nil),              // 83: banka.bank.v1.LoanWithInstallments
+	(*SubmitLoanRequestRequest)(nil),          // 84: banka.bank.v1.SubmitLoanRequestRequest
+	(*ListLoanRequestsRequest)(nil),           // 85: banka.bank.v1.ListLoanRequestsRequest
+	(*ListLoanRequestsResponse)(nil),          // 86: banka.bank.v1.ListLoanRequestsResponse
+	(*DecideLoanRequestRequest)(nil),          // 87: banka.bank.v1.DecideLoanRequestRequest
+	(*ListLoansRequest)(nil),                  // 88: banka.bank.v1.ListLoansRequest
+	(*ListLoansResponse)(nil),                 // 89: banka.bank.v1.ListLoansResponse
+	(*GetLoanRequest)(nil),                    // 90: banka.bank.v1.GetLoanRequest
+	(*RunInstallmentJobRequest)(nil),          // 91: banka.bank.v1.RunInstallmentJobRequest
+	(*RunInstallmentJobResponse)(nil),         // 92: banka.bank.v1.RunInstallmentJobResponse
+	(*RunVariableRateJobRequest)(nil),         // 93: banka.bank.v1.RunVariableRateJobRequest
+	(*RunVariableRateJobResponse)(nil),        // 94: banka.bank.v1.RunVariableRateJobResponse
+	(*RunMaintenanceFeeJobRequest)(nil),       // 95: banka.bank.v1.RunMaintenanceFeeJobRequest
+	(*RunMaintenanceFeeJobResponse)(nil),      // 96: banka.bank.v1.RunMaintenanceFeeJobResponse
+	(*RunSpentResetJobRequest)(nil),           // 97: banka.bank.v1.RunSpentResetJobRequest
+	(*RunSpentResetJobResponse)(nil),          // 98: banka.bank.v1.RunSpentResetJobResponse
+	(*ForexForward)(nil),                      // 99: banka.bank.v1.ForexForward
+	(*ForexForwardSpread)(nil),                // 100: banka.bank.v1.ForexForwardSpread
+	(*ForexForwardQuote)(nil),                 // 101: banka.bank.v1.ForexForwardQuote
+	(*QuoteForexForwardRequest)(nil),          // 102: banka.bank.v1.QuoteForexForwardRequest
+	(*CreateForexForwardRequest)(nil),         // 103: banka.bank.v1.CreateForexForwardRequest
+	(*ListForexForwardsRequest)(nil),          // 104: banka.bank.v1.ListForexForwardsRequest
+	(*ListForexForwardsResponse)(nil),         // 105: banka.bank.v1.ListForexForwardsResponse
+	(*CancelForexForwardRequest)(nil),         // 106: banka.bank.v1.CancelForexForwardRequest
+	(*GetForexForwardSpreadsRequest)(nil),     // 107: banka.bank.v1.GetForexForwardSpreadsRequest
+	(*GetForexForwardSpreadsResponse)(nil),    // 108: banka.bank.v1.GetForexForwardSpreadsResponse
+	(*SetForexForwardSpreadRequest)(nil),      // 109: banka.bank.v1.SetForexForwardSpreadRequest
+	(*RunForexForwardSettlementRequest)(nil),  // 110: banka.bank.v1.RunForexForwardSettlementRequest
+	(*RunForexForwardSettlementResponse)(nil), // 111: banka.bank.v1.RunForexForwardSettlementResponse
+	(*timestamppb.Timestamp)(nil),             // 112: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                     // 113: google.protobuf.Empty
 }
 var file_bank_v1_bank_proto_depIdxs = []int32{
-	98,  // 0: banka.bank.v1.Company.created_at:type_name -> google.protobuf.Timestamp
-	98,  // 1: banka.bank.v1.Company.updated_at:type_name -> google.protobuf.Timestamp
+	112, // 0: banka.bank.v1.Company.created_at:type_name -> google.protobuf.Timestamp
+	112, // 1: banka.bank.v1.Company.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 2: banka.bank.v1.Account.kind:type_name -> banka.bank.v1.AccountKind
 	2,   // 3: banka.bank.v1.Account.subtype:type_name -> banka.bank.v1.AccountSubtype
 	0,   // 4: banka.bank.v1.Account.currency:type_name -> banka.bank.v1.Currency
 	3,   // 5: banka.bank.v1.Account.status:type_name -> banka.bank.v1.AccountStatus
-	98,  // 6: banka.bank.v1.Account.created_at:type_name -> google.protobuf.Timestamp
-	98,  // 7: banka.bank.v1.Account.expires_at:type_name -> google.protobuf.Timestamp
-	98,  // 8: banka.bank.v1.Account.updated_at:type_name -> google.protobuf.Timestamp
-	16,  // 9: banka.bank.v1.ListCompaniesResponse.companies:type_name -> banka.bank.v1.Company
+	112, // 6: banka.bank.v1.Account.created_at:type_name -> google.protobuf.Timestamp
+	112, // 7: banka.bank.v1.Account.expires_at:type_name -> google.protobuf.Timestamp
+	112, // 8: banka.bank.v1.Account.updated_at:type_name -> google.protobuf.Timestamp
+	17,  // 9: banka.bank.v1.ListCompaniesResponse.companies:type_name -> banka.bank.v1.Company
 	1,   // 10: banka.bank.v1.CreateAccountRequest.kind:type_name -> banka.bank.v1.AccountKind
 	2,   // 11: banka.bank.v1.CreateAccountRequest.subtype:type_name -> banka.bank.v1.AccountSubtype
 	0,   // 12: banka.bank.v1.CreateAccountRequest.currency:type_name -> banka.bank.v1.Currency
 	1,   // 13: banka.bank.v1.ListAccountsRequest.kind:type_name -> banka.bank.v1.AccountKind
 	0,   // 14: banka.bank.v1.ListAccountsRequest.currency:type_name -> banka.bank.v1.Currency
 	3,   // 15: banka.bank.v1.ListAccountsRequest.status:type_name -> banka.bank.v1.AccountStatus
-	17,  // 16: banka.bank.v1.ListAccountsResponse.accounts:type_name -> banka.bank.v1.Account
+	18,  // 16: banka.bank.v1.ListAccountsResponse.accounts:type_name -> banka.bank.v1.Account
 	3,   // 17: banka.bank.v1.SetAccountStatusRequest.status:type_name -> banka.bank.v1.AccountStatus
 	0,   // 18: banka.bank.v1.GetSystemAccountRequest.currency:type_name -> banka.bank.v1.Currency
 	0,   // 19: banka.bank.v1.CreateFundAccountRequest.currency:type_name -> banka.bank.v1.Currency
 	0,   // 20: banka.bank.v1.SettleTradeRequest.currency:type_name -> banka.bank.v1.Currency
-	48,  // 21: banka.bank.v1.SettleTradeResponse.transactions:type_name -> banka.bank.v1.Transaction
-	48,  // 22: banka.bank.v1.SettleCapitalGainsTaxResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 21: banka.bank.v1.SettleTradeResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 22: banka.bank.v1.SettleCapitalGainsTaxResponse.transactions:type_name -> banka.bank.v1.Transaction
 	0,   // 23: banka.bank.v1.SettleDividendRequest.currency:type_name -> banka.bank.v1.Currency
-	48,  // 24: banka.bank.v1.SettleDividendResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 24: banka.bank.v1.SettleDividendResponse.transactions:type_name -> banka.bank.v1.Transaction
 	0,   // 25: banka.bank.v1.SettleForexFillRequest.base_currency:type_name -> banka.bank.v1.Currency
 	0,   // 26: banka.bank.v1.SettleForexFillRequest.quote_currency:type_name -> banka.bank.v1.Currency
-	48,  // 27: banka.bank.v1.SettleForexFillResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 27: banka.bank.v1.SettleForexFillResponse.transactions:type_name -> banka.bank.v1.Transaction
 	0,   // 28: banka.bank.v1.ReserveFundsRequest.currency:type_name -> banka.bank.v1.Currency
 	0,   // 29: banka.bank.v1.CommitReservedFundsRequest.dest_currency:type_name -> banka.bank.v1.Currency
-	48,  // 30: banka.bank.v1.CommitReservedFundsResponse.transactions:type_name -> banka.bank.v1.Transaction
-	48,  // 31: banka.bank.v1.TransferBetweenClientsResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 30: banka.bank.v1.CommitReservedFundsResponse.transactions:type_name -> banka.bank.v1.Transaction
+	49,  // 31: banka.bank.v1.TransferBetweenClientsResponse.transactions:type_name -> banka.bank.v1.Transaction
 	5,   // 32: banka.bank.v1.Transaction.kind:type_name -> banka.bank.v1.TransactionKind
 	4,   // 33: banka.bank.v1.Transaction.status:type_name -> banka.bank.v1.TransactionStatus
-	98,  // 34: banka.bank.v1.Transaction.created_at:type_name -> google.protobuf.Timestamp
-	48,  // 35: banka.bank.v1.PaymentResult.transactions:type_name -> banka.bank.v1.Transaction
+	112, // 34: banka.bank.v1.Transaction.created_at:type_name -> google.protobuf.Timestamp
+	49,  // 35: banka.bank.v1.PaymentResult.transactions:type_name -> banka.bank.v1.Transaction
 	4,   // 36: banka.bank.v1.PaymentResult.status:type_name -> banka.bank.v1.TransactionStatus
 	0,   // 37: banka.bank.v1.QuoteExchangeRequest.from:type_name -> banka.bank.v1.Currency
 	0,   // 38: banka.bank.v1.QuoteExchangeRequest.to:type_name -> banka.bank.v1.Currency
-	98,  // 39: banka.bank.v1.ListTransactionsRequest.from:type_name -> google.protobuf.Timestamp
-	98,  // 40: banka.bank.v1.ListTransactionsRequest.to:type_name -> google.protobuf.Timestamp
-	48,  // 41: banka.bank.v1.ListTransactionsResponse.transactions:type_name -> banka.bank.v1.Transaction
-	98,  // 42: banka.bank.v1.PaymentRecipient.created_at:type_name -> google.protobuf.Timestamp
-	56,  // 43: banka.bank.v1.ListPaymentRecipientsResponse.recipients:type_name -> banka.bank.v1.PaymentRecipient
+	112, // 39: banka.bank.v1.ListTransactionsRequest.from:type_name -> google.protobuf.Timestamp
+	112, // 40: banka.bank.v1.ListTransactionsRequest.to:type_name -> google.protobuf.Timestamp
+	49,  // 41: banka.bank.v1.ListTransactionsResponse.transactions:type_name -> banka.bank.v1.Transaction
+	112, // 42: banka.bank.v1.PaymentRecipient.created_at:type_name -> google.protobuf.Timestamp
+	57,  // 43: banka.bank.v1.ListPaymentRecipientsResponse.recipients:type_name -> banka.bank.v1.PaymentRecipient
 	0,   // 44: banka.bank.v1.ScheduledPayment.currency:type_name -> banka.bank.v1.Currency
-	98,  // 45: banka.bank.v1.ScheduledPayment.scheduled_date:type_name -> google.protobuf.Timestamp
+	112, // 45: banka.bank.v1.ScheduledPayment.scheduled_date:type_name -> google.protobuf.Timestamp
 	6,   // 46: banka.bank.v1.ScheduledPayment.status:type_name -> banka.bank.v1.ScheduledPaymentStatus
-	98,  // 47: banka.bank.v1.ScheduledPayment.created_at:type_name -> google.protobuf.Timestamp
-	98,  // 48: banka.bank.v1.ScheduledPayment.executed_at:type_name -> google.protobuf.Timestamp
-	98,  // 49: banka.bank.v1.SchedulePaymentRequest.scheduled_date:type_name -> google.protobuf.Timestamp
-	62,  // 50: banka.bank.v1.ListScheduledPaymentsResponse.scheduled_payments:type_name -> banka.bank.v1.ScheduledPayment
+	112, // 47: banka.bank.v1.ScheduledPayment.created_at:type_name -> google.protobuf.Timestamp
+	112, // 48: banka.bank.v1.ScheduledPayment.executed_at:type_name -> google.protobuf.Timestamp
+	112, // 49: banka.bank.v1.SchedulePaymentRequest.scheduled_date:type_name -> google.protobuf.Timestamp
+	63,  // 50: banka.bank.v1.ListScheduledPaymentsResponse.scheduled_payments:type_name -> banka.bank.v1.ScheduledPayment
 	7,   // 51: banka.bank.v1.Card.brand:type_name -> banka.bank.v1.CardBrand
 	8,   // 52: banka.bank.v1.Card.status:type_name -> banka.bank.v1.CardStatus
-	98,  // 53: banka.bank.v1.Card.expires_at:type_name -> google.protobuf.Timestamp
-	98,  // 54: banka.bank.v1.Card.created_at:type_name -> google.protobuf.Timestamp
-	98,  // 55: banka.bank.v1.Card.updated_at:type_name -> google.protobuf.Timestamp
+	112, // 53: banka.bank.v1.Card.expires_at:type_name -> google.protobuf.Timestamp
+	112, // 54: banka.bank.v1.Card.created_at:type_name -> google.protobuf.Timestamp
+	112, // 55: banka.bank.v1.Card.updated_at:type_name -> google.protobuf.Timestamp
 	7,   // 56: banka.bank.v1.CreateCardRequest.brand:type_name -> banka.bank.v1.CardBrand
-	69,  // 57: banka.bank.v1.ListCardsResponse.cards:type_name -> banka.bank.v1.Card
+	70,  // 57: banka.bank.v1.ListCardsResponse.cards:type_name -> banka.bank.v1.Card
 	8,   // 58: banka.bank.v1.SetCardStatusRequest.status:type_name -> banka.bank.v1.CardStatus
 	9,   // 59: banka.bank.v1.AuthorizedPerson.gender:type_name -> banka.bank.v1.Gender
-	98,  // 60: banka.bank.v1.AuthorizedPerson.created_at:type_name -> google.protobuf.Timestamp
-	98,  // 61: banka.bank.v1.AuthorizedPerson.updated_at:type_name -> google.protobuf.Timestamp
+	112, // 60: banka.bank.v1.AuthorizedPerson.created_at:type_name -> google.protobuf.Timestamp
+	112, // 61: banka.bank.v1.AuthorizedPerson.updated_at:type_name -> google.protobuf.Timestamp
 	9,   // 62: banka.bank.v1.CreateAuthorizedPersonRequest.gender:type_name -> banka.bank.v1.Gender
-	75,  // 63: banka.bank.v1.ListAuthorizedPersonsResponse.authorized_persons:type_name -> banka.bank.v1.AuthorizedPerson
+	76,  // 63: banka.bank.v1.ListAuthorizedPersonsResponse.authorized_persons:type_name -> banka.bank.v1.AuthorizedPerson
 	10,  // 64: banka.bank.v1.LoanRequest.loan_type:type_name -> banka.bank.v1.LoanType
 	11,  // 65: banka.bank.v1.LoanRequest.interest_type:type_name -> banka.bank.v1.InterestType
 	0,   // 66: banka.bank.v1.LoanRequest.currency:type_name -> banka.bank.v1.Currency
 	12,  // 67: banka.bank.v1.LoanRequest.employment_status:type_name -> banka.bank.v1.EmploymentStatus
 	13,  // 68: banka.bank.v1.LoanRequest.status:type_name -> banka.bank.v1.LoanRequestStatus
-	98,  // 69: banka.bank.v1.LoanRequest.decided_at:type_name -> google.protobuf.Timestamp
-	98,  // 70: banka.bank.v1.LoanRequest.created_at:type_name -> google.protobuf.Timestamp
+	112, // 69: banka.bank.v1.LoanRequest.decided_at:type_name -> google.protobuf.Timestamp
+	112, // 70: banka.bank.v1.LoanRequest.created_at:type_name -> google.protobuf.Timestamp
 	10,  // 71: banka.bank.v1.Loan.loan_type:type_name -> banka.bank.v1.LoanType
 	11,  // 72: banka.bank.v1.Loan.interest_type:type_name -> banka.bank.v1.InterestType
 	0,   // 73: banka.bank.v1.Loan.currency:type_name -> banka.bank.v1.Currency
 	14,  // 74: banka.bank.v1.Loan.status:type_name -> banka.bank.v1.LoanStatus
-	98,  // 75: banka.bank.v1.Loan.contracted_at:type_name -> google.protobuf.Timestamp
+	112, // 75: banka.bank.v1.Loan.contracted_at:type_name -> google.protobuf.Timestamp
 	0,   // 76: banka.bank.v1.LoanInstallment.currency:type_name -> banka.bank.v1.Currency
-	98,  // 77: banka.bank.v1.LoanInstallment.actual_paid_at:type_name -> google.protobuf.Timestamp
+	112, // 77: banka.bank.v1.LoanInstallment.actual_paid_at:type_name -> google.protobuf.Timestamp
 	15,  // 78: banka.bank.v1.LoanInstallment.status:type_name -> banka.bank.v1.InstallmentStatus
-	80,  // 79: banka.bank.v1.LoanWithInstallments.loan:type_name -> banka.bank.v1.Loan
-	81,  // 80: banka.bank.v1.LoanWithInstallments.installments:type_name -> banka.bank.v1.LoanInstallment
+	81,  // 79: banka.bank.v1.LoanWithInstallments.loan:type_name -> banka.bank.v1.Loan
+	82,  // 80: banka.bank.v1.LoanWithInstallments.installments:type_name -> banka.bank.v1.LoanInstallment
 	10,  // 81: banka.bank.v1.SubmitLoanRequestRequest.loan_type:type_name -> banka.bank.v1.LoanType
 	11,  // 82: banka.bank.v1.SubmitLoanRequestRequest.interest_type:type_name -> banka.bank.v1.InterestType
 	0,   // 83: banka.bank.v1.SubmitLoanRequestRequest.currency:type_name -> banka.bank.v1.Currency
 	12,  // 84: banka.bank.v1.SubmitLoanRequestRequest.employment_status:type_name -> banka.bank.v1.EmploymentStatus
 	13,  // 85: banka.bank.v1.ListLoanRequestsRequest.status:type_name -> banka.bank.v1.LoanRequestStatus
 	10,  // 86: banka.bank.v1.ListLoanRequestsRequest.loan_type:type_name -> banka.bank.v1.LoanType
-	79,  // 87: banka.bank.v1.ListLoanRequestsResponse.requests:type_name -> banka.bank.v1.LoanRequest
+	80,  // 87: banka.bank.v1.ListLoanRequestsResponse.requests:type_name -> banka.bank.v1.LoanRequest
 	10,  // 88: banka.bank.v1.ListLoansRequest.loan_type:type_name -> banka.bank.v1.LoanType
 	14,  // 89: banka.bank.v1.ListLoansRequest.status:type_name -> banka.bank.v1.LoanStatus
-	80,  // 90: banka.bank.v1.ListLoansResponse.loans:type_name -> banka.bank.v1.Loan
-	18,  // 91: banka.bank.v1.BankService.CreateCompany:input_type -> banka.bank.v1.CreateCompanyRequest
-	19,  // 92: banka.bank.v1.BankService.ListCompanies:input_type -> banka.bank.v1.ListCompaniesRequest
-	21,  // 93: banka.bank.v1.BankService.GetCompany:input_type -> banka.bank.v1.GetCompanyRequest
-	22,  // 94: banka.bank.v1.BankService.UpdateCompany:input_type -> banka.bank.v1.UpdateCompanyRequest
-	23,  // 95: banka.bank.v1.BankService.CreateAccount:input_type -> banka.bank.v1.CreateAccountRequest
-	24,  // 96: banka.bank.v1.BankService.ListAccounts:input_type -> banka.bank.v1.ListAccountsRequest
-	26,  // 97: banka.bank.v1.BankService.GetAccount:input_type -> banka.bank.v1.GetAccountRequest
-	27,  // 98: banka.bank.v1.BankService.UpdateAccountLimits:input_type -> banka.bank.v1.UpdateAccountLimitsRequest
-	28,  // 99: banka.bank.v1.BankService.UpdateAccountName:input_type -> banka.bank.v1.UpdateAccountNameRequest
-	29,  // 100: banka.bank.v1.BankService.SetAccountStatus:input_type -> banka.bank.v1.SetAccountStatusRequest
-	30,  // 101: banka.bank.v1.BankService.GetSystemAccount:input_type -> banka.bank.v1.GetSystemAccountRequest
-	32,  // 102: banka.bank.v1.BankService.SettleTrade:input_type -> banka.bank.v1.SettleTradeRequest
-	34,  // 103: banka.bank.v1.BankService.SettleCapitalGainsTax:input_type -> banka.bank.v1.SettleCapitalGainsTaxRequest
-	36,  // 104: banka.bank.v1.BankService.SettleDividend:input_type -> banka.bank.v1.SettleDividendRequest
-	38,  // 105: banka.bank.v1.BankService.SettleForexFill:input_type -> banka.bank.v1.SettleForexFillRequest
-	40,  // 106: banka.bank.v1.BankService.ReserveFunds:input_type -> banka.bank.v1.ReserveFundsRequest
-	42,  // 107: banka.bank.v1.BankService.ReleaseFunds:input_type -> banka.bank.v1.ReleaseFundsRequest
-	44,  // 108: banka.bank.v1.BankService.CommitReservedFunds:input_type -> banka.bank.v1.CommitReservedFundsRequest
-	46,  // 109: banka.bank.v1.BankService.TransferBetweenClients:input_type -> banka.bank.v1.TransferBetweenClientsRequest
-	31,  // 110: banka.bank.v1.BankService.CreateFundAccount:input_type -> banka.bank.v1.CreateFundAccountRequest
-	49,  // 111: banka.bank.v1.BankService.CreatePayment:input_type -> banka.bank.v1.CreatePaymentRequest
-	50,  // 112: banka.bank.v1.BankService.CreateTransfer:input_type -> banka.bank.v1.CreateTransferRequest
-	52,  // 113: banka.bank.v1.BankService.QuoteExchange:input_type -> banka.bank.v1.QuoteExchangeRequest
-	54,  // 114: banka.bank.v1.BankService.ListTransactions:input_type -> banka.bank.v1.ListTransactionsRequest
-	57,  // 115: banka.bank.v1.BankService.CreatePaymentRecipient:input_type -> banka.bank.v1.CreatePaymentRecipientRequest
-	58,  // 116: banka.bank.v1.BankService.ListPaymentRecipients:input_type -> banka.bank.v1.ListPaymentRecipientsRequest
-	60,  // 117: banka.bank.v1.BankService.UpdatePaymentRecipient:input_type -> banka.bank.v1.UpdatePaymentRecipientRequest
-	61,  // 118: banka.bank.v1.BankService.DeletePaymentRecipient:input_type -> banka.bank.v1.DeletePaymentRecipientRequest
-	63,  // 119: banka.bank.v1.BankService.SchedulePayment:input_type -> banka.bank.v1.SchedulePaymentRequest
-	64,  // 120: banka.bank.v1.BankService.ListScheduledPayments:input_type -> banka.bank.v1.ListScheduledPaymentsRequest
-	66,  // 121: banka.bank.v1.BankService.CancelScheduledPayment:input_type -> banka.bank.v1.CancelScheduledPaymentRequest
-	67,  // 122: banka.bank.v1.BankService.RunDueScheduledPayments:input_type -> banka.bank.v1.RunDueScheduledPaymentsRequest
-	70,  // 123: banka.bank.v1.BankService.CreateCard:input_type -> banka.bank.v1.CreateCardRequest
-	71,  // 124: banka.bank.v1.BankService.ListCards:input_type -> banka.bank.v1.ListCardsRequest
-	73,  // 125: banka.bank.v1.BankService.SetCardStatus:input_type -> banka.bank.v1.SetCardStatusRequest
-	74,  // 126: banka.bank.v1.BankService.UpdateCardLimit:input_type -> banka.bank.v1.UpdateCardLimitRequest
-	76,  // 127: banka.bank.v1.BankService.CreateAuthorizedPerson:input_type -> banka.bank.v1.CreateAuthorizedPersonRequest
-	77,  // 128: banka.bank.v1.BankService.ListAuthorizedPersons:input_type -> banka.bank.v1.ListAuthorizedPersonsRequest
-	83,  // 129: banka.bank.v1.BankService.SubmitLoanRequest:input_type -> banka.bank.v1.SubmitLoanRequestRequest
-	84,  // 130: banka.bank.v1.BankService.ListLoanRequests:input_type -> banka.bank.v1.ListLoanRequestsRequest
-	86,  // 131: banka.bank.v1.BankService.DecideLoanRequest:input_type -> banka.bank.v1.DecideLoanRequestRequest
-	87,  // 132: banka.bank.v1.BankService.ListLoans:input_type -> banka.bank.v1.ListLoansRequest
-	89,  // 133: banka.bank.v1.BankService.GetLoan:input_type -> banka.bank.v1.GetLoanRequest
-	90,  // 134: banka.bank.v1.BankService.RunInstallmentJob:input_type -> banka.bank.v1.RunInstallmentJobRequest
-	92,  // 135: banka.bank.v1.BankService.RunVariableRateJob:input_type -> banka.bank.v1.RunVariableRateJobRequest
-	94,  // 136: banka.bank.v1.BankService.RunMaintenanceFeeJob:input_type -> banka.bank.v1.RunMaintenanceFeeJobRequest
-	96,  // 137: banka.bank.v1.BankService.RunSpentResetJob:input_type -> banka.bank.v1.RunSpentResetJobRequest
-	16,  // 138: banka.bank.v1.BankService.CreateCompany:output_type -> banka.bank.v1.Company
-	20,  // 139: banka.bank.v1.BankService.ListCompanies:output_type -> banka.bank.v1.ListCompaniesResponse
-	16,  // 140: banka.bank.v1.BankService.GetCompany:output_type -> banka.bank.v1.Company
-	16,  // 141: banka.bank.v1.BankService.UpdateCompany:output_type -> banka.bank.v1.Company
-	17,  // 142: banka.bank.v1.BankService.CreateAccount:output_type -> banka.bank.v1.Account
-	25,  // 143: banka.bank.v1.BankService.ListAccounts:output_type -> banka.bank.v1.ListAccountsResponse
-	17,  // 144: banka.bank.v1.BankService.GetAccount:output_type -> banka.bank.v1.Account
-	17,  // 145: banka.bank.v1.BankService.UpdateAccountLimits:output_type -> banka.bank.v1.Account
-	17,  // 146: banka.bank.v1.BankService.UpdateAccountName:output_type -> banka.bank.v1.Account
-	17,  // 147: banka.bank.v1.BankService.SetAccountStatus:output_type -> banka.bank.v1.Account
-	17,  // 148: banka.bank.v1.BankService.GetSystemAccount:output_type -> banka.bank.v1.Account
-	33,  // 149: banka.bank.v1.BankService.SettleTrade:output_type -> banka.bank.v1.SettleTradeResponse
-	35,  // 150: banka.bank.v1.BankService.SettleCapitalGainsTax:output_type -> banka.bank.v1.SettleCapitalGainsTaxResponse
-	37,  // 151: banka.bank.v1.BankService.SettleDividend:output_type -> banka.bank.v1.SettleDividendResponse
-	39,  // 152: banka.bank.v1.BankService.SettleForexFill:output_type -> banka.bank.v1.SettleForexFillResponse
-	41,  // 153: banka.bank.v1.BankService.ReserveFunds:output_type -> banka.bank.v1.ReserveFundsResponse
-	43,  // 154: banka.bank.v1.BankService.ReleaseFunds:output_type -> banka.bank.v1.ReleaseFundsResponse
-	45,  // 155: banka.bank.v1.BankService.CommitReservedFunds:output_type -> banka.bank.v1.CommitReservedFundsResponse
-	47,  // 156: banka.bank.v1.BankService.TransferBetweenClients:output_type -> banka.bank.v1.TransferBetweenClientsResponse
-	17,  // 157: banka.bank.v1.BankService.CreateFundAccount:output_type -> banka.bank.v1.Account
-	51,  // 158: banka.bank.v1.BankService.CreatePayment:output_type -> banka.bank.v1.PaymentResult
-	51,  // 159: banka.bank.v1.BankService.CreateTransfer:output_type -> banka.bank.v1.PaymentResult
-	53,  // 160: banka.bank.v1.BankService.QuoteExchange:output_type -> banka.bank.v1.QuoteExchangeResponse
-	55,  // 161: banka.bank.v1.BankService.ListTransactions:output_type -> banka.bank.v1.ListTransactionsResponse
-	56,  // 162: banka.bank.v1.BankService.CreatePaymentRecipient:output_type -> banka.bank.v1.PaymentRecipient
-	59,  // 163: banka.bank.v1.BankService.ListPaymentRecipients:output_type -> banka.bank.v1.ListPaymentRecipientsResponse
-	56,  // 164: banka.bank.v1.BankService.UpdatePaymentRecipient:output_type -> banka.bank.v1.PaymentRecipient
-	99,  // 165: banka.bank.v1.BankService.DeletePaymentRecipient:output_type -> google.protobuf.Empty
-	62,  // 166: banka.bank.v1.BankService.SchedulePayment:output_type -> banka.bank.v1.ScheduledPayment
-	65,  // 167: banka.bank.v1.BankService.ListScheduledPayments:output_type -> banka.bank.v1.ListScheduledPaymentsResponse
-	62,  // 168: banka.bank.v1.BankService.CancelScheduledPayment:output_type -> banka.bank.v1.ScheduledPayment
-	68,  // 169: banka.bank.v1.BankService.RunDueScheduledPayments:output_type -> banka.bank.v1.RunDueScheduledPaymentsResponse
-	69,  // 170: banka.bank.v1.BankService.CreateCard:output_type -> banka.bank.v1.Card
-	72,  // 171: banka.bank.v1.BankService.ListCards:output_type -> banka.bank.v1.ListCardsResponse
-	69,  // 172: banka.bank.v1.BankService.SetCardStatus:output_type -> banka.bank.v1.Card
-	69,  // 173: banka.bank.v1.BankService.UpdateCardLimit:output_type -> banka.bank.v1.Card
-	75,  // 174: banka.bank.v1.BankService.CreateAuthorizedPerson:output_type -> banka.bank.v1.AuthorizedPerson
-	78,  // 175: banka.bank.v1.BankService.ListAuthorizedPersons:output_type -> banka.bank.v1.ListAuthorizedPersonsResponse
-	79,  // 176: banka.bank.v1.BankService.SubmitLoanRequest:output_type -> banka.bank.v1.LoanRequest
-	85,  // 177: banka.bank.v1.BankService.ListLoanRequests:output_type -> banka.bank.v1.ListLoanRequestsResponse
-	79,  // 178: banka.bank.v1.BankService.DecideLoanRequest:output_type -> banka.bank.v1.LoanRequest
-	88,  // 179: banka.bank.v1.BankService.ListLoans:output_type -> banka.bank.v1.ListLoansResponse
-	82,  // 180: banka.bank.v1.BankService.GetLoan:output_type -> banka.bank.v1.LoanWithInstallments
-	91,  // 181: banka.bank.v1.BankService.RunInstallmentJob:output_type -> banka.bank.v1.RunInstallmentJobResponse
-	93,  // 182: banka.bank.v1.BankService.RunVariableRateJob:output_type -> banka.bank.v1.RunVariableRateJobResponse
-	95,  // 183: banka.bank.v1.BankService.RunMaintenanceFeeJob:output_type -> banka.bank.v1.RunMaintenanceFeeJobResponse
-	97,  // 184: banka.bank.v1.BankService.RunSpentResetJob:output_type -> banka.bank.v1.RunSpentResetJobResponse
-	138, // [138:185] is the sub-list for method output_type
-	91,  // [91:138] is the sub-list for method input_type
-	91,  // [91:91] is the sub-list for extension type_name
-	91,  // [91:91] is the sub-list for extension extendee
-	0,   // [0:91] is the sub-list for field type_name
+	81,  // 90: banka.bank.v1.ListLoansResponse.loans:type_name -> banka.bank.v1.Loan
+	0,   // 91: banka.bank.v1.ForexForward.base_currency:type_name -> banka.bank.v1.Currency
+	0,   // 92: banka.bank.v1.ForexForward.quote_currency:type_name -> banka.bank.v1.Currency
+	112, // 93: banka.bank.v1.ForexForward.settlement_date:type_name -> google.protobuf.Timestamp
+	16,  // 94: banka.bank.v1.ForexForward.status:type_name -> banka.bank.v1.ForexForwardStatus
+	112, // 95: banka.bank.v1.ForexForward.created_at:type_name -> google.protobuf.Timestamp
+	112, // 96: banka.bank.v1.ForexForward.settled_at:type_name -> google.protobuf.Timestamp
+	0,   // 97: banka.bank.v1.ForexForwardSpread.base_currency:type_name -> banka.bank.v1.Currency
+	0,   // 98: banka.bank.v1.ForexForwardSpread.quote_currency:type_name -> banka.bank.v1.Currency
+	112, // 99: banka.bank.v1.ForexForwardSpread.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 100: banka.bank.v1.ForexForwardQuote.base_currency:type_name -> banka.bank.v1.Currency
+	0,   // 101: banka.bank.v1.ForexForwardQuote.quote_currency:type_name -> banka.bank.v1.Currency
+	0,   // 102: banka.bank.v1.QuoteForexForwardRequest.base_currency:type_name -> banka.bank.v1.Currency
+	112, // 103: banka.bank.v1.QuoteForexForwardRequest.settlement_date:type_name -> google.protobuf.Timestamp
+	0,   // 104: banka.bank.v1.CreateForexForwardRequest.base_currency:type_name -> banka.bank.v1.Currency
+	112, // 105: banka.bank.v1.CreateForexForwardRequest.settlement_date:type_name -> google.protobuf.Timestamp
+	99,  // 106: banka.bank.v1.ListForexForwardsResponse.forex_forwards:type_name -> banka.bank.v1.ForexForward
+	100, // 107: banka.bank.v1.GetForexForwardSpreadsResponse.spreads:type_name -> banka.bank.v1.ForexForwardSpread
+	0,   // 108: banka.bank.v1.SetForexForwardSpreadRequest.base_currency:type_name -> banka.bank.v1.Currency
+	0,   // 109: banka.bank.v1.SetForexForwardSpreadRequest.quote_currency:type_name -> banka.bank.v1.Currency
+	19,  // 110: banka.bank.v1.BankService.CreateCompany:input_type -> banka.bank.v1.CreateCompanyRequest
+	20,  // 111: banka.bank.v1.BankService.ListCompanies:input_type -> banka.bank.v1.ListCompaniesRequest
+	22,  // 112: banka.bank.v1.BankService.GetCompany:input_type -> banka.bank.v1.GetCompanyRequest
+	23,  // 113: banka.bank.v1.BankService.UpdateCompany:input_type -> banka.bank.v1.UpdateCompanyRequest
+	24,  // 114: banka.bank.v1.BankService.CreateAccount:input_type -> banka.bank.v1.CreateAccountRequest
+	25,  // 115: banka.bank.v1.BankService.ListAccounts:input_type -> banka.bank.v1.ListAccountsRequest
+	27,  // 116: banka.bank.v1.BankService.GetAccount:input_type -> banka.bank.v1.GetAccountRequest
+	28,  // 117: banka.bank.v1.BankService.UpdateAccountLimits:input_type -> banka.bank.v1.UpdateAccountLimitsRequest
+	29,  // 118: banka.bank.v1.BankService.UpdateAccountName:input_type -> banka.bank.v1.UpdateAccountNameRequest
+	30,  // 119: banka.bank.v1.BankService.SetAccountStatus:input_type -> banka.bank.v1.SetAccountStatusRequest
+	31,  // 120: banka.bank.v1.BankService.GetSystemAccount:input_type -> banka.bank.v1.GetSystemAccountRequest
+	33,  // 121: banka.bank.v1.BankService.SettleTrade:input_type -> banka.bank.v1.SettleTradeRequest
+	35,  // 122: banka.bank.v1.BankService.SettleCapitalGainsTax:input_type -> banka.bank.v1.SettleCapitalGainsTaxRequest
+	37,  // 123: banka.bank.v1.BankService.SettleDividend:input_type -> banka.bank.v1.SettleDividendRequest
+	39,  // 124: banka.bank.v1.BankService.SettleForexFill:input_type -> banka.bank.v1.SettleForexFillRequest
+	41,  // 125: banka.bank.v1.BankService.ReserveFunds:input_type -> banka.bank.v1.ReserveFundsRequest
+	43,  // 126: banka.bank.v1.BankService.ReleaseFunds:input_type -> banka.bank.v1.ReleaseFundsRequest
+	45,  // 127: banka.bank.v1.BankService.CommitReservedFunds:input_type -> banka.bank.v1.CommitReservedFundsRequest
+	47,  // 128: banka.bank.v1.BankService.TransferBetweenClients:input_type -> banka.bank.v1.TransferBetweenClientsRequest
+	32,  // 129: banka.bank.v1.BankService.CreateFundAccount:input_type -> banka.bank.v1.CreateFundAccountRequest
+	50,  // 130: banka.bank.v1.BankService.CreatePayment:input_type -> banka.bank.v1.CreatePaymentRequest
+	51,  // 131: banka.bank.v1.BankService.CreateTransfer:input_type -> banka.bank.v1.CreateTransferRequest
+	53,  // 132: banka.bank.v1.BankService.QuoteExchange:input_type -> banka.bank.v1.QuoteExchangeRequest
+	55,  // 133: banka.bank.v1.BankService.ListTransactions:input_type -> banka.bank.v1.ListTransactionsRequest
+	58,  // 134: banka.bank.v1.BankService.CreatePaymentRecipient:input_type -> banka.bank.v1.CreatePaymentRecipientRequest
+	59,  // 135: banka.bank.v1.BankService.ListPaymentRecipients:input_type -> banka.bank.v1.ListPaymentRecipientsRequest
+	61,  // 136: banka.bank.v1.BankService.UpdatePaymentRecipient:input_type -> banka.bank.v1.UpdatePaymentRecipientRequest
+	62,  // 137: banka.bank.v1.BankService.DeletePaymentRecipient:input_type -> banka.bank.v1.DeletePaymentRecipientRequest
+	64,  // 138: banka.bank.v1.BankService.SchedulePayment:input_type -> banka.bank.v1.SchedulePaymentRequest
+	65,  // 139: banka.bank.v1.BankService.ListScheduledPayments:input_type -> banka.bank.v1.ListScheduledPaymentsRequest
+	67,  // 140: banka.bank.v1.BankService.CancelScheduledPayment:input_type -> banka.bank.v1.CancelScheduledPaymentRequest
+	68,  // 141: banka.bank.v1.BankService.RunDueScheduledPayments:input_type -> banka.bank.v1.RunDueScheduledPaymentsRequest
+	71,  // 142: banka.bank.v1.BankService.CreateCard:input_type -> banka.bank.v1.CreateCardRequest
+	72,  // 143: banka.bank.v1.BankService.ListCards:input_type -> banka.bank.v1.ListCardsRequest
+	74,  // 144: banka.bank.v1.BankService.SetCardStatus:input_type -> banka.bank.v1.SetCardStatusRequest
+	75,  // 145: banka.bank.v1.BankService.UpdateCardLimit:input_type -> banka.bank.v1.UpdateCardLimitRequest
+	77,  // 146: banka.bank.v1.BankService.CreateAuthorizedPerson:input_type -> banka.bank.v1.CreateAuthorizedPersonRequest
+	78,  // 147: banka.bank.v1.BankService.ListAuthorizedPersons:input_type -> banka.bank.v1.ListAuthorizedPersonsRequest
+	84,  // 148: banka.bank.v1.BankService.SubmitLoanRequest:input_type -> banka.bank.v1.SubmitLoanRequestRequest
+	85,  // 149: banka.bank.v1.BankService.ListLoanRequests:input_type -> banka.bank.v1.ListLoanRequestsRequest
+	87,  // 150: banka.bank.v1.BankService.DecideLoanRequest:input_type -> banka.bank.v1.DecideLoanRequestRequest
+	88,  // 151: banka.bank.v1.BankService.ListLoans:input_type -> banka.bank.v1.ListLoansRequest
+	90,  // 152: banka.bank.v1.BankService.GetLoan:input_type -> banka.bank.v1.GetLoanRequest
+	91,  // 153: banka.bank.v1.BankService.RunInstallmentJob:input_type -> banka.bank.v1.RunInstallmentJobRequest
+	93,  // 154: banka.bank.v1.BankService.RunVariableRateJob:input_type -> banka.bank.v1.RunVariableRateJobRequest
+	95,  // 155: banka.bank.v1.BankService.RunMaintenanceFeeJob:input_type -> banka.bank.v1.RunMaintenanceFeeJobRequest
+	97,  // 156: banka.bank.v1.BankService.RunSpentResetJob:input_type -> banka.bank.v1.RunSpentResetJobRequest
+	102, // 157: banka.bank.v1.BankService.QuoteForexForward:input_type -> banka.bank.v1.QuoteForexForwardRequest
+	103, // 158: banka.bank.v1.BankService.CreateForexForward:input_type -> banka.bank.v1.CreateForexForwardRequest
+	104, // 159: banka.bank.v1.BankService.ListForexForwards:input_type -> banka.bank.v1.ListForexForwardsRequest
+	106, // 160: banka.bank.v1.BankService.CancelForexForward:input_type -> banka.bank.v1.CancelForexForwardRequest
+	107, // 161: banka.bank.v1.BankService.GetForexForwardSpreads:input_type -> banka.bank.v1.GetForexForwardSpreadsRequest
+	109, // 162: banka.bank.v1.BankService.SetForexForwardSpread:input_type -> banka.bank.v1.SetForexForwardSpreadRequest
+	110, // 163: banka.bank.v1.BankService.RunForexForwardSettlement:input_type -> banka.bank.v1.RunForexForwardSettlementRequest
+	17,  // 164: banka.bank.v1.BankService.CreateCompany:output_type -> banka.bank.v1.Company
+	21,  // 165: banka.bank.v1.BankService.ListCompanies:output_type -> banka.bank.v1.ListCompaniesResponse
+	17,  // 166: banka.bank.v1.BankService.GetCompany:output_type -> banka.bank.v1.Company
+	17,  // 167: banka.bank.v1.BankService.UpdateCompany:output_type -> banka.bank.v1.Company
+	18,  // 168: banka.bank.v1.BankService.CreateAccount:output_type -> banka.bank.v1.Account
+	26,  // 169: banka.bank.v1.BankService.ListAccounts:output_type -> banka.bank.v1.ListAccountsResponse
+	18,  // 170: banka.bank.v1.BankService.GetAccount:output_type -> banka.bank.v1.Account
+	18,  // 171: banka.bank.v1.BankService.UpdateAccountLimits:output_type -> banka.bank.v1.Account
+	18,  // 172: banka.bank.v1.BankService.UpdateAccountName:output_type -> banka.bank.v1.Account
+	18,  // 173: banka.bank.v1.BankService.SetAccountStatus:output_type -> banka.bank.v1.Account
+	18,  // 174: banka.bank.v1.BankService.GetSystemAccount:output_type -> banka.bank.v1.Account
+	34,  // 175: banka.bank.v1.BankService.SettleTrade:output_type -> banka.bank.v1.SettleTradeResponse
+	36,  // 176: banka.bank.v1.BankService.SettleCapitalGainsTax:output_type -> banka.bank.v1.SettleCapitalGainsTaxResponse
+	38,  // 177: banka.bank.v1.BankService.SettleDividend:output_type -> banka.bank.v1.SettleDividendResponse
+	40,  // 178: banka.bank.v1.BankService.SettleForexFill:output_type -> banka.bank.v1.SettleForexFillResponse
+	42,  // 179: banka.bank.v1.BankService.ReserveFunds:output_type -> banka.bank.v1.ReserveFundsResponse
+	44,  // 180: banka.bank.v1.BankService.ReleaseFunds:output_type -> banka.bank.v1.ReleaseFundsResponse
+	46,  // 181: banka.bank.v1.BankService.CommitReservedFunds:output_type -> banka.bank.v1.CommitReservedFundsResponse
+	48,  // 182: banka.bank.v1.BankService.TransferBetweenClients:output_type -> banka.bank.v1.TransferBetweenClientsResponse
+	18,  // 183: banka.bank.v1.BankService.CreateFundAccount:output_type -> banka.bank.v1.Account
+	52,  // 184: banka.bank.v1.BankService.CreatePayment:output_type -> banka.bank.v1.PaymentResult
+	52,  // 185: banka.bank.v1.BankService.CreateTransfer:output_type -> banka.bank.v1.PaymentResult
+	54,  // 186: banka.bank.v1.BankService.QuoteExchange:output_type -> banka.bank.v1.QuoteExchangeResponse
+	56,  // 187: banka.bank.v1.BankService.ListTransactions:output_type -> banka.bank.v1.ListTransactionsResponse
+	57,  // 188: banka.bank.v1.BankService.CreatePaymentRecipient:output_type -> banka.bank.v1.PaymentRecipient
+	60,  // 189: banka.bank.v1.BankService.ListPaymentRecipients:output_type -> banka.bank.v1.ListPaymentRecipientsResponse
+	57,  // 190: banka.bank.v1.BankService.UpdatePaymentRecipient:output_type -> banka.bank.v1.PaymentRecipient
+	113, // 191: banka.bank.v1.BankService.DeletePaymentRecipient:output_type -> google.protobuf.Empty
+	63,  // 192: banka.bank.v1.BankService.SchedulePayment:output_type -> banka.bank.v1.ScheduledPayment
+	66,  // 193: banka.bank.v1.BankService.ListScheduledPayments:output_type -> banka.bank.v1.ListScheduledPaymentsResponse
+	63,  // 194: banka.bank.v1.BankService.CancelScheduledPayment:output_type -> banka.bank.v1.ScheduledPayment
+	69,  // 195: banka.bank.v1.BankService.RunDueScheduledPayments:output_type -> banka.bank.v1.RunDueScheduledPaymentsResponse
+	70,  // 196: banka.bank.v1.BankService.CreateCard:output_type -> banka.bank.v1.Card
+	73,  // 197: banka.bank.v1.BankService.ListCards:output_type -> banka.bank.v1.ListCardsResponse
+	70,  // 198: banka.bank.v1.BankService.SetCardStatus:output_type -> banka.bank.v1.Card
+	70,  // 199: banka.bank.v1.BankService.UpdateCardLimit:output_type -> banka.bank.v1.Card
+	76,  // 200: banka.bank.v1.BankService.CreateAuthorizedPerson:output_type -> banka.bank.v1.AuthorizedPerson
+	79,  // 201: banka.bank.v1.BankService.ListAuthorizedPersons:output_type -> banka.bank.v1.ListAuthorizedPersonsResponse
+	80,  // 202: banka.bank.v1.BankService.SubmitLoanRequest:output_type -> banka.bank.v1.LoanRequest
+	86,  // 203: banka.bank.v1.BankService.ListLoanRequests:output_type -> banka.bank.v1.ListLoanRequestsResponse
+	80,  // 204: banka.bank.v1.BankService.DecideLoanRequest:output_type -> banka.bank.v1.LoanRequest
+	89,  // 205: banka.bank.v1.BankService.ListLoans:output_type -> banka.bank.v1.ListLoansResponse
+	83,  // 206: banka.bank.v1.BankService.GetLoan:output_type -> banka.bank.v1.LoanWithInstallments
+	92,  // 207: banka.bank.v1.BankService.RunInstallmentJob:output_type -> banka.bank.v1.RunInstallmentJobResponse
+	94,  // 208: banka.bank.v1.BankService.RunVariableRateJob:output_type -> banka.bank.v1.RunVariableRateJobResponse
+	96,  // 209: banka.bank.v1.BankService.RunMaintenanceFeeJob:output_type -> banka.bank.v1.RunMaintenanceFeeJobResponse
+	98,  // 210: banka.bank.v1.BankService.RunSpentResetJob:output_type -> banka.bank.v1.RunSpentResetJobResponse
+	101, // 211: banka.bank.v1.BankService.QuoteForexForward:output_type -> banka.bank.v1.ForexForwardQuote
+	99,  // 212: banka.bank.v1.BankService.CreateForexForward:output_type -> banka.bank.v1.ForexForward
+	105, // 213: banka.bank.v1.BankService.ListForexForwards:output_type -> banka.bank.v1.ListForexForwardsResponse
+	99,  // 214: banka.bank.v1.BankService.CancelForexForward:output_type -> banka.bank.v1.ForexForward
+	108, // 215: banka.bank.v1.BankService.GetForexForwardSpreads:output_type -> banka.bank.v1.GetForexForwardSpreadsResponse
+	100, // 216: banka.bank.v1.BankService.SetForexForwardSpread:output_type -> banka.bank.v1.ForexForwardSpread
+	111, // 217: banka.bank.v1.BankService.RunForexForwardSettlement:output_type -> banka.bank.v1.RunForexForwardSettlementResponse
+	164, // [164:218] is the sub-list for method output_type
+	110, // [110:164] is the sub-list for method input_type
+	110, // [110:110] is the sub-list for extension type_name
+	110, // [110:110] is the sub-list for extension extendee
+	0,   // [0:110] is the sub-list for field type_name
 }
 
 func init() { file_bank_v1_bank_proto_init() }
@@ -7976,8 +9009,8 @@ func file_bank_v1_bank_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bank_v1_bank_proto_rawDesc), len(file_bank_v1_bank_proto_rawDesc)),
-			NumEnums:      16,
-			NumMessages:   82,
+			NumEnums:      17,
+			NumMessages:   95,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/bank/v1/bank.pb.gw.go
+++ b/gen/proto/bank/v1/bank.pb.gw.go
@@ -1255,6 +1255,168 @@ func local_request_BankService_RunSpentResetJob_0(ctx context.Context, marshaler
 	return msg, metadata, err
 }
 
+func request_BankService_QuoteForexForward_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuoteForexForwardRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.QuoteForexForward(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_QuoteForexForward_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuoteForexForwardRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.QuoteForexForward(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_BankService_CreateForexForward_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateForexForwardRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateForexForward(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_CreateForexForward_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateForexForwardRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateForexForward(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_BankService_ListForexForwards_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListForexForwardsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListForexForwards(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_ListForexForwards_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListForexForwardsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListForexForwards(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_BankService_CancelForexForward_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelForexForwardRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.CancelForexForward(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_CancelForexForward_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelForexForwardRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.CancelForexForward(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_BankService_GetForexForwardSpreads_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetForexForwardSpreadsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetForexForwardSpreads(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_GetForexForwardSpreads_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetForexForwardSpreadsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetForexForwardSpreads(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_BankService_SetForexForwardSpread_0(ctx context.Context, marshaler runtime.Marshaler, client BankServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetForexForwardSpreadRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SetForexForwardSpread(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_BankService_SetForexForwardSpread_0(ctx context.Context, marshaler runtime.Marshaler, server BankServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetForexForwardSpreadRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SetForexForwardSpread(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterBankServiceHandlerServer registers the http handlers for service BankService to "mux".
 // UnaryRPC     :call BankServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1981,6 +2143,126 @@ func RegisterBankServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_BankService_RunSpentResetJob_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_BankService_QuoteForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/QuoteForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/quote"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_QuoteForexForward_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_QuoteForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_BankService_CreateForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/CreateForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_CreateForexForward_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_CreateForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_BankService_ListForexForwards_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/ListForexForwards", runtime.WithHTTPPathPattern("/api/v1/forex-forwards"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_ListForexForwards_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_ListForexForwards_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_BankService_CancelForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/CancelForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_CancelForexForward_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_CancelForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_BankService_GetForexForwardSpreads_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/GetForexForwardSpreads", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/spreads"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_GetForexForwardSpreads_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_GetForexForwardSpreads_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_BankService_SetForexForwardSpread_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.bank.v1.BankService/SetForexForwardSpread", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/spreads"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_BankService_SetForexForwardSpread_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_SetForexForwardSpread_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -2633,6 +2915,108 @@ func RegisterBankServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_BankService_RunSpentResetJob_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_BankService_QuoteForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/QuoteForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/quote"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_QuoteForexForward_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_QuoteForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_BankService_CreateForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/CreateForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_CreateForexForward_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_CreateForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_BankService_ListForexForwards_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/ListForexForwards", runtime.WithHTTPPathPattern("/api/v1/forex-forwards"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_ListForexForwards_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_ListForexForwards_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_BankService_CancelForexForward_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/CancelForexForward", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_CancelForexForward_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_CancelForexForward_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_BankService_GetForexForwardSpreads_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/GetForexForwardSpreads", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/spreads"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_GetForexForwardSpreads_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_GetForexForwardSpreads_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_BankService_SetForexForwardSpread_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.bank.v1.BankService/SetForexForwardSpread", runtime.WithHTTPPathPattern("/api/v1/forex-forwards/spreads"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_BankService_SetForexForwardSpread_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_BankService_SetForexForwardSpread_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -2673,6 +3057,12 @@ var (
 	pattern_BankService_RunVariableRateJob_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "loans", "run-variable-rate-job"}, ""))
 	pattern_BankService_RunMaintenanceFeeJob_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "accounts", "run-maintenance-fee-job"}, ""))
 	pattern_BankService_RunSpentResetJob_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "accounts", "run-spent-reset-job"}, ""))
+	pattern_BankService_QuoteForexForward_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "forex-forwards", "quote"}, ""))
+	pattern_BankService_CreateForexForward_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "forex-forwards"}, ""))
+	pattern_BankService_ListForexForwards_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "forex-forwards"}, ""))
+	pattern_BankService_CancelForexForward_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "forex-forwards", "id"}, ""))
+	pattern_BankService_GetForexForwardSpreads_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "forex-forwards", "spreads"}, ""))
+	pattern_BankService_SetForexForwardSpread_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "forex-forwards", "spreads"}, ""))
 )
 
 var (
@@ -2712,4 +3102,10 @@ var (
 	forward_BankService_RunVariableRateJob_0     = runtime.ForwardResponseMessage
 	forward_BankService_RunMaintenanceFeeJob_0   = runtime.ForwardResponseMessage
 	forward_BankService_RunSpentResetJob_0       = runtime.ForwardResponseMessage
+	forward_BankService_QuoteForexForward_0      = runtime.ForwardResponseMessage
+	forward_BankService_CreateForexForward_0     = runtime.ForwardResponseMessage
+	forward_BankService_ListForexForwards_0      = runtime.ForwardResponseMessage
+	forward_BankService_CancelForexForward_0     = runtime.ForwardResponseMessage
+	forward_BankService_GetForexForwardSpreads_0 = runtime.ForwardResponseMessage
+	forward_BankService_SetForexForwardSpread_0  = runtime.ForwardResponseMessage
 )

--- a/gen/proto/bank/v1/bank_grpc.pb.go
+++ b/gen/proto/bank/v1/bank_grpc.pb.go
@@ -20,53 +20,60 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BankService_CreateCompany_FullMethodName           = "/banka.bank.v1.BankService/CreateCompany"
-	BankService_ListCompanies_FullMethodName           = "/banka.bank.v1.BankService/ListCompanies"
-	BankService_GetCompany_FullMethodName              = "/banka.bank.v1.BankService/GetCompany"
-	BankService_UpdateCompany_FullMethodName           = "/banka.bank.v1.BankService/UpdateCompany"
-	BankService_CreateAccount_FullMethodName           = "/banka.bank.v1.BankService/CreateAccount"
-	BankService_ListAccounts_FullMethodName            = "/banka.bank.v1.BankService/ListAccounts"
-	BankService_GetAccount_FullMethodName              = "/banka.bank.v1.BankService/GetAccount"
-	BankService_UpdateAccountLimits_FullMethodName     = "/banka.bank.v1.BankService/UpdateAccountLimits"
-	BankService_UpdateAccountName_FullMethodName       = "/banka.bank.v1.BankService/UpdateAccountName"
-	BankService_SetAccountStatus_FullMethodName        = "/banka.bank.v1.BankService/SetAccountStatus"
-	BankService_GetSystemAccount_FullMethodName        = "/banka.bank.v1.BankService/GetSystemAccount"
-	BankService_SettleTrade_FullMethodName             = "/banka.bank.v1.BankService/SettleTrade"
-	BankService_SettleCapitalGainsTax_FullMethodName   = "/banka.bank.v1.BankService/SettleCapitalGainsTax"
-	BankService_SettleDividend_FullMethodName          = "/banka.bank.v1.BankService/SettleDividend"
-	BankService_SettleForexFill_FullMethodName         = "/banka.bank.v1.BankService/SettleForexFill"
-	BankService_ReserveFunds_FullMethodName            = "/banka.bank.v1.BankService/ReserveFunds"
-	BankService_ReleaseFunds_FullMethodName            = "/banka.bank.v1.BankService/ReleaseFunds"
-	BankService_CommitReservedFunds_FullMethodName     = "/banka.bank.v1.BankService/CommitReservedFunds"
-	BankService_TransferBetweenClients_FullMethodName  = "/banka.bank.v1.BankService/TransferBetweenClients"
-	BankService_CreateFundAccount_FullMethodName       = "/banka.bank.v1.BankService/CreateFundAccount"
-	BankService_CreatePayment_FullMethodName           = "/banka.bank.v1.BankService/CreatePayment"
-	BankService_CreateTransfer_FullMethodName          = "/banka.bank.v1.BankService/CreateTransfer"
-	BankService_QuoteExchange_FullMethodName           = "/banka.bank.v1.BankService/QuoteExchange"
-	BankService_ListTransactions_FullMethodName        = "/banka.bank.v1.BankService/ListTransactions"
-	BankService_CreatePaymentRecipient_FullMethodName  = "/banka.bank.v1.BankService/CreatePaymentRecipient"
-	BankService_ListPaymentRecipients_FullMethodName   = "/banka.bank.v1.BankService/ListPaymentRecipients"
-	BankService_UpdatePaymentRecipient_FullMethodName  = "/banka.bank.v1.BankService/UpdatePaymentRecipient"
-	BankService_DeletePaymentRecipient_FullMethodName  = "/banka.bank.v1.BankService/DeletePaymentRecipient"
-	BankService_SchedulePayment_FullMethodName         = "/banka.bank.v1.BankService/SchedulePayment"
-	BankService_ListScheduledPayments_FullMethodName   = "/banka.bank.v1.BankService/ListScheduledPayments"
-	BankService_CancelScheduledPayment_FullMethodName  = "/banka.bank.v1.BankService/CancelScheduledPayment"
-	BankService_RunDueScheduledPayments_FullMethodName = "/banka.bank.v1.BankService/RunDueScheduledPayments"
-	BankService_CreateCard_FullMethodName              = "/banka.bank.v1.BankService/CreateCard"
-	BankService_ListCards_FullMethodName               = "/banka.bank.v1.BankService/ListCards"
-	BankService_SetCardStatus_FullMethodName           = "/banka.bank.v1.BankService/SetCardStatus"
-	BankService_UpdateCardLimit_FullMethodName         = "/banka.bank.v1.BankService/UpdateCardLimit"
-	BankService_CreateAuthorizedPerson_FullMethodName  = "/banka.bank.v1.BankService/CreateAuthorizedPerson"
-	BankService_ListAuthorizedPersons_FullMethodName   = "/banka.bank.v1.BankService/ListAuthorizedPersons"
-	BankService_SubmitLoanRequest_FullMethodName       = "/banka.bank.v1.BankService/SubmitLoanRequest"
-	BankService_ListLoanRequests_FullMethodName        = "/banka.bank.v1.BankService/ListLoanRequests"
-	BankService_DecideLoanRequest_FullMethodName       = "/banka.bank.v1.BankService/DecideLoanRequest"
-	BankService_ListLoans_FullMethodName               = "/banka.bank.v1.BankService/ListLoans"
-	BankService_GetLoan_FullMethodName                 = "/banka.bank.v1.BankService/GetLoan"
-	BankService_RunInstallmentJob_FullMethodName       = "/banka.bank.v1.BankService/RunInstallmentJob"
-	BankService_RunVariableRateJob_FullMethodName      = "/banka.bank.v1.BankService/RunVariableRateJob"
-	BankService_RunMaintenanceFeeJob_FullMethodName    = "/banka.bank.v1.BankService/RunMaintenanceFeeJob"
-	BankService_RunSpentResetJob_FullMethodName        = "/banka.bank.v1.BankService/RunSpentResetJob"
+	BankService_CreateCompany_FullMethodName             = "/banka.bank.v1.BankService/CreateCompany"
+	BankService_ListCompanies_FullMethodName             = "/banka.bank.v1.BankService/ListCompanies"
+	BankService_GetCompany_FullMethodName                = "/banka.bank.v1.BankService/GetCompany"
+	BankService_UpdateCompany_FullMethodName             = "/banka.bank.v1.BankService/UpdateCompany"
+	BankService_CreateAccount_FullMethodName             = "/banka.bank.v1.BankService/CreateAccount"
+	BankService_ListAccounts_FullMethodName              = "/banka.bank.v1.BankService/ListAccounts"
+	BankService_GetAccount_FullMethodName                = "/banka.bank.v1.BankService/GetAccount"
+	BankService_UpdateAccountLimits_FullMethodName       = "/banka.bank.v1.BankService/UpdateAccountLimits"
+	BankService_UpdateAccountName_FullMethodName         = "/banka.bank.v1.BankService/UpdateAccountName"
+	BankService_SetAccountStatus_FullMethodName          = "/banka.bank.v1.BankService/SetAccountStatus"
+	BankService_GetSystemAccount_FullMethodName          = "/banka.bank.v1.BankService/GetSystemAccount"
+	BankService_SettleTrade_FullMethodName               = "/banka.bank.v1.BankService/SettleTrade"
+	BankService_SettleCapitalGainsTax_FullMethodName     = "/banka.bank.v1.BankService/SettleCapitalGainsTax"
+	BankService_SettleDividend_FullMethodName            = "/banka.bank.v1.BankService/SettleDividend"
+	BankService_SettleForexFill_FullMethodName           = "/banka.bank.v1.BankService/SettleForexFill"
+	BankService_ReserveFunds_FullMethodName              = "/banka.bank.v1.BankService/ReserveFunds"
+	BankService_ReleaseFunds_FullMethodName              = "/banka.bank.v1.BankService/ReleaseFunds"
+	BankService_CommitReservedFunds_FullMethodName       = "/banka.bank.v1.BankService/CommitReservedFunds"
+	BankService_TransferBetweenClients_FullMethodName    = "/banka.bank.v1.BankService/TransferBetweenClients"
+	BankService_CreateFundAccount_FullMethodName         = "/banka.bank.v1.BankService/CreateFundAccount"
+	BankService_CreatePayment_FullMethodName             = "/banka.bank.v1.BankService/CreatePayment"
+	BankService_CreateTransfer_FullMethodName            = "/banka.bank.v1.BankService/CreateTransfer"
+	BankService_QuoteExchange_FullMethodName             = "/banka.bank.v1.BankService/QuoteExchange"
+	BankService_ListTransactions_FullMethodName          = "/banka.bank.v1.BankService/ListTransactions"
+	BankService_CreatePaymentRecipient_FullMethodName    = "/banka.bank.v1.BankService/CreatePaymentRecipient"
+	BankService_ListPaymentRecipients_FullMethodName     = "/banka.bank.v1.BankService/ListPaymentRecipients"
+	BankService_UpdatePaymentRecipient_FullMethodName    = "/banka.bank.v1.BankService/UpdatePaymentRecipient"
+	BankService_DeletePaymentRecipient_FullMethodName    = "/banka.bank.v1.BankService/DeletePaymentRecipient"
+	BankService_SchedulePayment_FullMethodName           = "/banka.bank.v1.BankService/SchedulePayment"
+	BankService_ListScheduledPayments_FullMethodName     = "/banka.bank.v1.BankService/ListScheduledPayments"
+	BankService_CancelScheduledPayment_FullMethodName    = "/banka.bank.v1.BankService/CancelScheduledPayment"
+	BankService_RunDueScheduledPayments_FullMethodName   = "/banka.bank.v1.BankService/RunDueScheduledPayments"
+	BankService_CreateCard_FullMethodName                = "/banka.bank.v1.BankService/CreateCard"
+	BankService_ListCards_FullMethodName                 = "/banka.bank.v1.BankService/ListCards"
+	BankService_SetCardStatus_FullMethodName             = "/banka.bank.v1.BankService/SetCardStatus"
+	BankService_UpdateCardLimit_FullMethodName           = "/banka.bank.v1.BankService/UpdateCardLimit"
+	BankService_CreateAuthorizedPerson_FullMethodName    = "/banka.bank.v1.BankService/CreateAuthorizedPerson"
+	BankService_ListAuthorizedPersons_FullMethodName     = "/banka.bank.v1.BankService/ListAuthorizedPersons"
+	BankService_SubmitLoanRequest_FullMethodName         = "/banka.bank.v1.BankService/SubmitLoanRequest"
+	BankService_ListLoanRequests_FullMethodName          = "/banka.bank.v1.BankService/ListLoanRequests"
+	BankService_DecideLoanRequest_FullMethodName         = "/banka.bank.v1.BankService/DecideLoanRequest"
+	BankService_ListLoans_FullMethodName                 = "/banka.bank.v1.BankService/ListLoans"
+	BankService_GetLoan_FullMethodName                   = "/banka.bank.v1.BankService/GetLoan"
+	BankService_RunInstallmentJob_FullMethodName         = "/banka.bank.v1.BankService/RunInstallmentJob"
+	BankService_RunVariableRateJob_FullMethodName        = "/banka.bank.v1.BankService/RunVariableRateJob"
+	BankService_RunMaintenanceFeeJob_FullMethodName      = "/banka.bank.v1.BankService/RunMaintenanceFeeJob"
+	BankService_RunSpentResetJob_FullMethodName          = "/banka.bank.v1.BankService/RunSpentResetJob"
+	BankService_QuoteForexForward_FullMethodName         = "/banka.bank.v1.BankService/QuoteForexForward"
+	BankService_CreateForexForward_FullMethodName        = "/banka.bank.v1.BankService/CreateForexForward"
+	BankService_ListForexForwards_FullMethodName         = "/banka.bank.v1.BankService/ListForexForwards"
+	BankService_CancelForexForward_FullMethodName        = "/banka.bank.v1.BankService/CancelForexForward"
+	BankService_GetForexForwardSpreads_FullMethodName    = "/banka.bank.v1.BankService/GetForexForwardSpreads"
+	BankService_SetForexForwardSpread_FullMethodName     = "/banka.bank.v1.BankService/SetForexForwardSpread"
+	BankService_RunForexForwardSettlement_FullMethodName = "/banka.bank.v1.BankService/RunForexForwardSettlement"
 )
 
 // BankServiceClient is the client API for BankService service.
@@ -212,6 +219,26 @@ type BankServiceClient interface {
 	// RunSpentResetJob zeroes the daily/monthly spent counters that are due
 	// to roll over. Normally driven by the scheduler service; admin-only.
 	RunSpentResetJob(ctx context.Context, in *RunSpentResetJobRequest, opts ...grpc.CallOption) (*RunSpentResetJobResponse, error)
+	// QuoteForexForward returns a side-effect-free preview of a prospective
+	// forward: the locked-in ForwardRate (= SpotAsk × (1 + days/365 ×
+	// spread)) plus the reserved obligation amount and commission.
+	QuoteForexForward(ctx context.Context, in *QuoteForexForwardRequest, opts ...grpc.CallOption) (*ForexForwardQuote, error)
+	// CreateForexForward concludes a forward: locks the rate, reserves the
+	// RSD obligation on the client's RSD account, charges the commission,
+	// and persists the contract as 'active'.
+	CreateForexForward(ctx context.Context, in *CreateForexForwardRequest, opts ...grpc.CallOption) (*ForexForward, error)
+	// ListForexForwards returns the caller's forward contracts.
+	ListForexForwards(ctx context.Context, in *ListForexForwardsRequest, opts ...grpc.CallOption) (*ListForexForwardsResponse, error)
+	// CancelForexForward cancels a still-'active' contract and releases the
+	// reservation.
+	CancelForexForward(ctx context.Context, in *CancelForexForwardRequest, opts ...grpc.CallOption) (*ForexForward, error)
+	// GetForexForwardSpreads returns every configured pair's SpreadFactor.
+	GetForexForwardSpreads(ctx context.Context, in *GetForexForwardSpreadsRequest, opts ...grpc.CallOption) (*GetForexForwardSpreadsResponse, error)
+	// SetForexForwardSpread upserts a pair's SpreadFactor. Supervisor-only.
+	SetForexForwardSpread(ctx context.Context, in *SetForexForwardSpreadRequest, opts ...grpc.CallOption) (*ForexForwardSpread, error)
+	// RunForexForwardSettlement settles every active forward whose
+	// settlement date has arrived. Internal — driven by the scheduler.
+	RunForexForwardSettlement(ctx context.Context, in *RunForexForwardSettlementRequest, opts ...grpc.CallOption) (*RunForexForwardSettlementResponse, error)
 }
 
 type bankServiceClient struct {
@@ -692,6 +719,76 @@ func (c *bankServiceClient) RunSpentResetJob(ctx context.Context, in *RunSpentRe
 	return out, nil
 }
 
+func (c *bankServiceClient) QuoteForexForward(ctx context.Context, in *QuoteForexForwardRequest, opts ...grpc.CallOption) (*ForexForwardQuote, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForexForwardQuote)
+	err := c.cc.Invoke(ctx, BankService_QuoteForexForward_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) CreateForexForward(ctx context.Context, in *CreateForexForwardRequest, opts ...grpc.CallOption) (*ForexForward, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForexForward)
+	err := c.cc.Invoke(ctx, BankService_CreateForexForward_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) ListForexForwards(ctx context.Context, in *ListForexForwardsRequest, opts ...grpc.CallOption) (*ListForexForwardsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListForexForwardsResponse)
+	err := c.cc.Invoke(ctx, BankService_ListForexForwards_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) CancelForexForward(ctx context.Context, in *CancelForexForwardRequest, opts ...grpc.CallOption) (*ForexForward, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForexForward)
+	err := c.cc.Invoke(ctx, BankService_CancelForexForward_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) GetForexForwardSpreads(ctx context.Context, in *GetForexForwardSpreadsRequest, opts ...grpc.CallOption) (*GetForexForwardSpreadsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetForexForwardSpreadsResponse)
+	err := c.cc.Invoke(ctx, BankService_GetForexForwardSpreads_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) SetForexForwardSpread(ctx context.Context, in *SetForexForwardSpreadRequest, opts ...grpc.CallOption) (*ForexForwardSpread, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForexForwardSpread)
+	err := c.cc.Invoke(ctx, BankService_SetForexForwardSpread_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *bankServiceClient) RunForexForwardSettlement(ctx context.Context, in *RunForexForwardSettlementRequest, opts ...grpc.CallOption) (*RunForexForwardSettlementResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunForexForwardSettlementResponse)
+	err := c.cc.Invoke(ctx, BankService_RunForexForwardSettlement_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BankServiceServer is the server API for BankService service.
 // All implementations should embed UnimplementedBankServiceServer
 // for forward compatibility.
@@ -835,6 +932,26 @@ type BankServiceServer interface {
 	// RunSpentResetJob zeroes the daily/monthly spent counters that are due
 	// to roll over. Normally driven by the scheduler service; admin-only.
 	RunSpentResetJob(context.Context, *RunSpentResetJobRequest) (*RunSpentResetJobResponse, error)
+	// QuoteForexForward returns a side-effect-free preview of a prospective
+	// forward: the locked-in ForwardRate (= SpotAsk × (1 + days/365 ×
+	// spread)) plus the reserved obligation amount and commission.
+	QuoteForexForward(context.Context, *QuoteForexForwardRequest) (*ForexForwardQuote, error)
+	// CreateForexForward concludes a forward: locks the rate, reserves the
+	// RSD obligation on the client's RSD account, charges the commission,
+	// and persists the contract as 'active'.
+	CreateForexForward(context.Context, *CreateForexForwardRequest) (*ForexForward, error)
+	// ListForexForwards returns the caller's forward contracts.
+	ListForexForwards(context.Context, *ListForexForwardsRequest) (*ListForexForwardsResponse, error)
+	// CancelForexForward cancels a still-'active' contract and releases the
+	// reservation.
+	CancelForexForward(context.Context, *CancelForexForwardRequest) (*ForexForward, error)
+	// GetForexForwardSpreads returns every configured pair's SpreadFactor.
+	GetForexForwardSpreads(context.Context, *GetForexForwardSpreadsRequest) (*GetForexForwardSpreadsResponse, error)
+	// SetForexForwardSpread upserts a pair's SpreadFactor. Supervisor-only.
+	SetForexForwardSpread(context.Context, *SetForexForwardSpreadRequest) (*ForexForwardSpread, error)
+	// RunForexForwardSettlement settles every active forward whose
+	// settlement date has arrived. Internal — driven by the scheduler.
+	RunForexForwardSettlement(context.Context, *RunForexForwardSettlementRequest) (*RunForexForwardSettlementResponse, error)
 }
 
 // UnimplementedBankServiceServer should be embedded to have
@@ -984,6 +1101,27 @@ func (UnimplementedBankServiceServer) RunMaintenanceFeeJob(context.Context, *Run
 }
 func (UnimplementedBankServiceServer) RunSpentResetJob(context.Context, *RunSpentResetJobRequest) (*RunSpentResetJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunSpentResetJob not implemented")
+}
+func (UnimplementedBankServiceServer) QuoteForexForward(context.Context, *QuoteForexForwardRequest) (*ForexForwardQuote, error) {
+	return nil, status.Error(codes.Unimplemented, "method QuoteForexForward not implemented")
+}
+func (UnimplementedBankServiceServer) CreateForexForward(context.Context, *CreateForexForwardRequest) (*ForexForward, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateForexForward not implemented")
+}
+func (UnimplementedBankServiceServer) ListForexForwards(context.Context, *ListForexForwardsRequest) (*ListForexForwardsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListForexForwards not implemented")
+}
+func (UnimplementedBankServiceServer) CancelForexForward(context.Context, *CancelForexForwardRequest) (*ForexForward, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelForexForward not implemented")
+}
+func (UnimplementedBankServiceServer) GetForexForwardSpreads(context.Context, *GetForexForwardSpreadsRequest) (*GetForexForwardSpreadsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetForexForwardSpreads not implemented")
+}
+func (UnimplementedBankServiceServer) SetForexForwardSpread(context.Context, *SetForexForwardSpreadRequest) (*ForexForwardSpread, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetForexForwardSpread not implemented")
+}
+func (UnimplementedBankServiceServer) RunForexForwardSettlement(context.Context, *RunForexForwardSettlementRequest) (*RunForexForwardSettlementResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunForexForwardSettlement not implemented")
 }
 func (UnimplementedBankServiceServer) testEmbeddedByValue() {}
 
@@ -1851,6 +1989,132 @@ func _BankService_RunSpentResetJob_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BankService_QuoteForexForward_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QuoteForexForwardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).QuoteForexForward(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_QuoteForexForward_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).QuoteForexForward(ctx, req.(*QuoteForexForwardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_CreateForexForward_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateForexForwardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).CreateForexForward(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_CreateForexForward_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).CreateForexForward(ctx, req.(*CreateForexForwardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_ListForexForwards_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListForexForwardsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).ListForexForwards(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_ListForexForwards_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).ListForexForwards(ctx, req.(*ListForexForwardsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_CancelForexForward_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelForexForwardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).CancelForexForward(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_CancelForexForward_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).CancelForexForward(ctx, req.(*CancelForexForwardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_GetForexForwardSpreads_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetForexForwardSpreadsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).GetForexForwardSpreads(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_GetForexForwardSpreads_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).GetForexForwardSpreads(ctx, req.(*GetForexForwardSpreadsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_SetForexForwardSpread_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetForexForwardSpreadRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).SetForexForwardSpread(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_SetForexForwardSpread_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).SetForexForwardSpread(ctx, req.(*SetForexForwardSpreadRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BankService_RunForexForwardSettlement_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunForexForwardSettlementRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BankServiceServer).RunForexForwardSettlement(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BankService_RunForexForwardSettlement_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BankServiceServer).RunForexForwardSettlement(ctx, req.(*RunForexForwardSettlementRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BankService_ServiceDesc is the grpc.ServiceDesc for BankService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2045,6 +2309,34 @@ var BankService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RunSpentResetJob",
 			Handler:    _BankService_RunSpentResetJob_Handler,
+		},
+		{
+			MethodName: "QuoteForexForward",
+			Handler:    _BankService_QuoteForexForward_Handler,
+		},
+		{
+			MethodName: "CreateForexForward",
+			Handler:    _BankService_CreateForexForward_Handler,
+		},
+		{
+			MethodName: "ListForexForwards",
+			Handler:    _BankService_ListForexForwards_Handler,
+		},
+		{
+			MethodName: "CancelForexForward",
+			Handler:    _BankService_CancelForexForward_Handler,
+		},
+		{
+			MethodName: "GetForexForwardSpreads",
+			Handler:    _BankService_GetForexForwardSpreads_Handler,
+		},
+		{
+			MethodName: "SetForexForwardSpread",
+			Handler:    _BankService_SetForexForwardSpread_Handler,
+		},
+		{
+			MethodName: "RunForexForwardSettlement",
+			Handler:    _BankService_RunForexForwardSettlement_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/bank/v1/bank.proto
+++ b/proto/bank/v1/bank.proto
@@ -375,6 +375,58 @@ service BankService {
       body: "*"
     };
   }
+
+  // -----------------------------------------------------------------
+  // Forex forwards (terminski valutni ugovori, todoSpec C3)
+  // -----------------------------------------------------------------
+
+  // QuoteForexForward returns a side-effect-free preview of a prospective
+  // forward: the locked-in ForwardRate (= SpotAsk × (1 + days/365 ×
+  // spread)) plus the reserved obligation amount and commission.
+  rpc QuoteForexForward(QuoteForexForwardRequest) returns (ForexForwardQuote) {
+    option (google.api.http) = {
+      post: "/api/v1/forex-forwards/quote"
+      body: "*"
+    };
+  }
+
+  // CreateForexForward concludes a forward: locks the rate, reserves the
+  // RSD obligation on the client's RSD account, charges the commission,
+  // and persists the contract as 'active'.
+  rpc CreateForexForward(CreateForexForwardRequest) returns (ForexForward) {
+    option (google.api.http) = {
+      post: "/api/v1/forex-forwards"
+      body: "*"
+    };
+  }
+
+  // ListForexForwards returns the caller's forward contracts.
+  rpc ListForexForwards(ListForexForwardsRequest) returns (ListForexForwardsResponse) {
+    option (google.api.http) = {get: "/api/v1/forex-forwards"};
+  }
+
+  // CancelForexForward cancels a still-'active' contract and releases the
+  // reservation.
+  rpc CancelForexForward(CancelForexForwardRequest) returns (ForexForward) {
+    option (google.api.http) = {delete: "/api/v1/forex-forwards/{id}"};
+  }
+
+  // GetForexForwardSpreads returns every configured pair's SpreadFactor.
+  rpc GetForexForwardSpreads(GetForexForwardSpreadsRequest) returns (GetForexForwardSpreadsResponse) {
+    option (google.api.http) = {get: "/api/v1/forex-forwards/spreads"};
+  }
+
+  // SetForexForwardSpread upserts a pair's SpreadFactor. Supervisor-only.
+  rpc SetForexForwardSpread(SetForexForwardSpreadRequest) returns (ForexForwardSpread) {
+    option (google.api.http) = {
+      put: "/api/v1/forex-forwards/spreads"
+      body: "*"
+    };
+  }
+
+  // RunForexForwardSettlement settles every active forward whose
+  // settlement date has arrived. Internal — driven by the scheduler.
+  rpc RunForexForwardSettlement(RunForexForwardSettlementRequest) returns (RunForexForwardSettlementResponse);
 }
 
 // =====================================================================
@@ -1463,4 +1515,104 @@ message RunSpentResetJobRequest {}
 message RunSpentResetJobResponse {
   int64 daily = 1;
   int64 monthly = 2;
+}
+
+// =====================================================================
+// Forex forwards (terminski valutni ugovori, todoSpec C3)
+// =====================================================================
+
+enum ForexForwardStatus {
+  FOREX_FORWARD_STATUS_UNSPECIFIED = 0;
+  FOREX_FORWARD_STATUS_ACTIVE = 1;
+  FOREX_FORWARD_STATUS_SETTLED = 2;
+  FOREX_FORWARD_STATUS_CANCELLED = 3;
+  FOREX_FORWARD_STATUS_FAILED = 4;
+}
+
+// ForexForward is one concluded forward contract.
+message ForexForward {
+  string id = 1;
+  string client_id = 2;
+  Currency base_currency = 3; // notional currency (bought forward)
+  Currency quote_currency = 4; // settlement leg (RSD)
+  string notional = 5;
+  string forward_rate = 6; // locked quote-per-1-base
+  string spot_ask_rate = 7;
+  string spread_factor = 8;
+  int32 days_to_settlement = 9;
+  string commission = 10;
+  string reservation_id = 11;
+  string from_account_id = 12; // client RSD account, debited at settlement
+  string to_account_id = 13; // client base-currency account, credited at settlement
+  google.protobuf.Timestamp settlement_date = 14;
+  ForexForwardStatus status = 15;
+  string failure_reason = 16;
+  google.protobuf.Timestamp created_at = 17;
+  google.protobuf.Timestamp settled_at = 18;
+}
+
+// ForexForwardSpread is the per-pair annualised spread factor.
+message ForexForwardSpread {
+  Currency base_currency = 1;
+  Currency quote_currency = 2;
+  string spread_factor = 3;
+  string updated_by = 4;
+  google.protobuf.Timestamp updated_at = 5;
+}
+
+// ForexForwardQuote is the side-effect-free preview returned by
+// QuoteForexForward.
+message ForexForwardQuote {
+  Currency base_currency = 1;
+  Currency quote_currency = 2;
+  string notional = 3;
+  string spot_ask_rate = 4;
+  string spread_factor = 5;
+  int32 days_to_settlement = 6;
+  string forward_rate = 7;
+  string quote_amount = 8; // forward_rate × notional (reserved at conclusion)
+  string commission = 9;
+}
+
+message QuoteForexForwardRequest {
+  Currency base_currency = 1 [(buf.validate.field).enum.defined_only = true];
+  string notional = 2 [(buf.validate.field).string.min_len = 1];
+  // YYYY-MM-DD settlement date in the future.
+  google.protobuf.Timestamp settlement_date = 3 [(buf.validate.field).required = true];
+}
+
+message CreateForexForwardRequest {
+  Currency base_currency = 1 [(buf.validate.field).enum.defined_only = true];
+  string notional = 2 [(buf.validate.field).string.min_len = 1];
+  google.protobuf.Timestamp settlement_date = 3 [(buf.validate.field).required = true];
+}
+
+message ListForexForwardsRequest {}
+
+message ListForexForwardsResponse {
+  repeated ForexForward forex_forwards = 1;
+}
+
+message CancelForexForwardRequest {
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+message GetForexForwardSpreadsRequest {}
+
+message GetForexForwardSpreadsResponse {
+  repeated ForexForwardSpread spreads = 1;
+}
+
+message SetForexForwardSpreadRequest {
+  Currency base_currency = 1 [(buf.validate.field).enum.defined_only = true];
+  Currency quote_currency = 2 [(buf.validate.field).enum.defined_only = true];
+  string spread_factor = 3 [(buf.validate.field).string.min_len = 1];
+}
+
+message RunForexForwardSettlementRequest {}
+
+message RunForexForwardSettlementResponse {
+  int32 processed = 1;
+  int32 settled = 2;
+  int32 failed = 3;
 }

--- a/services/bank/internal/domain/forex_forward.go
+++ b/services/bank/internal/domain/forex_forward.go
@@ -1,0 +1,58 @@
+package domain
+
+import "time"
+
+// =====================================================================
+// Forex forwards (terminski valutni ugovori, todoSpec C3)
+// =====================================================================
+
+// ForexForwardStatus pins the bank.forex_forwards row lifecycle.
+type ForexForwardStatus string
+
+const (
+	// ForexForwardActive — concluded, quote-currency obligation reserved,
+	// awaiting its settlement date.
+	ForexForwardActive ForexForwardStatus = "active"
+	// ForexForwardSettled — the settlement sweep performed the direct
+	// fixed-rate conversion successfully.
+	ForexForwardSettled ForexForwardStatus = "settled"
+	// ForexForwardCancelled — the client cancelled while still active; the
+	// reservation was released.
+	ForexForwardCancelled ForexForwardStatus = "cancelled"
+	// ForexForwardFailed — the settlement sweep could not complete (e.g.
+	// the reserved funds were already spent through another path); the
+	// reservation, if still held, is released.
+	ForexForwardFailed ForexForwardStatus = "failed"
+)
+
+// ForexForwardSpread is the per-pair annualised spread factor used in the
+// forward-rate formula. Set by supervisors.
+type ForexForwardSpread struct {
+	BaseCurrency  Currency
+	QuoteCurrency Currency
+	SpreadFactor  string // decimal string, e.g. "0.02" = 2%/yr
+	UpdatedBy     string
+	UpdatedAt     time.Time
+}
+
+// ForexForward is one concluded forward contract.
+type ForexForward struct {
+	ID               string
+	ClientID         string
+	BaseCurrency     Currency // notional currency (bought forward, credited at settlement)
+	QuoteCurrency    Currency // settlement-leg currency (RSD; debited at settlement)
+	Notional         string
+	ForwardRate      string // locked quote-per-1-base
+	SpotAskRate      string // spot ASK at conclusion (quote per 1 base)
+	SpreadFactor     string
+	DaysToSettlement int
+	Commission       string // in quote currency
+	ReservationID    string // op_id of the held reservation on the quote account
+	FromAccountID    string // client's quote (RSD) account
+	ToAccountID      string // client's base-currency account
+	SettlementDate   time.Time
+	Status           ForexForwardStatus
+	FailureReason    string
+	CreatedAt        time.Time
+	SettledAt        *time.Time
+}

--- a/services/bank/internal/domain/payments.go
+++ b/services/bank/internal/domain/payments.go
@@ -41,6 +41,15 @@ const (
 	// engine converts (commission-free) so RSD-only holders still get
 	// paid (S56).
 	TxKindDividend TransactionKind = "dividend"
+
+	// TxKindForexForward tags the settlement leg of a forex forward
+	// (terminski valutni ugovor, todoSpec C3). On the settlement date the
+	// bank performs a DIRECT fixed-rate conversion at the locked
+	// ForwardRate (not a menjačnica RSD round-trip): debit RSD from the
+	// client's RSD account and credit the notional in the base currency
+	// to the client's base-currency account, both legs hopping through
+	// the bank's per-currency house accounts.
+	TxKindForexForward TransactionKind = "forex_forward"
 )
 
 // ReservationState pins the bank.reservations row lifecycle (c4).

--- a/services/bank/internal/server/forex_forward.go
+++ b/services/bank/internal/server/forex_forward.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"context"
+
+	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/service"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func (s *Server) QuoteForexForward(ctx context.Context, in *bankpb.QuoteForexForwardRequest) (*bankpb.ForexForwardQuote, error) {
+	q, err := s.Svc.QuoteForexForward(ctx,
+		currencyFromProto(in.GetBaseCurrency()),
+		domain.CurrencyRSD,
+		in.GetNotional(),
+		in.GetSettlementDate().AsTime(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return forexForwardQuoteToProto(q), nil
+}
+
+func (s *Server) CreateForexForward(ctx context.Context, in *bankpb.CreateForexForwardRequest) (*bankpb.ForexForward, error) {
+	f, err := s.Svc.CreateForexForward(ctx, service.CreateForexForwardInput{
+		BaseCurrency:   currencyFromProto(in.GetBaseCurrency()),
+		Notional:       in.GetNotional(),
+		SettlementDate: in.GetSettlementDate().AsTime(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return forexForwardToProto(f), nil
+}
+
+func (s *Server) ListForexForwards(ctx context.Context, _ *bankpb.ListForexForwardsRequest) (*bankpb.ListForexForwardsResponse, error) {
+	fs, err := s.Svc.ListForexForwards(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*bankpb.ForexForward, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, forexForwardToProto(f))
+	}
+	return &bankpb.ListForexForwardsResponse{ForexForwards: out}, nil
+}
+
+func (s *Server) CancelForexForward(ctx context.Context, in *bankpb.CancelForexForwardRequest) (*bankpb.ForexForward, error) {
+	f, err := s.Svc.CancelForexForward(ctx, in.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return forexForwardToProto(f), nil
+}
+
+func (s *Server) GetForexForwardSpreads(ctx context.Context, _ *bankpb.GetForexForwardSpreadsRequest) (*bankpb.GetForexForwardSpreadsResponse, error) {
+	sps, err := s.Svc.GetForexForwardSpreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*bankpb.ForexForwardSpread, 0, len(sps))
+	for _, sp := range sps {
+		out = append(out, forexForwardSpreadToProto(sp))
+	}
+	return &bankpb.GetForexForwardSpreadsResponse{Spreads: out}, nil
+}
+
+func (s *Server) SetForexForwardSpread(ctx context.Context, in *bankpb.SetForexForwardSpreadRequest) (*bankpb.ForexForwardSpread, error) {
+	sp, err := s.Svc.SetForexForwardSpread(ctx,
+		currencyFromProto(in.GetBaseCurrency()),
+		currencyFromProto(in.GetQuoteCurrency()),
+		in.GetSpreadFactor(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return forexForwardSpreadToProto(sp), nil
+}
+
+func (s *Server) RunForexForwardSettlement(ctx context.Context, _ *bankpb.RunForexForwardSettlementRequest) (*bankpb.RunForexForwardSettlementResponse, error) {
+	r, err := s.Svc.RunForexForwardSettlement(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &bankpb.RunForexForwardSettlementResponse{
+		Processed: int32(r.Processed),
+		Settled:   int32(r.Settled),
+		Failed:    int32(r.Failed),
+	}, nil
+}
+
+func forexForwardToProto(f *domain.ForexForward) *bankpb.ForexForward {
+	out := &bankpb.ForexForward{
+		Id:               f.ID,
+		ClientId:         f.ClientID,
+		BaseCurrency:     currencyToProto(f.BaseCurrency),
+		QuoteCurrency:    currencyToProto(f.QuoteCurrency),
+		Notional:         f.Notional,
+		ForwardRate:      f.ForwardRate,
+		SpotAskRate:      f.SpotAskRate,
+		SpreadFactor:     f.SpreadFactor,
+		DaysToSettlement: int32(f.DaysToSettlement),
+		Commission:       f.Commission,
+		ReservationId:    f.ReservationID,
+		FromAccountId:    f.FromAccountID,
+		ToAccountId:      f.ToAccountID,
+		SettlementDate:   timestamppb.New(f.SettlementDate),
+		Status:           forexForwardStatusToProto(f.Status),
+		FailureReason:    f.FailureReason,
+		CreatedAt:        timestamppb.New(f.CreatedAt),
+	}
+	if f.SettledAt != nil {
+		out.SettledAt = timestamppb.New(*f.SettledAt)
+	}
+	return out
+}
+
+func forexForwardSpreadToProto(sp *domain.ForexForwardSpread) *bankpb.ForexForwardSpread {
+	return &bankpb.ForexForwardSpread{
+		BaseCurrency:  currencyToProto(sp.BaseCurrency),
+		QuoteCurrency: currencyToProto(sp.QuoteCurrency),
+		SpreadFactor:  sp.SpreadFactor,
+		UpdatedBy:     sp.UpdatedBy,
+		UpdatedAt:     timestamppb.New(sp.UpdatedAt),
+	}
+}
+
+func forexForwardQuoteToProto(q *service.ForexForwardQuote) *bankpb.ForexForwardQuote {
+	return &bankpb.ForexForwardQuote{
+		BaseCurrency:     currencyToProto(q.BaseCurrency),
+		QuoteCurrency:    currencyToProto(q.QuoteCurrency),
+		Notional:         q.Notional,
+		SpotAskRate:      q.SpotAskRate,
+		SpreadFactor:     q.SpreadFactor,
+		DaysToSettlement: int32(q.DaysToSettlement),
+		ForwardRate:      q.ForwardRate,
+		QuoteAmount:      q.QuoteAmount,
+		Commission:       q.Commission,
+	}
+}
+
+func forexForwardStatusToProto(st domain.ForexForwardStatus) bankpb.ForexForwardStatus {
+	switch st {
+	case domain.ForexForwardActive:
+		return bankpb.ForexForwardStatus_FOREX_FORWARD_STATUS_ACTIVE
+	case domain.ForexForwardSettled:
+		return bankpb.ForexForwardStatus_FOREX_FORWARD_STATUS_SETTLED
+	case domain.ForexForwardCancelled:
+		return bankpb.ForexForwardStatus_FOREX_FORWARD_STATUS_CANCELLED
+	case domain.ForexForwardFailed:
+		return bankpb.ForexForwardStatus_FOREX_FORWARD_STATUS_FAILED
+	}
+	return bankpb.ForexForwardStatus_FOREX_FORWARD_STATUS_UNSPECIFIED
+}

--- a/services/bank/internal/service/forex_forward.go
+++ b/services/bank/internal/service/forex_forward.go
@@ -1,0 +1,527 @@
+// Forex forwards (terminski valutni ugovori, todoSpec C3).
+//
+// A forex forward is a contract between a client and the bank that fixes
+// TODAY a rate for a FUTURE currency conversion. The forward rate is
+//
+//   ForwardRate = SpotAskRate × (1 + (DaysToSettlement / 365) × SpreadFactor)
+//
+// where SpotAskRate is the spot ASK for base→RSD (spec p.26 always-ASK
+// policy, reused via the menjačnica rate provider) and SpreadFactor is a
+// per-pair bank parameter set by supervisors.
+//
+// At conclusion the bank RESERVES the quote-currency obligation
+// (ForwardRate × Notional, in RSD) on the client's RSD account through
+// the existing reservation primitive and charges a commission. On the
+// settlement date the bank performs a DIRECT fixed-rate conversion: debit
+// RSD (ForwardRate × Notional) from the client's RSD account and credit
+// Notional in the base currency to the client's base-currency account.
+// This is NOT a menjačnica RSD round-trip — the spread risk is already
+// priced into ForwardRate — so the conversion runs commission-free at the
+// locked rate, hopping through the bank's per-currency house accounts.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/schedule"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// defaultForexForwardSpread is the fallback annualised spread factor (2%)
+// used when a supervisor hasn't configured the pair yet.
+const defaultForexForwardSpread = "0.02"
+
+// daysInYear is the day-count basis in the forward-rate formula.
+const daysInYear = 365
+
+// computeForwardRate applies the spec forward-rate formula:
+//
+//	ForwardRate = SpotAskRate × (1 + (DaysToSettlement / 365) × SpreadFactor)
+//
+// Pure function over *big.Rat so it's unit-testable with an exact worked
+// example. spotAsk and spreadFactor are the spot ASK (quote per 1 base)
+// and the annualised spread factor; days is the calendar days to
+// settlement.
+func computeForwardRate(spotAsk, spreadFactor *big.Rat, days int) *big.Rat {
+	// fraction = days / 365
+	fraction := new(big.Rat).SetFrac64(int64(days), daysInYear)
+	// factor = 1 + fraction × spreadFactor
+	factor := money.Add(money.MustParse("1"), money.Mul(fraction, spreadFactor))
+	return money.Mul(spotAsk, factor)
+}
+
+// daysToSettlement returns the whole calendar days from now to the
+// settlement date, rounded up so a same-day-plus-a-bit settlement counts
+// as at least one day. Caller guarantees settlement is strictly future.
+func daysToSettlement(now, settlement time.Time) int {
+	d := settlement.Sub(now)
+	days := int(d.Hours() / 24)
+	if time.Duration(days)*24*time.Hour < d {
+		days++
+	}
+	if days < 1 {
+		days = 1
+	}
+	return days
+}
+
+// ForexForwardQuote is the resolved preview of a prospective forward.
+type ForexForwardQuote struct {
+	BaseCurrency     domain.Currency
+	QuoteCurrency    domain.Currency
+	Notional         string
+	SpotAskRate      string
+	SpreadFactor     string
+	DaysToSettlement int
+	ForwardRate      string
+	QuoteAmount      string // forward_rate × notional, in quote currency (reserved at conclusion)
+	Commission       string // in quote currency
+}
+
+// quoteCurrency is the settlement leg currency for every forward — the
+// bank only holds an RSD account for the obligation leg, mirroring the
+// capital-gains-tax model.
+const forwardQuoteCurrency = domain.CurrencyRSD
+
+// resolveSpreadFactor returns the configured SpreadFactor for the pair,
+// or the default when unset.
+func (s *Service) resolveSpreadFactor(ctx context.Context, base, quote domain.Currency) (*big.Rat, string, error) {
+	sp, err := s.Store.GetForexForwardSpread(ctx, base, quote)
+	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			return money.MustParse(defaultForexForwardSpread), defaultForexForwardSpread, nil
+		}
+		return nil, "", err
+	}
+	r, perr := money.Parse(sp.SpreadFactor)
+	if perr != nil {
+		return nil, "", apperr.Internal("parse spread factor", perr)
+	}
+	return r, sp.SpreadFactor, nil
+}
+
+// quoteForward computes the forward rate + amounts without side effects.
+// Shared by QuoteForexForward (preview) and CreateForexForward.
+func (s *Service) quoteForward(ctx context.Context, base, quote domain.Currency, notional string, settlement time.Time) (*ForexForwardQuote, *big.Rat, error) {
+	if !base.Supported() || !quote.Supported() {
+		return nil, nil, apperr.Validation("unsupported currency")
+	}
+	if quote != forwardQuoteCurrency {
+		return nil, nil, apperr.Validation("terminski ugovor se poravnava u RSD")
+	}
+	if base == quote {
+		return nil, nil, apperr.Validation("valute terminskog ugovora moraju biti različite")
+	}
+	notionalR, err := parsePositive(notional)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := schedule.ValidateFuture(settlement, s.now()); err != nil {
+		return nil, nil, apperr.Validation(err.Error())
+	}
+	if s.Rates == nil {
+		return nil, nil, apperr.Internal("exchange rate provider not configured", nil)
+	}
+
+	days := daysToSettlement(s.now(), settlement)
+
+	// Spot ASK for base→RSD per spec p.26 (always sell-side).
+	_, ask, err := s.Rates.Quote(ctx, base, quote)
+	if err != nil {
+		return nil, nil, err
+	}
+	spotAsk, perr := money.Parse(ask)
+	if perr != nil {
+		return nil, nil, apperr.Internal("parse spot ask", perr)
+	}
+	if !money.IsPositive(spotAsk) {
+		return nil, nil, apperr.Internal("spot ask non-positive", nil)
+	}
+
+	spreadFactor, spreadStr, err := s.resolveSpreadFactor(ctx, base, quote)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	forwardRate := computeForwardRate(spotAsk, spreadFactor, days)
+	quoteAmount := money.Mul(forwardRate, notionalR)
+	commission := money.Mul(quoteAmount, s.commissionRate())
+
+	return &ForexForwardQuote{
+		BaseCurrency:     base,
+		QuoteCurrency:    quote,
+		Notional:         money.FormatAmount(notionalR),
+		SpotAskRate:      money.FormatRate(spotAsk),
+		SpreadFactor:     spreadStr,
+		DaysToSettlement: days,
+		ForwardRate:      money.FormatRate(forwardRate),
+		QuoteAmount:      money.FormatAmount(quoteAmount),
+		Commission:       money.FormatAmount(commission),
+	}, quoteAmount, nil
+}
+
+// QuoteForexForward returns a side-effect-free preview of a prospective
+// forward. Available to any payment-capable principal.
+func (s *Service) QuoteForexForward(ctx context.Context, base, quote domain.Currency, notional string, settlement time.Time) (*ForexForwardQuote, error) {
+	if err := s.requirePermission(ctx, permissions.PaymentWrite); err != nil {
+		return nil, err
+	}
+	q, _, err := s.quoteForward(ctx, base, quote, notional, settlement)
+	return q, err
+}
+
+// CreateForexForwardInput is the validated payload for concluding a
+// forward.
+type CreateForexForwardInput struct {
+	BaseCurrency   domain.Currency
+	Notional       string
+	SettlementDate time.Time
+}
+
+// CreateForexForward locks the forward rate, reserves the quote-currency
+// obligation (forward_rate × notional) on the client's RSD account via
+// the existing reservation primitive, charges the commission, and
+// persists the contract as 'active'. The client must hold both an RSD
+// account (the obligation/settlement leg) and a base-currency account
+// (credited at settlement).
+func (s *Service) CreateForexForward(ctx context.Context, in CreateForexForwardInput) (*domain.ForexForward, error) {
+	if err := s.requirePermission(ctx, permissions.PaymentWrite); err != nil {
+		return nil, err
+	}
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if p.UserKind != auth.KindClient {
+		return nil, apperr.Validation("terminski ugovor mogu zaključiti samo klijenti")
+	}
+
+	quote := forwardQuoteCurrency
+	preview, quoteAmount, err := s.quoteForward(ctx, in.BaseCurrency, quote, in.Notional, in.SettlementDate)
+	if err != nil {
+		return nil, err
+	}
+	commission := money.Mul(quoteAmount, s.commissionRate())
+
+	// Resolve the client's RSD (obligation) account and base-currency
+	// (credit) account.
+	rsdAcc, err := s.clientAccountByCurrency(ctx, p.UserID, quote)
+	if err != nil {
+		return nil, err
+	}
+	baseAcc, err := s.clientAccountByCurrency(ctx, p.UserID, in.BaseCurrency)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reserve the obligation amount on the RSD account. The reservation
+	// primitive debits available_balance now; the settlement sweep commits
+	// it (debits balance) at the fixed rate. Reservation is internal-only,
+	// so present an admin-flavoured outgoing principal.
+	opID := uuid.NewString()
+	reserveCtx := s.internalCtx(ctx)
+	if _, err := s.ReserveFunds(reserveCtx, ReserveFundsInput{
+		AccountID: rsdAcc.ID,
+		Amount:    money.FormatAmount(quoteAmount),
+		Currency:  quote,
+		OpID:      opID,
+		OpKind:    string(domain.TxKindForexForward),
+	}); err != nil {
+		return nil, err
+	}
+
+	// Charge the commission from the client's RSD account into the bank's
+	// RSD house account, then persist the contract — all atomic, so a
+	// failed insert rolls back the commission. (The reservation already
+	// committed available_balance; if the insert fails below we release
+	// it.)
+	var out *domain.ForexForward
+	err = s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+		if money.IsPositive(commission) {
+			house, herr := s.Store.GetSystemAccount(ctx, quote)
+			if herr != nil {
+				return herr
+			}
+			negComm := money.FormatAmount(money.Sub(money.MustParse("0"), commission))
+			if cerr := s.Store.CheckLimits(ctx, tx, rsdAcc.ID, money.FormatAmount(commission)); cerr != nil {
+				return cerr
+			}
+			if cerr := s.Store.AdjustBalance(ctx, tx, rsdAcc.ID, negComm); cerr != nil {
+				return cerr
+			}
+			if cerr := s.Store.AdjustBalance(ctx, tx, house.ID, money.FormatAmount(commission)); cerr != nil {
+				return cerr
+			}
+			if _, cerr := s.Store.InsertTransaction(ctx, tx, &domain.Transaction{
+				OpID: opID, Kind: domain.TxKindFee, LegIndex: 100,
+				FromAccountID: rsdAcc.ID, ToAccountID: house.ID,
+				FromAmount: money.FormatAmount(commission), ToAmount: money.FormatAmount(commission),
+				Purpose:           "Provizija za terminski ugovor",
+				InitiatorClientID: p.UserID,
+				Status:            domain.TxStatusRealized,
+			}); cerr != nil {
+				return cerr
+			}
+		}
+		row, ierr := s.Store.InsertForexForward(ctx, tx, &domain.ForexForward{
+			ClientID:         p.UserID,
+			BaseCurrency:     in.BaseCurrency,
+			QuoteCurrency:    quote,
+			Notional:         preview.Notional,
+			ForwardRate:      preview.ForwardRate,
+			SpotAskRate:      preview.SpotAskRate,
+			SpreadFactor:     preview.SpreadFactor,
+			DaysToSettlement: preview.DaysToSettlement,
+			Commission:       money.FormatAmount(commission),
+			ReservationID:    opID,
+			FromAccountID:    rsdAcc.ID,
+			ToAccountID:      baseAcc.ID,
+			SettlementDate:   in.SettlementDate,
+		})
+		if ierr != nil {
+			return ierr
+		}
+		out = row
+		return nil
+	})
+	if err != nil {
+		// Roll back the reservation we made before the tx.
+		_, _ = s.ReleaseFunds(reserveCtx, opID)
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListForexForwards returns the caller's own forward contracts.
+func (s *Service) ListForexForwards(ctx context.Context) ([]*domain.ForexForward, error) {
+	if err := s.requirePermission(ctx, permissions.PaymentWrite); err != nil {
+		return nil, err
+	}
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.Store.ListForexForwardsByClient(ctx, p.UserID)
+}
+
+// CancelForexForward cancels a still-'active' contract owned by the caller
+// and releases the held reservation.
+func (s *Service) CancelForexForward(ctx context.Context, id string) (*domain.ForexForward, error) {
+	if err := s.requirePermission(ctx, permissions.PaymentWrite); err != nil {
+		return nil, err
+	}
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if id == "" {
+		return nil, apperr.Validation("id is required")
+	}
+	f, err := s.Store.CancelForexForward(ctx, id, p.UserID)
+	if err != nil {
+		return nil, err
+	}
+	// Release the obligation reservation (best-effort, idempotent).
+	if _, rerr := s.ReleaseFunds(s.internalCtx(ctx), f.ReservationID); rerr != nil {
+		s.Log.WarnContext(ctx, "forex forward cancel: release reservation failed",
+			"id", f.ID, "reservation_id", f.ReservationID, "err", rerr.Error())
+	}
+	return f, nil
+}
+
+// ForexForwardSettlementResult tallies one settlement-sweep pass.
+type ForexForwardSettlementResult struct {
+	Processed int
+	Settled   int
+	Failed    int
+}
+
+// RunForexForwardSettlement settles every 'active' forward whose
+// settlement date has arrived. Admin-only (the scheduler presents an
+// admin principal). For each due contract it commits the held reservation
+// into a DIRECT fixed-rate conversion: the reserved RSD (forward_rate ×
+// notional) settles against the client's base-currency account, crediting
+// exactly the notional at the locked rate (commission-free — the spread
+// is already in the rate). On success the row is 'settled' and the client
+// notified; on failure 'failed' + release + notify. Idempotent: the
+// CommitReservedFunds op_id guard means a re-swept already-committed
+// reservation returns its existing legs without double-crediting.
+func (s *Service) RunForexForwardSettlement(ctx context.Context) (*ForexForwardSettlementResult, error) {
+	if err := s.requirePermission(ctx, permissions.Admin); err != nil {
+		return nil, err
+	}
+	now := s.now()
+	due, err := s.Store.ListDueForexForwards(ctx, now)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ForexForwardSettlementResult{}
+	for _, f := range due {
+		res.Processed++
+		execErr := s.settleForexForward(ctx, f)
+		at := s.now()
+		switch {
+		case execErr == nil:
+			if merr := s.Store.MarkForexForwardSettled(ctx, f.ID, at); merr != nil {
+				s.Log.WarnContext(ctx, "forex forward mark-settled failed", "id", f.ID, "err", merr.Error())
+				continue
+			}
+			res.Settled++
+			s.notifyForexForwardSettled(ctx, f)
+		default:
+			// Settlement could not complete (e.g. the reserved funds were
+			// somehow spent, or a balance invariant tripped). Mark failed,
+			// release the reservation, notify.
+			reason := "poravnanje terminskog ugovora nije uspelo"
+			if errors.Is(execErr, errForwardReleasedReservation) {
+				reason = "rezervisana sredstva više nisu dostupna"
+			}
+			if merr := s.Store.MarkForexForwardFailed(ctx, f.ID, reason, at); merr != nil {
+				s.Log.WarnContext(ctx, "forex forward mark-failed failed", "id", f.ID, "err", merr.Error())
+				continue
+			}
+			_, _ = s.ReleaseFunds(s.internalCtx(ctx), f.ReservationID)
+			res.Failed++
+			s.notifyForexForwardFailed(ctx, f, reason)
+			s.Log.WarnContext(ctx, "forex forward settlement failed",
+				"id", f.ID, "client_id", f.ClientID, "err", execErr.Error())
+		}
+	}
+	return res, nil
+}
+
+// errForwardReleasedReservation flags that the held reservation was no
+// longer 'held' at settlement time (released/committed elsewhere).
+var errForwardReleasedReservation = errors.New("reservation no longer held")
+
+// settleForexForward commits the contract's reservation into the direct
+// fixed-rate conversion. The reserved amount (forward_rate × notional, in
+// RSD) is committed against the client's base-currency account, crediting
+// exactly the contract notional. CommitReservedFunds writes the FX-leg
+// ledger rows hopping through the bank's house accounts; passing
+// IsActuary=true zeroes any commission so the move runs at the locked
+// rate exactly.
+func (s *Service) settleForexForward(ctx context.Context, f *domain.ForexForward) error {
+	_, err := s.CommitReservedFunds(s.internalCtx(ctx), CommitReservedFundsInput{
+		OpID:          f.ReservationID,
+		DestAccountID: f.ToAccountID,
+		DestAmount:    f.Notional,
+		DestCurrency:  f.BaseCurrency,
+		IsActuary:     true, // fixed-rate, commission-free
+		Purpose:       "Poravnanje terminskog ugovora",
+	})
+	if err != nil {
+		if apperrIs(err, apperr.KindFailedPrecondition) {
+			return errForwardReleasedReservation
+		}
+		return err
+	}
+	return nil
+}
+
+// =====================================================================
+// Spread factor configuration (supervisor-set)
+// =====================================================================
+
+// GetForexForwardSpreads returns every configured pair's SpreadFactor.
+// Available to any payment-capable principal (clients see what they'll be
+// quoted; supervisors edit).
+func (s *Service) GetForexForwardSpreads(ctx context.Context) ([]*domain.ForexForwardSpread, error) {
+	if err := s.requirePermission(ctx, permissions.PaymentWrite); err != nil {
+		return nil, err
+	}
+	return s.Store.ListForexForwardSpreads(ctx)
+}
+
+// SetForexForwardSpread upserts a pair's SpreadFactor. Supervisor-only
+// (spec: bank parameters are supervisor-managed). Admin also admitted.
+func (s *Service) SetForexForwardSpread(ctx context.Context, base, quote domain.Currency, spreadFactor string) (*domain.ForexForwardSpread, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !permissions.HasAny(p.Permissions, permissions.ActuarySupervisor, permissions.Admin) {
+		return nil, apperr.PermissionDenied("samo supervizor može menjati parametre terminskih ugovora")
+	}
+	if !base.Supported() || !quote.Supported() {
+		return nil, apperr.Validation("unsupported currency")
+	}
+	if quote != forwardQuoteCurrency {
+		return nil, apperr.Validation("terminski ugovor se poravnava u RSD")
+	}
+	if base == quote {
+		return nil, apperr.Validation("valute moraju biti različite")
+	}
+	sf, perr := money.Parse(spreadFactor)
+	if perr != nil {
+		return nil, apperr.Validation(perr.Error())
+	}
+	if sf.Sign() < 0 {
+		return nil, apperr.Validation("spread faktor ne sme biti negativan")
+	}
+	return s.Store.UpsertForexForwardSpread(ctx, &domain.ForexForwardSpread{
+		BaseCurrency:  base,
+		QuoteCurrency: quote,
+		SpreadFactor:  money.FormatRate(sf),
+		UpdatedBy:     p.UserID,
+	})
+}
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+// clientAccountByCurrency resolves the client's single active account in
+// the given currency. Forwards need exactly one RSD obligation account
+// and one base-currency credit account.
+func (s *Service) clientAccountByCurrency(ctx context.Context, clientID string, cur domain.Currency) (*domain.Account, error) {
+	accs, _, err := s.Store.ListAccounts(ctx, domain.AccountFilter{
+		OwnerClientID: clientID,
+		Currency:      cur,
+		Status:        domain.AccountActive,
+		ExcludeKinds:  []domain.AccountKind{domain.KindSystem, domain.KindStateTax, domain.KindForexBook, domain.KindFund},
+	}, 1, 2)
+	if err != nil {
+		return nil, err
+	}
+	if len(accs) == 0 {
+		return nil, apperr.FailedPrecondition("klijent nema aktivan " + string(cur) + " račun")
+	}
+	return accs[0], nil
+}
+
+// internalCtx stamps an admin principal on the outgoing context so the
+// internal-only reservation RPCs (ReserveFunds / CommitReservedFunds /
+// ReleaseFunds) admit the call. These run within the same process, but
+// requireInternal reads the principal from context, so we present one.
+func (s *Service) internalCtx(ctx context.Context) context.Context {
+	return auth.WithPrincipal(ctx, auth.Principal{
+		UserID:      domain.SystemOwnerID,
+		UserKind:    auth.KindEmployee,
+		Permissions: []string{permissions.Admin},
+	})
+}
+
+func (s *Service) notifyForexForwardSettled(ctx context.Context, f *domain.ForexForward) {
+	body := "Poštovani,\n\nVaš terminski ugovor je poravnan: kupili ste " +
+		f.Notional + " " + string(f.BaseCurrency) + " po kursu " + f.ForwardRate +
+		" RSD.\n\nBanka 3"
+	s.notify(ctx, f.ClientID, "payment", "Terminski ugovor je poravnan", body)
+}
+
+func (s *Service) notifyForexForwardFailed(ctx context.Context, f *domain.ForexForward, reason string) {
+	body := "Poštovani,\n\nVaš terminski ugovor za " + f.Notional + " " +
+		string(f.BaseCurrency) + " nije mogao da se poravna (" + reason + ").\n\nBanka 3"
+	s.notify(ctx, f.ClientID, "payment", "Terminski ugovor nije poravnan", body)
+}

--- a/services/bank/internal/service/forex_forward.go
+++ b/services/bank/internal/service/forex_forward.go
@@ -371,8 +371,8 @@ func (s *Service) RunForexForwardSettlement(ctx context.Context) (*ForexForwardS
 		res.Processed++
 		execErr := s.settleForexForward(ctx, f)
 		at := s.now()
-		switch {
-		case execErr == nil:
+		switch execErr {
+		case nil:
 			if merr := s.Store.MarkForexForwardSettled(ctx, f.ID, at); merr != nil {
 				s.Log.WarnContext(ctx, "forex forward mark-settled failed", "id", f.ID, "err", merr.Error())
 				continue

--- a/services/bank/internal/service/forex_forward_test.go
+++ b/services/bank/internal/service/forex_forward_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/schedule"
+)
+
+// TestComputeForwardRate pins the spec forward-rate formula with a worked
+// example:
+//
+//	ForwardRate = SpotAsk × (1 + (days/365) × spread)
+//
+// SpotAsk = 117.50 RSD/EUR, spread = 2%/yr, days = 365 ⇒
+//
+//	117.50 × (1 + 1 × 0.02) = 117.50 × 1.02 = 119.85
+func TestComputeForwardRate(t *testing.T) {
+	tests := []struct {
+		name    string
+		spotAsk string
+		spread  string
+		days    int
+		want    string // FormatRate (8 dp)
+	}{
+		{"one year 2pct", "117.50", "0.02", 365, "119.85000000"},
+		// Half a year at 2%/yr: 117.50 × (1 + 0.5 × 0.02) = 117.50 × 1.01 = 118.675
+		{"half year 2pct", "117.50", "0.02", 182, "118.67178082"},
+		// Zero spread leaves the spot rate untouched.
+		{"zero spread", "100.00", "0", 90, "100.00000000"},
+		// 73 days (= 1/5 year) at 5%/yr: 100 × (1 + 0.2 × 0.05) = 100 × 1.01 = 101.
+		{"one fifth year 5pct", "100.00", "0.05", 73, "101.00000000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := money.FormatRate(computeForwardRate(money.MustParse(tt.spotAsk), money.MustParse(tt.spread), tt.days))
+			if got != tt.want {
+				t.Fatalf("computeForwardRate(%s, %s, %d) = %s, want %s", tt.spotAsk, tt.spread, tt.days, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeForwardRateWorkedQuoteAmount(t *testing.T) {
+	// Worked end-to-end: buy forward 1000 EUR, spot ASK 117.50, 2%/yr,
+	// one year out. ForwardRate = 119.85, so the RSD obligation is
+	// 119.85 × 1000 = 119850.0000.
+	rate := computeForwardRate(money.MustParse("117.50"), money.MustParse("0.02"), 365)
+	quoteAmount := money.Mul(rate, money.MustParse("1000"))
+	if got := money.FormatAmount(quoteAmount); got != "119850.0000" {
+		t.Fatalf("quote amount = %s, want 119850.0000", got)
+	}
+	// Commission at the default 0.5% of the obligation = 599.25 RSD.
+	commission := money.Mul(quoteAmount, money.MustParse("0.005"))
+	if got := money.FormatAmount(commission); got != "599.2500" {
+		t.Fatalf("commission = %s, want 599.2500", got)
+	}
+}
+
+func TestDaysToSettlement(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		settlement time.Time
+		want       int
+	}{
+		{"exactly 365 days", now.AddDate(1, 0, 0), 365},
+		{"tomorrow same time", now.AddDate(0, 0, 1), 1},
+		// A few hours into the future rounds up to a full day.
+		{"hours ahead rounds up", now.Add(3 * time.Hour), 1},
+		{"30 days exact", now.AddDate(0, 0, 30), 30},
+		// 30 days plus a bit rounds up to 31.
+		{"30 days plus hours", now.AddDate(0, 0, 30).Add(5 * time.Hour), 31},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := daysToSettlement(now, tt.settlement); got != tt.want {
+				t.Fatalf("daysToSettlement = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateFutureSettlementGuard(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	// Past and present dates must be rejected (reused pkg/schedule guard).
+	if err := schedule.ValidateFuture(now, now); err == nil {
+		t.Fatal("expected now == settlement to be rejected")
+	}
+	if err := schedule.ValidateFuture(now.AddDate(0, 0, -1), now); err == nil {
+		t.Fatal("expected past settlement to be rejected")
+	}
+	if err := schedule.ValidateFuture(now.AddDate(0, 0, 1), now); err != nil {
+		t.Fatalf("expected future settlement to pass, got %v", err)
+	}
+}

--- a/services/bank/internal/service/reservations.go
+++ b/services/bank/internal/service/reservations.go
@@ -38,6 +38,7 @@ var allowedReservationOpKinds = map[string]domain.TransactionKind{
 	string(domain.TxKindFundInvest):       domain.TxKindFundInvest,
 	string(domain.TxKindFundWithdraw):     domain.TxKindFundWithdraw,
 	string(domain.TxKindInterbankPayment): domain.TxKindInterbankPayment,
+	string(domain.TxKindForexForward):     domain.TxKindForexForward,
 }
 
 // ReserveFundsInput is the validated payload of an RPC call.

--- a/services/bank/internal/store/forex_forward.go
+++ b/services/bank/internal/store/forex_forward.go
@@ -1,0 +1,234 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
+)
+
+// =====================================================================
+// Forex forward spreads (per-pair SpreadFactor, supervisor-set)
+// =====================================================================
+
+const forexSpreadCols = `base_currency, quote_currency, spread_factor::text,
+    coalesce(updated_by::text, ''), updated_at`
+
+func scanForexSpread(row interface{ Scan(...any) error }) (*domain.ForexForwardSpread, error) {
+	var sp domain.ForexForwardSpread
+	var base, quote string
+	if err := row.Scan(&base, &quote, &sp.SpreadFactor, &sp.UpdatedBy, &sp.UpdatedAt); err != nil {
+		return nil, err
+	}
+	sp.BaseCurrency = domain.Currency(base)
+	sp.QuoteCurrency = domain.Currency(quote)
+	return &sp, nil
+}
+
+// GetForexForwardSpread returns the SpreadFactor row for a pair, or
+// NotFound when the supervisor hasn't configured the pair yet.
+func (s *Store) GetForexForwardSpread(ctx context.Context, base, quote domain.Currency) (*domain.ForexForwardSpread, error) {
+	const q = `select ` + forexSpreadCols + `
+        from "bank".forex_forward_spreads where base_currency = $1 and quote_currency = $2`
+	sp, err := scanForexSpread(s.DB.QueryRow(postgres.WithRead(ctx), q, string(base), string(quote)))
+	if err != nil {
+		if noRows(err) {
+			return nil, apperr.NotFound("spread za valutni par nije podešen")
+		}
+		return nil, apperr.Internal("get forex spread", err)
+	}
+	return sp, nil
+}
+
+// ListForexForwardSpreads returns every configured pair, ordered by pair.
+func (s *Store) ListForexForwardSpreads(ctx context.Context) ([]*domain.ForexForwardSpread, error) {
+	const q = `select ` + forexSpreadCols + `
+        from "bank".forex_forward_spreads order by base_currency, quote_currency`
+	rows, err := s.DB.Query(postgres.WithRead(ctx), q)
+	if err != nil {
+		return nil, apperr.Internal("list forex spreads", err)
+	}
+	defer rows.Close()
+	var out []*domain.ForexForwardSpread
+	for rows.Next() {
+		sp, err := scanForexSpread(rows)
+		if err != nil {
+			return nil, apperr.Internal("scan forex spread", err)
+		}
+		out = append(out, sp)
+	}
+	return out, rows.Err()
+}
+
+// UpsertForexForwardSpread inserts or updates a pair's SpreadFactor,
+// stamping the supervisor who set it.
+func (s *Store) UpsertForexForwardSpread(ctx context.Context, sp *domain.ForexForwardSpread) (*domain.ForexForwardSpread, error) {
+	const q = `
+        insert into "bank".forex_forward_spreads (base_currency, quote_currency, spread_factor, updated_by, updated_at)
+        values ($1, $2, $3::numeric, nullif($4, '')::uuid, now())
+        on conflict (base_currency, quote_currency) do update
+            set spread_factor = excluded.spread_factor,
+                updated_by    = excluded.updated_by,
+                updated_at    = now()
+        returning ` + forexSpreadCols
+	out, err := scanForexSpread(s.DB.QueryRow(ctx, q,
+		string(sp.BaseCurrency), string(sp.QuoteCurrency), sp.SpreadFactor, sp.UpdatedBy))
+	if err != nil {
+		return nil, apperr.Internal("upsert forex spread", err)
+	}
+	return out, nil
+}
+
+// =====================================================================
+// Forex forwards (concluded contracts)
+// =====================================================================
+
+const forexForwardCols = `id, client_id, base_currency, quote_currency,
+    notional::text, forward_rate::text, spot_ask_rate::text, spread_factor::text,
+    days_to_settlement, commission::text, reservation_id, from_account_id, to_account_id,
+    settlement_date, status, coalesce(failure_reason, ''), created_at, settled_at`
+
+func scanForexForward(row interface{ Scan(...any) error }) (*domain.ForexForward, error) {
+	var f domain.ForexForward
+	var base, quote, status string
+	var settledAt *time.Time
+	if err := row.Scan(
+		&f.ID, &f.ClientID, &base, &quote,
+		&f.Notional, &f.ForwardRate, &f.SpotAskRate, &f.SpreadFactor,
+		&f.DaysToSettlement, &f.Commission, &f.ReservationID, &f.FromAccountID, &f.ToAccountID,
+		&f.SettlementDate, &status, &f.FailureReason, &f.CreatedAt, &settledAt,
+	); err != nil {
+		return nil, err
+	}
+	f.BaseCurrency = domain.Currency(base)
+	f.QuoteCurrency = domain.Currency(quote)
+	f.Status = domain.ForexForwardStatus(status)
+	f.SettledAt = settledAt
+	return &f, nil
+}
+
+// InsertForexForward persists a new 'active' contract inside the caller's
+// tx (the reservation + commission charge + insert run atomically).
+func (s *Store) InsertForexForward(ctx context.Context, tx pgx.Tx, f *domain.ForexForward) (*domain.ForexForward, error) {
+	const q = `
+        insert into "bank".forex_forwards
+            (client_id, base_currency, quote_currency, notional, forward_rate, spot_ask_rate,
+             spread_factor, days_to_settlement, commission, reservation_id,
+             from_account_id, to_account_id, settlement_date)
+        values ($1, $2, $3, $4::numeric, $5::numeric, $6::numeric, $7::numeric, $8, $9::numeric,
+                $10, $11, $12, $13)
+        returning ` + forexForwardCols
+	out, err := scanForexForward(tx.QueryRow(ctx, q,
+		f.ClientID, string(f.BaseCurrency), string(f.QuoteCurrency), f.Notional, f.ForwardRate,
+		f.SpotAskRate, f.SpreadFactor, f.DaysToSettlement, f.Commission, f.ReservationID,
+		f.FromAccountID, f.ToAccountID, f.SettlementDate,
+	))
+	if err != nil {
+		return nil, apperr.Internal("insert forex forward", err)
+	}
+	return out, nil
+}
+
+// GetForexForward loads a single contract by id.
+func (s *Store) GetForexForward(ctx context.Context, id string) (*domain.ForexForward, error) {
+	const q = `select ` + forexForwardCols + ` from "bank".forex_forwards where id = $1`
+	f, err := scanForexForward(s.DB.QueryRow(ctx, q, id))
+	if err != nil {
+		if noRows(err) {
+			return nil, apperr.NotFound("terminski ugovor ne postoji")
+		}
+		return nil, apperr.Internal("get forex forward", err)
+	}
+	return f, nil
+}
+
+// ListForexForwardsByClient returns the client's contracts, newest first.
+func (s *Store) ListForexForwardsByClient(ctx context.Context, clientID string) ([]*domain.ForexForward, error) {
+	const q = `select ` + forexForwardCols + `
+        from "bank".forex_forwards where client_id = $1 order by created_at desc`
+	return s.queryForexForwards(ctx, q, clientID)
+}
+
+// ListDueForexForwards returns every 'active' contract whose settlement
+// date is at or before now, oldest first. Read against the primary so a
+// just-concluded contract isn't missed by replica lag.
+func (s *Store) ListDueForexForwards(ctx context.Context, now time.Time) ([]*domain.ForexForward, error) {
+	const q = `select ` + forexForwardCols + `
+        from "bank".forex_forwards
+       where status = 'active' and settlement_date <= $1
+       order by settlement_date asc`
+	return s.queryForexForwards(ctx, q, now)
+}
+
+func (s *Store) queryForexForwards(ctx context.Context, q string, args ...any) ([]*domain.ForexForward, error) {
+	rows, err := s.DB.Query(ctx, q, args...)
+	if err != nil {
+		return nil, apperr.Internal("list forex forwards", err)
+	}
+	defer rows.Close()
+	var out []*domain.ForexForward
+	for rows.Next() {
+		f, err := scanForexForward(rows)
+		if err != nil {
+			return nil, apperr.Internal("scan forex forward", err)
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// MarkForexForwardSettled flips an 'active' row to 'settled' and stamps
+// settled_at. Status-guarded so a double-sweep is a no-op.
+func (s *Store) MarkForexForwardSettled(ctx context.Context, id string, at time.Time) error {
+	const q = `
+        update "bank".forex_forwards
+           set status = 'settled', settled_at = $2, failure_reason = null
+         where id = $1 and status = 'active'`
+	if _, err := s.DB.Exec(ctx, q, id, at); err != nil {
+		return apperr.Internal("mark forex forward settled", err)
+	}
+	return nil
+}
+
+// MarkForexForwardFailed flips an 'active' row to 'failed' with a reason
+// and stamps settled_at. Status-guarded so a double-sweep is a no-op.
+func (s *Store) MarkForexForwardFailed(ctx context.Context, id, reason string, at time.Time) error {
+	const q = `
+        update "bank".forex_forwards
+           set status = 'failed', settled_at = $2, failure_reason = $3
+         where id = $1 and status = 'active'`
+	if _, err := s.DB.Exec(ctx, q, id, at, reason); err != nil {
+		return apperr.Internal("mark forex forward failed", err)
+	}
+	return nil
+}
+
+// CancelForexForward flips an owner's still-'active' row to 'cancelled'.
+// Owner-scoped + status-guarded in one statement so a concurrent
+// settlement can't be cancelled mid-flight.
+func (s *Store) CancelForexForward(ctx context.Context, id, clientID string) (*domain.ForexForward, error) {
+	const q = `
+        update "bank".forex_forwards
+           set status = 'cancelled'
+         where id = $1 and client_id = $2 and status = 'active'
+        returning ` + forexForwardCols
+	f, err := scanForexForward(s.DB.QueryRow(ctx, q, id, clientID))
+	if err != nil {
+		if noRows(err) {
+			existing, gerr := s.GetForexForward(ctx, id)
+			if gerr != nil {
+				return nil, gerr
+			}
+			if existing.ClientID != clientID {
+				return nil, apperr.NotFound("terminski ugovor ne postoji")
+			}
+			return nil, apperr.FailedPrecondition("terminski ugovor se više ne može otkazati")
+		}
+		return nil, apperr.Internal("cancel forex forward", err)
+	}
+	return f, nil
+}

--- a/services/bank/migrations/0017_forex_forwards.down.sql
+++ b/services/bank/migrations/0017_forex_forwards.down.sql
@@ -1,0 +1,13 @@
+alter table "bank".transactions
+  drop constraint transactions_op_kind_check,
+  add constraint transactions_op_kind_check
+    check (op_kind in (
+      'payment','transfer','exchange','fee',
+      'loan_disbursement','loan_installment',
+      'trade','tax','forex_fill',
+      'otc_premium','otc_exercise','fund_invest','fund_withdraw',
+      'interbank_payment','dividend'
+    ));
+
+drop table if exists "bank".forex_forwards;
+drop table if exists "bank".forex_forward_spreads;

--- a/services/bank/migrations/0017_forex_forwards.up.sql
+++ b/services/bank/migrations/0017_forex_forwards.up.sql
@@ -1,0 +1,77 @@
+-- C3 — Forex Forwards (terminski valutni ugovori, todoSpec).
+--
+-- A forex forward is a contract between a client and the bank that fixes
+-- TODAY a rate for a FUTURE currency conversion. On the settlement date
+-- the bank debits the client's RSD account by ForwardRate × Notional and
+-- credits the Notional in the quote currency to the client's quote
+-- account — a DIRECT fixed-rate move, not a menjačnica RSD round-trip
+-- (the spread risk is already priced into ForwardRate).
+--
+-- Two tables:
+--   * forex_forward_spreads — per-pair SpreadFactor, set by supervisors.
+--   * forex_forwards        — the concluded contracts.
+
+-- Per-currency-pair annualised spread factor used in the forward-rate
+-- formula. base_currency is the currency the client buys forward (the
+-- Notional currency); quote_currency is RSD (the leg debited at
+-- settlement). Editable by supervisors only (service-layer gated).
+create table "bank".forex_forward_spreads (
+    base_currency  text           not null,
+    quote_currency text           not null,
+    spread_factor  numeric(10, 6) not null,
+    updated_by     uuid,
+    updated_at     timestamptz    not null default now(),
+    primary key (base_currency, quote_currency)
+);
+
+-- A concluded forward contract.
+--
+-- forward_rate is locked at conclusion via the spec formula:
+--   ForwardRate = SpotAskRate × (1 + (DaysToSettlement / 365) × SpreadFactor)
+-- The quote-currency obligation (forward_rate × notional) is reserved on
+-- the client's quote (RSD) account through the existing reservation
+-- primitive; reservation_id stores that reservation's op_id so the
+-- settlement / cancel paths can commit / release it. A commission is
+-- charged at conclusion.
+create table "bank".forex_forwards (
+    id                  uuid primary key default gen_random_uuid(),
+    client_id           uuid           not null,
+    base_currency       text           not null,
+    quote_currency      text           not null,
+    notional            numeric(20, 4) not null,
+    forward_rate        numeric(20, 8) not null,
+    spot_ask_rate       numeric(20, 8) not null,
+    spread_factor       numeric(10, 6) not null,
+    days_to_settlement  int            not null,
+    commission          numeric(20, 4) not null default 0,
+    reservation_id      text           not null,
+    from_account_id     uuid           not null, -- client's quote (RSD) account, debited at settlement
+    to_account_id       uuid           not null, -- client's base-currency account, credited at settlement
+    settlement_date     timestamptz    not null,
+    status              text           not null default 'active'
+        check (status in ('active', 'settled', 'cancelled', 'failed')),
+    failure_reason      text,
+    created_at          timestamptz    not null default now(),
+    settled_at          timestamptz
+);
+
+-- The settlement sweep selects on (status, settlement_date).
+create index forex_forwards_due_idx
+    on "bank".forex_forwards (status, settlement_date);
+
+-- The client's list view selects on client_id.
+create index forex_forwards_client_idx
+    on "bank".forex_forwards (client_id);
+
+-- Extend transactions.op_kind so the forward-settlement ledger leg is
+-- auditable. Same drop-and-recreate pattern as 0008/0009/0010/0012/0014/0016.
+alter table "bank".transactions
+  drop constraint transactions_op_kind_check,
+  add constraint transactions_op_kind_check
+    check (op_kind in (
+      'payment','transfer','exchange','fee',
+      'loan_disbursement','loan_installment',
+      'trade','tax','forex_fill',
+      'otc_premium','otc_exercise','fund_invest','fund_withdraw',
+      'interbank_payment','dividend','forex_forward'
+    ));

--- a/services/gateway/internal/verification/middleware.go
+++ b/services/gateway/internal/verification/middleware.go
@@ -72,6 +72,13 @@ func DefaultRules() []Rule {
 		// gate (and vice versa); same 6-digit UX, FE labels the dialog
 		// "Međubankarsko plaćanje".
 		{http.MethodPost, regexp.MustCompile(`^/api/v1/payments/interbank$`), verification.ActionInterbankPayment},
+		// Concluding a forex forward (terminski ugovor, todoSpec C3)
+		// reserves the RSD obligation and charges a commission on the
+		// client's account, so it's money-moving and gated like a payment.
+		// The /quote and /spreads sub-routes don't move money and are not
+		// gated — the trailing-$ anchor keeps this matching the bare
+		// conclude endpoint only.
+		{http.MethodPost, regexp.MustCompile(`^/api/v1/forex-forwards$`), verification.ActionPayment},
 	}
 }
 

--- a/services/scheduler/internal/app/jobs.go
+++ b/services/scheduler/internal/app/jobs.go
@@ -46,6 +46,8 @@ func (a *App) buildJobs() []job {
 			a.interval("bank-maintenance-fee", config.Duration("MAINTENANCE_FEE_JOB_INTERVAL", 24*time.Hour), false, a.bankMaintenance),
 			a.interval("bank-spent-reset", config.Duration("SPENT_RESET_JOB_INTERVAL", time.Hour), false, a.bankSpentReset),
 			a.interval("bank-scheduled-payments", config.Duration("SCHEDULED_PAYMENT_TICK", 5*time.Minute), true, a.bankScheduledPayments),
+			// Forex forwards settle on their settlement date — sweep daily.
+			a.daily("bank-forex-forward-settlement", 0, 10, a.bankForexForwardSettlement),
 		)
 	}
 	if a.trading != nil {
@@ -209,6 +211,17 @@ func (a *App) bankScheduledPayments(ctx context.Context) error {
 	}
 	if r.GetProcessed() > 0 {
 		a.log.Info("scheduled payments ran", "processed", r.GetProcessed(), "succeeded", r.GetSucceeded(), "failed", r.GetFailed())
+	}
+	return nil
+}
+
+func (a *App) bankForexForwardSettlement(ctx context.Context) error {
+	r, err := a.bank.RunForexForwardSettlement(ctx, &bankpb.RunForexForwardSettlementRequest{})
+	if err != nil {
+		return err
+	}
+	if r.GetProcessed() > 0 {
+		a.log.Info("forex forward settlement ran", "processed", r.GetProcessed(), "settled", r.GetSettled(), "failed", r.GetFailed())
 	}
 	return nil
 }


### PR DESCRIPTION
Forward FX contracts: per-pair supervisor SpreadFactor, ForwardRate = SpotAsk×(1+(days/365)×spread), quote-currency reservation at conclusion + commission, daily settlement cron (direct fixed-rate move, not a menjačnica round-trip). Bank migration 0017. Pure bank-service (no trading edits → clear of the SAGA session). Reuses the reservation primitive + money-move engine + rate provider.

todoSpec: C3 Forex Forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)