### PR TITLE
feat(interbank): HMAC signature + timestamp + hash on messages (celina 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,10 +154,20 @@ STOCK_BIDASK_SPREAD=0.001
 # OUTBOUND (the key THEY issued). Overrides INTERBANK_API_KEY per bank,
 # so our inbound key and each partner's outbound key can differ. Example:
 #   INTERBANK_PARTNER_KEYS=444:bank4-secret-key
+#
+# INTERBANK_SIGN_KEY is the shared secret for the celina-5 digital
+# signature (pkg/signature, HMAC-SHA256). When set, every OUTBOUND
+# inter-bank request is stamped with X-Timestamp + X-Content-Hash +
+# X-Signature, and the gateway VERIFIES those headers on INBOUND partner
+# payments (rejecting bad/missing/stale signatures with 401). Leave empty
+# for a dev stack: both sides skip signing so unsigned traffic still
+# works (same env-driven gating as SMTP). Both banks in a pair must agree
+# on the same value.
 BANK_ROUTING_NUMBER=333
 INTERBANK_ROUTES=
 INTERBANK_API_KEY=dev-outbound-banka3
 INTERBANK_PARTNER_KEYS=
+INTERBANK_SIGN_KEY=
 
 # Scheduler service — the single non-replicatable driver of every
 # cluster-wide cron + worker. It calls the bank/trading/exchange trigger

--- a/pkg/signature/signature.go
+++ b/pkg/signature/signature.go
@@ -1,0 +1,196 @@
+// Package signature implements the celina-5 "Digitalni potpis i
+// verifikacija" primitive: every message exchanged between banks carries
+// a timestamp, a content hash, and a keyed signature so the receiver can
+// authenticate the sender and detect tampering or replay.
+//
+// The scheme is symmetric HMAC-SHA256 over a shared secret (each pair of
+// banks agrees on a key out of band). Asymmetric signatures (RSA/Ed25519
+// with published public keys) would be the textbook choice, but the
+// inter-bank fabric in this project already authenticates peers with a
+// shared X-Api-Key; reusing a shared secret for the signature keeps the
+// trust model consistent and avoids a key-distribution mechanism the
+// spec doesn't call for. The signed value binds the timestamp to the
+// payload hash, so a captured signature can't be replayed against a
+// different body or (within the skew window) re-sent later.
+//
+//	signature = base64( HMAC-SHA256( key, ts + "." + hex(sha256(payload)) ) )
+//
+// Verify recomputes the signature in constant time and rejects any
+// timestamp outside the allowed skew window to bound replay.
+package signature
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultSkew is the maximum age (and future drift) tolerated for a
+// message timestamp. Messages older than this are rejected as possible
+// replays; messages too far in the future are rejected as malformed
+// clocks. Five minutes matches the verifikacioni-kod TTL elsewhere in
+// the system.
+const DefaultSkew = 5 * time.Minute
+
+// Errors returned by Verify. Callers typically only care that
+// verification failed (any non-nil error → reject), but the distinct
+// values aid logging and tests.
+var (
+	// ErrNoKey is returned when a Signer has no key configured. Callers
+	// that allow an unsigned dev stack should check Enabled() first and
+	// skip signing/verification entirely rather than treating this as a
+	// rejection.
+	ErrNoKey = errors.New("signature: no key configured")
+	// ErrBadSignature is returned when the supplied signature does not
+	// match the recomputed one (wrong key, tampered payload, or tampered
+	// timestamp).
+	ErrBadSignature = errors.New("signature: signature mismatch")
+	// ErrStaleTimestamp is returned when the timestamp is outside the
+	// allowed skew window.
+	ErrStaleTimestamp = errors.New("signature: timestamp outside skew window")
+	// ErrBadTimestamp is returned when the timestamp can't be parsed.
+	ErrBadTimestamp = errors.New("signature: malformed timestamp")
+)
+
+// Signer signs and verifies inter-bank messages with a shared secret.
+// The zero value (empty key) is a valid "disabled" signer: Enabled()
+// reports false and Sign/Verify return ErrNoKey, letting a dev stack
+// without INTERBANK_SIGN_KEY run unsigned. Signer is safe for concurrent
+// use.
+type Signer struct {
+	key  []byte
+	skew time.Duration
+	// now is overridable in tests; nil means time.Now.
+	now func() time.Time
+}
+
+// New constructs a Signer from a shared-secret key. An empty key yields
+// a disabled signer (Enabled()==false). The skew window is DefaultSkew.
+func New(key string) *Signer {
+	return &Signer{key: []byte(key), skew: DefaultSkew, now: time.Now}
+}
+
+// NewWithSkew is New with a caller-chosen skew window. A non-positive
+// skew falls back to DefaultSkew.
+func NewWithSkew(key string, skew time.Duration) *Signer {
+	if skew <= 0 {
+		skew = DefaultSkew
+	}
+	return &Signer{key: []byte(key), skew: skew, now: time.Now}
+}
+
+// Enabled reports whether a key is configured. When false, callers
+// should neither stamp nor verify signatures (dev mode).
+func (s *Signer) Enabled() bool {
+	return s != nil && len(s.key) > 0
+}
+
+func (s *Signer) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// Timestamp returns the current time formatted as a Unix-seconds string,
+// suitable for the X-Timestamp header passed to Sign/Verify.
+func (s *Signer) Timestamp() string {
+	return strconv.FormatInt(s.clock().Unix(), 10)
+}
+
+// ContentHash returns the lowercase hex SHA-256 of payload. Exposed so
+// callers can stamp an X-Content-Hash header alongside the signature;
+// the hash is advisory (Verify recomputes it from the body), but it lets
+// a human or a proxy inspect integrity without the key.
+func ContentHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+// signingString is the value fed to HMAC: "<ts>.<hex sha256(payload)>".
+func signingString(payload []byte, ts string) string {
+	return ts + "." + ContentHash(payload)
+}
+
+// Sign returns the base64 signature over (ts, payload). Returns ErrNoKey
+// when the signer is disabled.
+func (s *Signer) Sign(payload []byte, ts string) (string, error) {
+	if !s.Enabled() {
+		return "", ErrNoKey
+	}
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write([]byte(signingString(payload, ts)))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// Verify checks sig against (ts, payload) and that ts is within the skew
+// window. Returns nil on success, or one of the package errors. The
+// signature comparison is constant-time. A disabled signer returns
+// ErrNoKey — callers gate on Enabled() before reaching here.
+func (s *Signer) Verify(payload []byte, ts, sig string) error {
+	if !s.Enabled() {
+		return ErrNoKey
+	}
+	if err := s.checkTimestamp(ts); err != nil {
+		return err
+	}
+	want, err := s.Sign(payload, ts)
+	if err != nil {
+		return err
+	}
+	// Compare the decoded bytes so cosmetic base64 differences don't
+	// matter; fall back to a string compare if either side isn't valid
+	// base64 (a malformed sig simply won't match).
+	gotRaw, gErr := base64.StdEncoding.DecodeString(sig)
+	wantRaw, wErr := base64.StdEncoding.DecodeString(want)
+	if gErr == nil && wErr == nil {
+		if subtle.ConstantTimeCompare(gotRaw, wantRaw) == 1 {
+			return nil
+		}
+		return ErrBadSignature
+	}
+	if subtle.ConstantTimeCompare([]byte(sig), []byte(want)) == 1 {
+		return nil
+	}
+	return ErrBadSignature
+}
+
+// checkTimestamp parses ts (Unix seconds or RFC3339) and rejects it when
+// it falls outside [now-skew, now+skew].
+func (s *Signer) checkTimestamp(ts string) error {
+	t, err := ParseTimestamp(ts)
+	if err != nil {
+		return err
+	}
+	delta := s.clock().Sub(t)
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > s.skew {
+		return ErrStaleTimestamp
+	}
+	return nil
+}
+
+// ParseTimestamp parses a header timestamp. It accepts Unix seconds
+// (what Timestamp emits) and RFC3339 so a partner stamping either form
+// interoperates.
+func ParseTimestamp(ts string) (time.Time, error) {
+	ts = strings.TrimSpace(ts)
+	if ts == "" {
+		return time.Time{}, ErrBadTimestamp
+	}
+	if secs, err := strconv.ParseInt(ts, 10, 64); err == nil {
+		return time.Unix(secs, 0), nil
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t, nil
+	}
+	return time.Time{}, ErrBadTimestamp
+}

--- a/pkg/signature/signature_test.go
+++ b/pkg/signature/signature_test.go
@@ -1,0 +1,179 @@
+package signature
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+const testKey = "shared-secret-between-banks"
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	s := New(testKey)
+	payload := []byte(`{"transaction_id":"abc","amount":"100.00"}`)
+	ts := s.Timestamp()
+
+	sig, err := s.Sign(payload, ts)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if sig == "" {
+		t.Fatal("Sign returned empty signature")
+	}
+	if err := s.Verify(payload, ts, sig); err != nil {
+		t.Fatalf("Verify of fresh signature failed: %v", err)
+	}
+}
+
+func TestVerifyTamperedPayloadFails(t *testing.T) {
+	s := New(testKey)
+	ts := s.Timestamp()
+	sig, err := s.Sign([]byte("original body"), ts)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify([]byte("tampered body"), ts, sig); err == nil {
+		t.Fatal("Verify accepted a tampered payload")
+	}
+}
+
+func TestVerifyTamperedTimestampFails(t *testing.T) {
+	s := New(testKey)
+	payload := []byte("body")
+	ts := s.Timestamp()
+	sig, err := s.Sign(payload, ts)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// A different (still in-window) timestamp must invalidate the sig.
+	other := strconv.FormatInt(time.Now().Add(-30*time.Second).Unix(), 10)
+	if other == ts {
+		other = strconv.FormatInt(time.Now().Add(-60*time.Second).Unix(), 10)
+	}
+	if err := s.Verify(payload, other, sig); err == nil {
+		t.Fatal("Verify accepted a tampered timestamp")
+	}
+}
+
+func TestVerifyStaleTimestampFails(t *testing.T) {
+	s := New(testKey)
+	payload := []byte("body")
+	// Sign with a timestamp well outside the skew window.
+	stale := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	sig, err := s.Sign(payload, stale)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify(payload, stale, sig); err != ErrStaleTimestamp {
+		t.Fatalf("want ErrStaleTimestamp, got %v", err)
+	}
+}
+
+func TestVerifyFutureTimestampFails(t *testing.T) {
+	s := New(testKey)
+	payload := []byte("body")
+	future := strconv.FormatInt(time.Now().Add(10*time.Minute).Unix(), 10)
+	sig, err := s.Sign(payload, future)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify(payload, future, sig); err != ErrStaleTimestamp {
+		t.Fatalf("want ErrStaleTimestamp, got %v", err)
+	}
+}
+
+func TestVerifyWrongKeyFails(t *testing.T) {
+	signer := New(testKey)
+	verifier := New("a-different-secret")
+	payload := []byte("body")
+	ts := signer.Timestamp()
+	sig, err := signer.Sign(payload, ts)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := verifier.Verify(payload, ts, sig); err != ErrBadSignature {
+		t.Fatalf("want ErrBadSignature, got %v", err)
+	}
+}
+
+func TestVerifyMalformedTimestamp(t *testing.T) {
+	s := New(testKey)
+	if err := s.Verify([]byte("body"), "not-a-time", "AAAA"); err != ErrBadTimestamp {
+		t.Fatalf("want ErrBadTimestamp, got %v", err)
+	}
+}
+
+func TestVerifyGarbageSignature(t *testing.T) {
+	s := New(testKey)
+	ts := s.Timestamp()
+	if err := s.Verify([]byte("body"), ts, "!!!not-base64!!!"); err == nil {
+		t.Fatal("Verify accepted a garbage signature")
+	}
+}
+
+func TestDisabledSigner(t *testing.T) {
+	s := New("")
+	if s.Enabled() {
+		t.Fatal("empty-key signer reports Enabled")
+	}
+	if _, err := s.Sign([]byte("x"), "1"); err != ErrNoKey {
+		t.Fatalf("want ErrNoKey from Sign, got %v", err)
+	}
+	if err := s.Verify([]byte("x"), "1", "y"); err != ErrNoKey {
+		t.Fatalf("want ErrNoKey from Verify, got %v", err)
+	}
+}
+
+func TestRFC3339TimestampAccepted(t *testing.T) {
+	s := New(testKey)
+	payload := []byte("body")
+	ts := time.Now().UTC().Format(time.RFC3339)
+	sig, err := s.Sign(payload, ts)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify(payload, ts, sig); err != nil {
+		t.Fatalf("RFC3339 round-trip failed: %v", err)
+	}
+}
+
+func TestContentHashStable(t *testing.T) {
+	h1 := ContentHash([]byte("abc"))
+	h2 := ContentHash([]byte("abc"))
+	if h1 != h2 {
+		t.Fatal("ContentHash not deterministic")
+	}
+	if h1 == ContentHash([]byte("abd")) {
+		t.Fatal("ContentHash collision on different input")
+	}
+	if len(h1) != 64 {
+		t.Fatalf("want 64 hex chars, got %d", len(h1))
+	}
+}
+
+func TestSkewBoundary(t *testing.T) {
+	// A signer whose clock is pinned; verify a timestamp exactly at the
+	// edge of the window is accepted and just past it is rejected.
+	base := time.Unix(1_700_000_000, 0)
+	s := NewWithSkew(testKey, time.Minute)
+	s.now = func() time.Time { return base }
+	payload := []byte("body")
+
+	atEdge := strconv.FormatInt(base.Add(-time.Minute).Unix(), 10)
+	sig, err := s.Sign(payload, atEdge)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify(payload, atEdge, sig); err != nil {
+		t.Fatalf("edge-of-window timestamp rejected: %v", err)
+	}
+
+	past := strconv.FormatInt(base.Add(-time.Minute-time.Second).Unix(), 10)
+	sig2, err := s.Sign(payload, past)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := s.Verify(payload, past, sig2); err != ErrStaleTimestamp {
+		t.Fatalf("want ErrStaleTimestamp just past window, got %v", err)
+	}
+}

--- a/services/gateway/internal/app/app.go
+++ b/services/gateway/internal/app/app.go
@@ -139,6 +139,7 @@ func Run() error {
 			r.PartnerPayments = &router.PartnerPayments{
 				APIKey:    apiKey,
 				Interbank: cs.InterbankProtocol,
+				SignKey:   config.String("INTERBANK_SIGN_KEY", ""),
 			}
 		}
 		// Banka-2 dialect inbound shim — re-uses the same shared API

--- a/services/gateway/internal/router/partner_payments.go
+++ b/services/gateway/internal/router/partner_payments.go
@@ -19,6 +19,7 @@
 package router
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/json"
@@ -28,6 +29,7 @@ import (
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
 	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/signature"
 )
 
 // partnerCtx stamps the gateway's admin-sentinel principal as outgoing
@@ -49,6 +51,13 @@ func partnerCtx(ctx context.Context) context.Context {
 type PartnerPayments struct {
 	APIKey    string
 	Interbank bankpb.InterbankProtocolServiceClient
+	// SignKey enables celina-5 digital-signature verification on inbound
+	// partner messages. When set, guard() verifies X-Timestamp +
+	// X-Signature against the raw request body via pkg/signature and
+	// rejects bad/missing/stale signatures with 401, in addition to the
+	// X-Api-Key check. Empty disables verification so a dev stack without
+	// INTERBANK_SIGN_KEY accepts unsigned partner traffic.
+	SignKey string
 }
 
 // Wire types — native protocol, snake_case JSON.
@@ -107,11 +116,29 @@ func (p *PartnerPayments) MountPartnerPayments(mux *http.ServeMux) {
 
 func (p *PartnerPayments) guard(h http.HandlerFunc) http.HandlerFunc {
 	expected := []byte(p.APIKey)
+	verifier := signature.New(p.SignKey)
 	return func(w http.ResponseWriter, r *http.Request) {
 		got := []byte(r.Header.Get("X-Api-Key"))
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
 			writeError(w, http.StatusUnauthorized, "invalid X-Api-Key")
 			return
+		}
+		// Celina-5 digital signature: when a sign key is configured,
+		// verify the timestamp + signature over the raw body before the
+		// handler runs. The body is buffered and restored so downstream
+		// handlers (which read r.Body themselves) are unaffected.
+		if verifier.Enabled() {
+			body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+			_ = r.Body.Close()
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "read body: "+err.Error())
+				return
+			}
+			if err := verifier.Verify(body, r.Header.Get("X-Timestamp"), r.Header.Get("X-Signature")); err != nil {
+				writeError(w, http.StatusUnauthorized, "invalid signature: "+err.Error())
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		h(w, r)
 	}

--- a/services/trading/internal/app/app.go
+++ b/services/trading/internal/app/app.go
@@ -202,6 +202,7 @@ func Run() error {
 				APIKey:           config.String("INTERBANK_API_KEY", ""),
 				PartnerKeys:      interbank.ParsePartnerKeys(config.String("INTERBANK_PARTNER_KEYS", "")),
 				OwnRoutingNumber: config.String("BANK_ROUTING_NUMBER", "333"),
+				SignKey:          config.String("INTERBANK_SIGN_KEY", ""),
 			}, log)
 			svc.PartnerOTC = client
 			svc.PartnerPayer = client

--- a/services/trading/internal/external/interbank/client.go
+++ b/services/trading/internal/external/interbank/client.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/signature"
 )
 
 // Protocol identifies which wire shape a partner bank speaks.
@@ -49,6 +51,12 @@ type Config struct {
 	// OwnRoutingNumber identifies this bank to the partner (echoed in
 	// request payloads so partners can populate their remote_bank_code).
 	OwnRoutingNumber string
+	// SignKey is the shared secret for the celina-5 digital-signature
+	// primitive (INTERBANK_SIGN_KEY). When non-empty, every outbound
+	// request is stamped with X-Timestamp, X-Content-Hash, and
+	// X-Signature so the receiving bank can authenticate us and detect
+	// tampering/replay. Empty disables signing (dev stack without a key).
+	SignKey string
 	// HTTPClient — caller may override; defaults to a 10s-timeout client.
 	HTTPClient *http.Client
 }
@@ -59,6 +67,7 @@ type Config struct {
 type Client struct {
 	cfg       Config
 	log       *slog.Logger
+	signer    *signature.Signer
 	protocols sync.Map // bankCode -> Protocol (sticky after first probe)
 }
 
@@ -70,7 +79,7 @@ func New(cfg Config, log *slog.Logger) *Client {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Client{cfg: cfg, log: log}
+	return &Client{cfg: cfg, log: log, signer: signature.New(cfg.SignKey)}
 }
 
 // baseURL returns the registered URL for the bank code, or "".
@@ -153,6 +162,28 @@ func (c *Client) probeOK(ctx context.Context, method, url string, withAPIKey boo
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+// signRequest stamps the celina-5 digital-signature headers on an
+// outbound request when a sign key is configured. body is the exact
+// bytes that will be sent (nil/empty for GET probes). When signing is
+// disabled the request is left untouched, so a dev stack without
+// INTERBANK_SIGN_KEY interoperates with an unsigned peer.
+func (c *Client) signRequest(req *http.Request, body []byte) {
+	if c.signer == nil || !c.signer.Enabled() {
+		return
+	}
+	ts := c.signer.Timestamp()
+	sig, err := c.signer.Sign(body, ts)
+	if err != nil {
+		// Enabled() is true so the only error is a programming bug;
+		// log and send unsigned rather than dropping the request.
+		c.log.Warn("interbank sign failed", "error", err)
+		return
+	}
+	req.Header.Set("X-Timestamp", ts)
+	req.Header.Set("X-Content-Hash", signature.ContentHash(body))
+	req.Header.Set("X-Signature", sig)
+}
+
 // doJSON marshals body to JSON, attaches API key, fires the request,
 // reads up to ~1 MiB of response into respBody, returns the response
 // status code and body (regardless of status — callers decide whether
@@ -160,8 +191,10 @@ func (c *Client) probeOK(ctx context.Context, method, url string, withAPIKey boo
 // the caller can surface the partner's error message.
 func (c *Client) doJSON(ctx context.Context, method, url string, body any) (int, []byte, error) {
 	var reader io.Reader
+	var buf []byte
 	if body != nil {
-		buf, err := json.Marshal(body)
+		var err error
+		buf, err = json.Marshal(body)
 		if err != nil {
 			return 0, nil, fmt.Errorf("marshal: %w", err)
 		}
@@ -177,6 +210,7 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any) (int,
 	if k := c.apiKeyForURL(url); k != "" {
 		req.Header.Set("X-Api-Key", k)
 	}
+	c.signRequest(req, buf)
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
 		return 0, nil, fmt.Errorf("do request: %w", err)

--- a/services/trading/internal/external/interbank/payments.go
+++ b/services/trading/internal/external/interbank/payments.go
@@ -420,6 +420,7 @@ func (c *Client) doJSONWithHeaders(ctx context.Context, method, url string, body
 	if k := c.apiKeyForURL(url); k != "" {
 		req.Header.Set("X-Api-Key", k)
 	}
+	c.signRequest(req, buf)
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}


### PR DESCRIPTION
pkg/signature (HMAC-SHA256 + 5-min skew replay guard); outbound interbank client stamps X-Timestamp/X-Content-Hash/X-Signature; gateway partner endpoints verify inbound. Env-gated (INTERBANK_SIGN_KEY) — dev without key still works. No proto/migration.

todoSpec C5: digital signature + verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)