### PR TITLE
feat(trading): email leg for order + price-alert notifications

### DIFF
--- a/services/trading/internal/app/user_client.go
+++ b/services/trading/internal/app/user_client.go
@@ -75,6 +75,33 @@ func (a *userResolverAdapter) RecordAudit(ctx context.Context, action, actorID, 
 	return nil
 }
 
+// Email resolves a user's email address so the trading service can add an
+// email leg to its order/price-alert notifications. Mirrors bank's
+// userResolverAdapter.ClientEmail: it attaches the internal admin
+// principal to outgoing metadata (these calls run server-side, after the
+// triggering operation's own permission gate) then dials user-svc —
+// GetClient for clients, GetEmployee for employees, both of which carry
+// the address on their `email` field.
+func (a *userResolverAdapter) Email(ctx context.Context, userID string, kind domain.UserKind) (string, error) {
+	ctx = withUserAdmin(ctx)
+	switch kind {
+	case domain.KindClient:
+		resp, err := a.c.GetClient(ctx, &userpb.GetClientRequest{Id: userID})
+		if err != nil {
+			return "", fmt.Errorf("user.GetClient: %w", err)
+		}
+		return resp.GetEmail(), nil
+	case domain.KindEmployee:
+		resp, err := a.c.GetEmployee(ctx, &userpb.GetEmployeeRequest{Id: userID})
+		if err != nil {
+			return "", fmt.Errorf("user.GetEmployee: %w", err)
+		}
+		return resp.GetEmail(), nil
+	default:
+		return "", nil
+	}
+}
+
 func (a *userResolverAdapter) EmployeePermissions(ctx context.Context, userID string) ([]string, error) {
 	ctx = withUserAdmin(ctx)
 	resp, err := a.c.GetEmployee(ctx, &userpb.GetEmployeeRequest{Id: userID})

--- a/services/trading/internal/service/integration_test.go
+++ b/services/trading/internal/service/integration_test.go
@@ -1705,8 +1705,9 @@ func TestIntegration_Tax_LossClamped(t *testing.T) {
 // so display_name + name_query are exercised without spinning up the
 // user service.
 type stubUsers struct {
-	names map[string]string   // user_id → display name
-	perms map[string][]string // user_id → permission strings (CreateFund manager validation)
+	names  map[string]string   // user_id → display name
+	perms  map[string][]string // user_id → permission strings (CreateFund manager validation)
+	emails map[string]string   // user_id → email address
 }
 
 func (s *stubUsers) DisplayName(_ context.Context, userID string, _ domain.UserKind) (string, error) {
@@ -1725,6 +1726,13 @@ func (s *stubUsers) EmployeePermissions(_ context.Context, userID string) ([]str
 
 func (s *stubUsers) RecordAudit(_ context.Context, _, _, _, _, _, _, _, _ string) error {
 	return nil
+}
+
+func (s *stubUsers) Email(_ context.Context, userID string, _ domain.UserKind) (string, error) {
+	if e, ok := s.emails[userID]; ok {
+		return e, nil
+	}
+	return "", nil
 }
 
 // writeRealizedGainAt seeds a realized_gain row at a chosen wall-clock

--- a/services/trading/internal/service/order_notify.go
+++ b/services/trading/internal/service/order_notify.go
@@ -12,18 +12,15 @@ import (
 // Each helper is best-effort: it nil-checks s.Notifier and never returns
 // an error, so a notification failure can't fail the order operation that
 // triggered it. Delivery is the in-app row (always, when a Notifier is
-// wired); email is only attempted when an address is readily available.
-//
-// The trading service has no email-address resolver, so for order events
-// we generally have no `to` address — the in-app notification is what
-// satisfies these scenarios. The email leg is left as a deliberate no-op
-// (see notifyOrderEmail) until an address resolver is wired here.
+// wired) plus an email leg whenever the owner's address resolves.
 //
 // eventKind is always "order" so the FE can group these rows.
 const orderEventKind = "order"
 
 // notifyOrder writes the in-app row for an order event to the order's
-// owner. Best-effort: logs on error, never propagates.
+// owner and, when the owner's email resolves, sends the same Serbian
+// copy by email. Best-effort: logs on error, never propagates. The
+// in-app leg always fires even if email resolution or delivery fails.
 func (s *Service) notifyOrder(ctx context.Context, o *domain.Order, title, body string) {
 	if s == nil || s.Notifier == nil || o == nil {
 		return
@@ -32,9 +29,14 @@ func (s *Service) notifyOrder(ctx context.Context, o *domain.Order, title, body 
 		s.Log.Warn("order notify: in-app delivery failed",
 			"order_id", o.ID, "user_id", o.UserID, "title", title, "err", err.Error())
 	}
-	// Email is intentionally skipped: the trading service has no
-	// email-address resolver, so we have no `to` here. When one is wired,
-	// resolve the owner's address and call s.Notifier.Email(...).
+	// Email leg: resolve the owner's address and send the same copy. A
+	// "" address (unresolved / no resolver wired) is a no-op.
+	if to := s.recipientEmail(ctx, o.UserID, o.UserKind); to != "" {
+		if err := s.Notifier.Email(ctx, to, title, body); err != nil {
+			s.Log.Warn("order notify: email delivery failed",
+				"order_id", o.ID, "user_id", o.UserID, "title", title, "err", err.Error())
+		}
+	}
 }
 
 // notifyOrderPending — S20. An agent's order needing supervisor approval

--- a/services/trading/internal/service/price_alerts.go
+++ b/services/trading/internal/service/price_alerts.go
@@ -86,10 +86,9 @@ func (s *Service) DeletePriceAlert(ctx context.Context, id string) error {
 // silent (S29). Returns the number triggered.
 //
 // Notification is best-effort: a delivery failure never blocks the
-// deactivation (the alert is one-shot regardless). Email is sent only
-// when an address is resolvable; on this stack the trading service has
-// no user-email resolver wired, so the sweep delivers the in-app
-// notification and skips email (see report).
+// deactivation (the alert is one-shot regardless). Both the in-app row
+// and an email leg are delivered; the email is sent only when the alert
+// owner's address resolves, otherwise the sweep delivers in-app only.
 func (s *Service) RunPriceAlertSweep(ctx context.Context) (int, error) {
 	alerts, err := s.Store.ListActivePriceAlerts(ctx)
 	if err != nil {
@@ -162,5 +161,11 @@ func (s *Service) firePriceAlert(ctx context.Context, a *domain.PriceAlert, curr
 		ticker, dir, a.Threshold, currentPrice)
 	if err := s.Notifier.InApp(ctx, a.UserID, a.UserKind, "price_alert", title, body); err != nil {
 		s.Log.Warn("price alert: in-app notify failed", "alert_id", a.ID, "err", err.Error())
+	}
+	// Email leg: same copy to the owner's address when it resolves.
+	if to := s.recipientEmail(ctx, a.UserID, a.UserKind); to != "" {
+		if err := s.Notifier.Email(ctx, to, title, body); err != nil {
+			s.Log.Warn("price alert: email notify failed", "alert_id", a.ID, "err", err.Error())
+		}
 	}
 }

--- a/services/trading/internal/service/service.go
+++ b/services/trading/internal/service/service.go
@@ -91,6 +91,14 @@ type UserResolver interface {
 	// transport. Best-effort: implementations must not fail the
 	// underlying trading operation on a delivery error.
 	RecordAudit(ctx context.Context, action, actorID, actorKind, targetID, targetLabel, oldVal, newVal, note string) error
+	// Email resolves a user's email address so the trading service can
+	// add an email leg to its order/price-alert notifications (the
+	// in-app feed only carries a user_id, not an address). For
+	// kind=client it dials user-svc GetClient; for kind=employee it
+	// dials GetEmployee. Returns the address, or "" + error when the id
+	// does not resolve. Callers treat any error as "no address" and fall
+	// back to in-app only.
+	Email(ctx context.Context, userID string, kind domain.UserKind) (string, error)
 }
 
 // MarginChecker reads the funding-source state needed by spec p.55
@@ -458,4 +466,22 @@ func (s *Service) recordAudit(ctx context.Context, action, targetID, targetLabel
 	if err := s.Users.RecordAudit(ctx, action, actorID, actorKind, targetID, targetLabel, oldVal, newVal, note); err != nil {
 		s.Log.Warn("audit-log write failed", "action", action, "target_id", targetID, "err", err.Error())
 	}
+}
+
+// recipientEmail best-effort resolves a user's email address for the
+// email leg of an order/price-alert notification. Nil-safe (s.Users may
+// be unset on a minimal dev stack) and never fails the underlying
+// operation: any resolution error returns "" so the caller delivers the
+// in-app notification regardless. A "" return means "send no email".
+func (s *Service) recipientEmail(ctx context.Context, userID string, kind domain.UserKind) string {
+	if s.Users == nil {
+		return ""
+	}
+	addr, err := s.Users.Email(ctx, userID, kind)
+	if err != nil {
+		s.Log.Warn("notification: email lookup failed",
+			"user_id", userID, "kind", string(kind), "err", err.Error())
+		return ""
+	}
+	return addr
 }


### PR DESCRIPTION
Adds an email-address resolver to the trading UserResolver (mirrors bank ClientEmail: GetClient for clients, GetEmployee for employees) so order-lifecycle (S20-S25) and price-alert (S27) notifications now ALSO send email, alongside the existing in-app row (best-effort; in-app still fires if email lookup fails). No saga/OTC/proto/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)