### PR TITLE
feat(verification): poll-based Quick Approve (todoSpec S12)

### DIFF
--- a/pkg/verification/verification.go
+++ b/pkg/verification/verification.go
@@ -101,6 +101,11 @@ var (
 	// ErrMismatch means the record exists but for a different action
 	// kind. Surface 401/403 to the caller — never reveal the kind.
 	ErrMismatch = errors.New("verification: action mismatch")
+	// ErrNotApproved means a quick-approve consume was attempted against
+	// a record that exists and belongs to the user but has not been
+	// approved from the mobile app. The caller must either approve it
+	// (POST .../approve) or fall back to the 6-digit code path.
+	ErrNotApproved = errors.New("verification: not approved")
 )
 
 // Verifier is the interface the gateway middleware depends on. The
@@ -109,6 +114,22 @@ var (
 type Verifier interface {
 	Issue(ctx context.Context, userID string, kind ActionKind) (id, code string, expiresAt time.Time, err error)
 	Consume(ctx context.Context, id, code string, expectedKind ActionKind) error
+}
+
+// Approver is the optional quick-approve capability (todoSpec S12). The
+// mobile app marks a pending record APPROVED instead of relaying the
+// 6-digit code; the gateway middleware then admits an id-only request
+// via ConsumeApproved. Kept separate from Verifier so existing test
+// stubs don't have to implement it — the gateway type-asserts for it.
+type Approver interface {
+	// Approve marks the pending record id (which must belong to userID)
+	// as approved, within its existing TTL. Idempotent: re-approving an
+	// already-approved record succeeds.
+	Approve(ctx context.Context, userID, id string) error
+	// ConsumeApproved retires record id iff it exists, belongs to
+	// userID, matches expectedKind, and has been approved. Returns
+	// ErrNotApproved when the record exists but was never approved.
+	ConsumeApproved(ctx context.Context, userID, id string, expectedKind ActionKind) error
 }
 
 // Pending is one active (not yet consumed/expired) verification record,
@@ -121,6 +142,10 @@ type Pending struct {
 	Code      string
 	Attempts  int
 	ExpiresAt time.Time
+	// Approved reflects the quick-approve flag (todoSpec S12). The web
+	// app polls ListPending and, once a record reports Approved, fires
+	// the gated request with X-Verification-Id only (no code).
+	Approved bool
 }
 
 // PendingLister is an optional capability: list a user's active codes.
@@ -130,10 +155,16 @@ type PendingLister interface {
 	ListPending(ctx context.Context, userID string) ([]Pending, error)
 }
 
-// Cache is the Redis-backed Verifier (and PendingLister).
+// Cache is the Redis-backed Verifier (and PendingLister, Approver).
 type Cache struct {
 	R *redis.Client
 }
+
+var (
+	_ Verifier      = (*Cache)(nil)
+	_ PendingLister = (*Cache)(nil)
+	_ Approver      = (*Cache)(nil)
+)
 
 func key(id string) string      { return "verif:" + id }
 func userKey(uid string) string { return "verif:user:" + uid }
@@ -143,6 +174,9 @@ type record struct {
 	Kind     ActionKind `json:"k"`
 	Code     string     `json:"c"`
 	Attempts int        `json:"a"`
+	// Approved is set by the mobile quick-approve flow (todoSpec S12).
+	// Once true, ConsumeApproved retires the record without a code.
+	Approved bool `json:"ap,omitempty"`
 }
 
 // Issue mints a fresh verification code, stores the record under a new
@@ -217,6 +251,7 @@ func (c *Cache) ListPending(ctx context.Context, userID string) ([]Pending, erro
 			Code:      rec.Code,
 			Attempts:  rec.Attempts,
 			ExpiresAt: time.Unix(int64(z.Score), 0),
+			Approved:  rec.Approved,
 		})
 	}
 	return out, nil
@@ -266,6 +301,75 @@ func (c *Cache) Consume(ctx context.Context, id, code string, expectedKind Actio
 		return err
 	}
 	return ErrWrongCode
+}
+
+// Approve marks the record id as approved (todoSpec S12 quick-approve).
+// The record must exist and belong to userID; otherwise ErrNotFound.
+// The approved flag is persisted under the record's remaining TTL so
+// the 5-minute window is unchanged. Idempotent.
+func (c *Cache) Approve(ctx context.Context, userID, id string) error {
+	raw, err := c.R.Get(ctx, key(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	var rec record
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return err
+	}
+	// Ownership check: a user may only approve their own record. Return
+	// ErrNotFound (not a distinct error) so a caller can't probe whether
+	// an id belongs to someone else.
+	if rec.UserID != userID {
+		return ErrNotFound
+	}
+	if rec.Approved {
+		return nil
+	}
+	rec.Approved = true
+	ttl, terr := c.R.TTL(ctx, key(id)).Result()
+	if terr != nil || ttl <= 0 {
+		ttl = CodeTTL
+	}
+	updated, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return c.R.Set(ctx, key(id), updated, ttl).Err()
+}
+
+// ConsumeApproved retires record id without a code, succeeding only if
+// the record exists, belongs to userID, matches expectedKind, and has
+// been approved via Approve. Mirrors Consume's one-shot semantics: a
+// successful call deletes the record. An existing-but-unapproved record
+// returns ErrNotApproved and is left intact (the user may still approve
+// it from the phone or fall back to the code path).
+func (c *Cache) ConsumeApproved(ctx context.Context, userID, id string, expectedKind ActionKind) error {
+	raw, err := c.R.Get(ctx, key(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	var rec record
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return err
+	}
+	if rec.UserID != userID {
+		return ErrNotFound
+	}
+	if rec.Kind != expectedKind {
+		return ErrMismatch
+	}
+	if !rec.Approved {
+		return ErrNotApproved
+	}
+	// One-shot: a successful quick-approve consume retires the record.
+	_ = c.R.Del(ctx, key(id)).Err()
+	return nil
 }
 
 func newID() (string, error) {

--- a/pkg/verification/verification_test.go
+++ b/pkg/verification/verification_test.go
@@ -190,6 +190,88 @@ func TestListPendingReflectsAttempts(t *testing.T) {
 	}
 }
 
+func TestApproveThenConsumeApproved(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+	id, _, _, _ := c.Issue(ctx, "u1", ActionPayment)
+
+	// Un-approved id-only consume is rejected.
+	if err := c.ConsumeApproved(ctx, "u1", id, ActionPayment); !errors.Is(err, ErrNotApproved) {
+		t.Fatalf("pre-approve consume: want ErrNotApproved, got %v", err)
+	}
+
+	// Approve flips the flag and shows up in ListPending.
+	if err := c.Approve(ctx, "u1", id); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if err := c.Approve(ctx, "u1", id); err != nil {
+		t.Errorf("re-approve should be idempotent, got %v", err)
+	}
+	got, _ := c.ListPending(ctx, "u1")
+	if len(got) != 1 || !got[0].Approved {
+		t.Fatalf("pending should report approved=true, got %+v", got)
+	}
+
+	// Quick-approve consume succeeds and is one-shot.
+	if err := c.ConsumeApproved(ctx, "u1", id, ActionPayment); err != nil {
+		t.Fatalf("approved consume: %v", err)
+	}
+	if err := c.ConsumeApproved(ctx, "u1", id, ActionPayment); !errors.Is(err, ErrNotFound) {
+		t.Errorf("second consume: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestApproveOwnershipScoped(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+	id, _, _, _ := c.Issue(ctx, "owner", ActionPayment)
+
+	// A different user can neither approve nor consume-approved the record.
+	if err := c.Approve(ctx, "intruder", id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("foreign approve: want ErrNotFound, got %v", err)
+	}
+	if err := c.Approve(ctx, "owner", id); err != nil {
+		t.Fatalf("owner approve: %v", err)
+	}
+	if err := c.ConsumeApproved(ctx, "intruder", id, ActionPayment); !errors.Is(err, ErrNotFound) {
+		t.Errorf("foreign consume: want ErrNotFound, got %v", err)
+	}
+	// Wrong kind even when approved → ErrMismatch.
+	if err := c.ConsumeApproved(ctx, "owner", id, ActionTransfer); !errors.Is(err, ErrMismatch) {
+		t.Errorf("kind mismatch: want ErrMismatch, got %v", err)
+	}
+	// Owner + right kind still works.
+	if err := c.ConsumeApproved(ctx, "owner", id, ActionPayment); err != nil {
+		t.Errorf("owner approved consume: %v", err)
+	}
+}
+
+func TestConsumeApprovedMissing(t *testing.T) {
+	c := setup(t)
+	if err := c.ConsumeApproved(context.Background(), "u", "deadbeef", ActionPayment); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing id: want ErrNotFound, got %v", err)
+	}
+	if err := c.Approve(context.Background(), "u", "deadbeef"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("approve missing id: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestApprovePreservesTTL(t *testing.T) {
+	c := setup(t)
+	ctx := context.Background()
+	id, _, _, _ := c.Issue(ctx, "u", ActionPayment)
+	if err := c.Approve(ctx, "u", id); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	ttl, err := c.R.TTL(ctx, key(id)).Result()
+	if err != nil {
+		t.Fatalf("ttl: %v", err)
+	}
+	if ttl <= 0 || ttl > CodeTTL+time.Second {
+		t.Errorf("ttl after approve out of range: %v", ttl)
+	}
+}
+
 func TestConsumeExpired(t *testing.T) {
 	c := setup(t)
 	ctx := context.Background()

--- a/services/gateway/internal/router/router.go
+++ b/services/gateway/internal/router/router.go
@@ -73,6 +73,13 @@ func (r *Router) Mount(ctx context.Context, gwMux *runtime.ServeMux, registerGW 
 		// Additive: mobile polls this for the active codes to display
 		// (spec p.84). Auth-gated so we know whose codes to list.
 		mux.Handle("GET /api/v1/verification/pending", r.AuthMW(http.HandlerFunc(r.VerificationPendingHandler())))
+		// Additive: mobile quick-approve (todoSpec S12). Marks the
+		// caller's own pending record approved so the next gated request
+		// passes with X-Verification-Id only. Auth-gated.
+		mux.Handle("POST /api/v1/verification/{id}/approve", r.AuthMW(http.HandlerFunc(r.VerificationApproveHandler())))
+		// Additive: web poll-mode dialog reads pending|approved|expired
+		// for a single id to know when the phone approved (todoSpec S12).
+		mux.Handle("GET /api/v1/verification/{id}/status", r.AuthMW(http.HandlerFunc(r.VerificationStatusHandler())))
 		// Additive: mobile "Verifikacija" screen request history, each
 		// row marked successful/unsuccessful (spec p.84). Durable —
 		// backed by the user service, survives the Redis code TTL.

--- a/services/gateway/internal/router/verification.go
+++ b/services/gateway/internal/router/verification.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -81,6 +82,10 @@ type pendingItem struct {
 	Code              string    `json:"code"`
 	ExpiresAt         time.Time `json:"expiresAt"`
 	AttemptsRemaining int       `json:"attemptsRemaining"`
+	// Approved reflects the quick-approve flag (todoSpec S12): the
+	// mobile app hides the "Odobri" button once true, and the web app's
+	// poll-mode dialog auto-proceeds with an id-only gated request.
+	Approved bool `json:"approved"`
 }
 
 type pendingResponse struct {
@@ -123,6 +128,7 @@ func (r *Router) VerificationPendingHandler() http.HandlerFunc {
 				Code:              rec.Code,
 				ExpiresAt:         rec.ExpiresAt,
 				AttemptsRemaining: remaining,
+				Approved:          rec.Approved,
 			})
 		}
 		writeJSON(w, http.StatusOK, pendingResponse{Pending: items})
@@ -220,5 +226,105 @@ func (r *Router) VerificationHandler() http.HandlerFunc {
 			ExpiresAt:      exp,
 			Delivery:       "inline",
 		})
+	}
+}
+
+// approveResponse confirms a quick-approve (todoSpec S12).
+type approveResponse struct {
+	ID       string `json:"id"`
+	Approved bool   `json:"approved"`
+}
+
+// VerificationApproveHandler returns POST /api/v1/verification/{id}/approve
+// — the mobile app's quick-approve endpoint (todoSpec S12). Instead of
+// relaying the 6-digit code, the client taps "Odobri" and the phone
+// marks its own pending record approved in Redis. The next gated
+// request the user fires (from the web app) then passes verification
+// with X-Verification-Id only. Auth-gated so the caller can only
+// approve their own records (ownership enforced in verification.Approve).
+func (r *Router) VerificationApproveHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if r.Verifier == nil {
+			writeError(w, http.StatusServiceUnavailable, "Verifikacija nije konfigurisana.")
+			return
+		}
+		ap, ok := r.Verifier.(verification.Approver)
+		if !ok {
+			writeError(w, http.StatusServiceUnavailable, "Brzo odobravanje nije dostupno.")
+			return
+		}
+		id := req.PathValue("id")
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "neispravan zahtev")
+			return
+		}
+		p, ok := pkgauth.PrincipalFrom(req.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "missing access token")
+			return
+		}
+		err := ap.Approve(req.Context(), p.UserID, id)
+		switch {
+		case err == nil:
+			writeJSON(w, http.StatusOK, approveResponse{ID: id, Approved: true})
+		case errors.Is(err, verification.ErrNotFound):
+			// Not owned, expired, or already consumed — indistinguishable
+			// on purpose (don't let a caller probe foreign records).
+			writeError(w, http.StatusNotFound, "Zahtev za verifikaciju nije pronađen ili je istekao.")
+		default:
+			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
+		}
+	}
+}
+
+// statusResponse reports a single verification record's state to the web
+// app's poll-mode dialog (todoSpec S12): pending | approved | expired.
+type statusResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// VerificationStatusHandler returns GET /api/v1/verification/{id}/status
+// — the web app polls this after opening the quick-approve dialog. It
+// reports "approved" once the user taps Odobri on the phone (then the
+// dialog fires the gated request id-only), or "expired" when the record
+// is gone (consumed elsewhere or TTL elapsed). Derived from the caller's
+// own pending list so no foreign record can be probed.
+func (r *Router) VerificationStatusHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		id := req.PathValue("id")
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "neispravan zahtev")
+			return
+		}
+		p, ok := pkgauth.PrincipalFrom(req.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "missing access token")
+			return
+		}
+		lister, ok := r.Verifier.(verification.PendingLister)
+		if !ok {
+			writeJSON(w, http.StatusOK, statusResponse{ID: id, Status: "expired"})
+			return
+		}
+		recs, err := lister.ListPending(req.Context(), p.UserID)
+		if err != nil {
+			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
+			return
+		}
+		for _, rec := range recs {
+			if rec.ID != id {
+				continue
+			}
+			if rec.Approved {
+				writeJSON(w, http.StatusOK, statusResponse{ID: id, Status: "approved"})
+				return
+			}
+			writeJSON(w, http.StatusOK, statusResponse{ID: id, Status: "pending"})
+			return
+		}
+		// Not in the active pending set for this user: consumed or
+		// expired. The web dialog treats "expired" as terminal.
+		writeJSON(w, http.StatusOK, statusResponse{ID: id, Status: "expired"})
 	}
 }

--- a/services/gateway/internal/verification/middleware.go
+++ b/services/gateway/internal/verification/middleware.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"regexp"
 
+	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/verification"
 )
 
@@ -25,6 +26,13 @@ const (
 	HeaderID   = "X-Verification-Id"
 	HeaderCode = "X-Verification-Code"
 )
+
+// QuickApproveSentinel is an explicit code value the web app may send in
+// X-Verification-Code to signal "this request was approved from the
+// phone — validate by id only" (todoSpec S12). An empty code header is
+// treated identically; the sentinel exists so the intent is legible in
+// request logs and so a client can distinguish it from a forgotten code.
+const QuickApproveSentinel = "approved"
 
 // Rule maps a (method, path-pattern) tuple to the verification kind
 // the gated route requires.
@@ -108,10 +116,45 @@ func Middleware(v verification.Verifier, rules []Rule, log *slog.Logger) func(ht
 			}
 			id := r.Header.Get(HeaderID)
 			code := r.Header.Get(HeaderCode)
-			if id == "" || code == "" {
+			if id == "" {
 				writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je obavezan.")
 				return
 			}
+
+			// Quick-approve path (todoSpec S12): an id with no code (or
+			// the explicit sentinel) means the client approved the action
+			// from the mobile app. Validate by id+user without a code,
+			// admitting only if the record was actually approved. An
+			// un-approved id-only request is rejected by ConsumeApproved
+			// (ErrNotApproved) — it is NOT a bypass of the code gate.
+			if code == "" || code == QuickApproveSentinel {
+				ap, ok := v.(verification.Approver)
+				if !ok {
+					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je obavezan.")
+					return
+				}
+				p, ok := pkgauth.PrincipalFrom(r.Context())
+				if !ok {
+					writeErr(w, http.StatusUnauthorized, "missing access token")
+					return
+				}
+				aerr := ap.ConsumeApproved(r.Context(), p.UserID, id, kind)
+				switch {
+				case aerr == nil:
+					next.ServeHTTP(w, r)
+				case errors.Is(aerr, verification.ErrNotApproved):
+					writeErr(w, http.StatusUnauthorized, "Zahtev još nije odobren sa telefona.")
+				case errors.Is(aerr, verification.ErrNotFound):
+					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je istekao. Zatraži novi.")
+				case errors.Is(aerr, verification.ErrMismatch):
+					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod ne odgovara ovoj akciji.")
+				default:
+					log.Warn("verification quick-approve consume failed", "error", aerr)
+					writeErr(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
+				}
+				return
+			}
+
 			err := v.Consume(r.Context(), id, code, kind)
 			switch {
 			case err == nil:

--- a/services/gateway/internal/verification/middleware_test.go
+++ b/services/gateway/internal/verification/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/verification"
 )
 
@@ -24,6 +25,25 @@ func (s *stubVerifier) Issue(_ context.Context, _ string, _ verification.ActionK
 
 func (s *stubVerifier) Consume(_ context.Context, id, code string, kind verification.ActionKind) error {
 	return s.consume(id, code, kind)
+}
+
+// stubApprover is the in-memory test double that also implements the
+// quick-approve capability (todoSpec S12).
+type stubApprover struct {
+	stubVerifier
+	consumeApproved func(userID, id string, kind verification.ActionKind) error
+}
+
+func (s *stubApprover) Approve(_ context.Context, _, _ string) error { return nil }
+
+func (s *stubApprover) ConsumeApproved(_ context.Context, userID, id string, kind verification.ActionKind) error {
+	return s.consumeApproved(userID, id, kind)
+}
+
+// withPrincipal stamps a principal so PrincipalFrom in the quick-approve
+// branch resolves (the auth middleware does this in production).
+func withPrincipal(req *http.Request, userID string) *http.Request {
+	return req.WithContext(pkgauth.WithPrincipal(req.Context(), pkgauth.Principal{UserID: userID}))
 }
 
 func discardLog() *slog.Logger {
@@ -135,6 +155,87 @@ func TestMiddleware_MapsErrorsToStatusCodes(t *testing.T) {
 				t.Errorf("status: %d, want 401", rec.Code)
 			}
 		})
+	}
+}
+
+func TestMiddleware_QuickApprove_PassesWhenApproved(t *testing.T) {
+	var gotUser, gotID string
+	var gotKind verification.ActionKind
+	v := &stubApprover{
+		stubVerifier: stubVerifier{consume: func(string, string, verification.ActionKind) error {
+			t.Error("Consume must not be called on the quick-approve path")
+			return nil
+		}},
+		consumeApproved: func(userID, id string, kind verification.ActionKind) error {
+			gotUser, gotID, gotKind = userID, id, kind
+			return nil
+		},
+	}
+	mw := Middleware(v, DefaultRules(), discardLog())(okHandler())
+
+	// id present, no code → quick-approve.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", nil)
+	req.Header.Set(HeaderID, "vid-1")
+	req = withPrincipal(req, "user-7")
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: %d, want 200 (approved id-only request)", rec.Code)
+	}
+	if gotUser != "user-7" || gotID != "vid-1" || gotKind != verification.ActionPayment {
+		t.Errorf("ConsumeApproved called with (%q,%q,%q), want (user-7, vid-1, payment)", gotUser, gotID, gotKind)
+	}
+}
+
+func TestMiddleware_QuickApprove_SentinelCode(t *testing.T) {
+	called := false
+	v := &stubApprover{
+		stubVerifier:    stubVerifier{consume: func(string, string, verification.ActionKind) error { t.Error("Consume must not run"); return nil }},
+		consumeApproved: func(string, string, verification.ActionKind) error { called = true; return nil },
+	}
+	mw := Middleware(v, DefaultRules(), discardLog())(okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", nil)
+	req.Header.Set(HeaderID, "vid-1")
+	req.Header.Set(HeaderCode, QuickApproveSentinel)
+	req = withPrincipal(req, "u")
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	if !called || rec.Code != http.StatusOK {
+		t.Errorf("sentinel code should route to quick-approve and pass: called=%v status=%d", called, rec.Code)
+	}
+}
+
+func TestMiddleware_QuickApprove_RejectsUnapproved(t *testing.T) {
+	v := &stubApprover{
+		stubVerifier:    stubVerifier{consume: func(string, string, verification.ActionKind) error { return nil }},
+		consumeApproved: func(string, string, verification.ActionKind) error { return verification.ErrNotApproved },
+	}
+	mw := Middleware(v, DefaultRules(), discardLog())(okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", nil)
+	req.Header.Set(HeaderID, "vid-unapproved")
+	req = withPrincipal(req, "u")
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status: %d, want 401 (un-approved id-only request must be rejected)", rec.Code)
+	}
+}
+
+func TestMiddleware_QuickApprove_NoApproverCapabilityRejects(t *testing.T) {
+	// A plain Verifier (no Approver) must reject id-only requests rather
+	// than silently bypassing the code gate.
+	v := &stubVerifier{consume: func(string, string, verification.ActionKind) error {
+		t.Error("Consume must not be called for an id-only request")
+		return nil
+	}}
+	mw := Middleware(v, DefaultRules(), discardLog())(okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", nil)
+	req.Header.Set(HeaderID, "vid-1")
+	req = withPrincipal(req, "u")
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status: %d, want 401 (no Approver capability)", rec.Code)
 	}
 }
 

--- a/services/gateway/internal/verification/recorder.go
+++ b/services/gateway/internal/verification/recorder.go
@@ -35,6 +35,7 @@ type RecordingVerifier struct {
 var (
 	_ verification.Verifier      = (*RecordingVerifier)(nil)
 	_ verification.PendingLister = (*RecordingVerifier)(nil)
+	_ verification.Approver      = (*RecordingVerifier)(nil)
 )
 
 func (r *RecordingVerifier) Issue(ctx context.Context, userID string, kind verification.ActionKind) (string, string, time.Time, error) {
@@ -90,4 +91,33 @@ func (r *RecordingVerifier) ListPending(ctx context.Context, userID string) ([]v
 		return nil, nil
 	}
 	return lister.ListPending(ctx, userID)
+}
+
+// Approve forwards the quick-approve flag to the inner verifier (the
+// Redis Cache implements Approver). A verifier without the capability
+// reports ErrNotFound so the gateway surfaces a clean 404/410. Approval
+// itself writes no history row — the terminal outcome is recorded by
+// ConsumeApproved when the gated request actually lands.
+func (r *RecordingVerifier) Approve(ctx context.Context, userID, id string) error {
+	ap, ok := r.Inner.(verification.Approver)
+	if !ok {
+		return verification.ErrNotFound
+	}
+	return ap.Approve(ctx, userID, id)
+}
+
+// ConsumeApproved forwards to the inner verifier and, on a clean
+// one-shot consume, resolves the durable history row to success —
+// mirroring Consume so a quick-approved action shows up as a successful
+// verification in the mobile "Verifikacija" history (spec p.84).
+func (r *RecordingVerifier) ConsumeApproved(ctx context.Context, userID, id string, expectedKind verification.ActionKind) error {
+	ap, ok := r.Inner.(verification.Approver)
+	if !ok {
+		return verification.ErrNotFound
+	}
+	err := ap.ConsumeApproved(ctx, userID, id, expectedKind)
+	if err == nil {
+		r.resolve(ctx, id, true)
+	}
+	return err
 }


### PR DESCRIPTION
Approve a verification-gated action from the mobile app instead of typing the code. pkg/verification gains an Approve + ConsumeApproved (id-only, owner-scoped, one-shot); gateway adds POST /verification/{id}/approve + a status endpoint, and the middleware allows an approved id-only request (un-approved id-only still rejected; 6-digit path unchanged). No proto change. 5-min TTL.

todoSpec: S12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)