### PR TITLE
feat(interbank): retry queue + scheduled/periodic cross-bank payments (celina 5)

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -1454,6 +1454,169 @@
         ]
       }
     },
+    "/api/v1/cross-bank-payments/scheduled": {
+      "get": {
+        "summary": "ListScheduledInterbankPayments returns the caller's own scheduled\npayments (active + paused).",
+        "operationId": "CrossBankPaymentService_ListScheduledInterbankPayments",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListScheduledInterbankPaymentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      },
+      "post": {
+        "summary": "CreateScheduledInterbankPayment schedules a cross-bank payment to run\nonce on a future date or to repeat on a cadence. Spec example:\n\"Svakog prvog u mesecu poslati 400 EUR na dati račun.\"",
+        "operationId": "CrossBankPaymentService_CreateScheduledInterbankPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ScheduledInterbankPayment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateScheduledInterbankPaymentRequest"
+            }
+          }
+        ],
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      }
+    },
+    "/api/v1/cross-bank-payments/scheduled/{id}": {
+      "delete": {
+        "summary": "CancelScheduledInterbankPayment deletes a scheduled payment permanently.",
+        "operationId": "CrossBankPaymentService_CancelScheduledInterbankPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelScheduledInterbankPaymentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      }
+    },
+    "/api/v1/cross-bank-payments/scheduled/{id}/pause": {
+      "post": {
+        "summary": "PauseScheduledInterbankPayment flips active=false so the sweep skips it.",
+        "operationId": "CrossBankPaymentService_PauseScheduledInterbankPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ScheduledInterbankPayment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CrossBankPaymentServicePauseScheduledInterbankPaymentBody"
+            }
+          }
+        ],
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      }
+    },
+    "/api/v1/cross-bank-payments/scheduled/{id}/resume": {
+      "post": {
+        "summary": "ResumeScheduledInterbankPayment flips active=true so the sweep resumes it.",
+        "operationId": "CrossBankPaymentService_ResumeScheduledInterbankPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ScheduledInterbankPayment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CrossBankPaymentServiceResumeScheduledInterbankPaymentBody"
+            }
+          }
+        ],
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      }
+    },
     "/api/v1/dividends": {
       "get": {
         "summary": "ListDividendPayouts returns the caller's received-dividend history\n(todoSpec C3 S59), optionally scoped to one security for the\nper-position view. Supervisors/admin may pass user_id to inspect\nanother holder.",
@@ -4947,6 +5110,29 @@
         ]
       }
     },
+    "/api/v1/payments/interbank/retries": {
+      "get": {
+        "summary": "ListInterbankRetries returns the caller's own retry-queue entries.\nWhen a partner bank is unavailable the cross-bank payment is parked\nand retried every 5s; after 30s without success it fails and the\nclient is notified. This surfaces those entries for transparency.",
+        "operationId": "CrossBankPaymentService_ListInterbankRetries",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListInterbankRetriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "CrossBankPaymentService"
+        ]
+      }
+    },
     "/api/v1/payments/interbank/{transactionId}": {
       "get": {
         "summary": "GetCrossBankPayment fetches a saga row by transaction_id.\nAuth: only the originator (or admin) sees their payment.",
@@ -6285,6 +6471,12 @@
         }
       }
     },
+    "CrossBankPaymentServicePauseScheduledInterbankPaymentBody": {
+      "type": "object"
+    },
+    "CrossBankPaymentServiceResumeScheduledInterbankPaymentBody": {
+      "type": "object"
+    },
     "ExternalOTCServiceAcceptExternalOTCOfferBody": {
       "type": "object"
     },
@@ -7078,6 +7270,9 @@
     "v1CancelRecurringOrderResponse": {
       "type": "object"
     },
+    "v1CancelScheduledInterbankPaymentResponse": {
+      "type": "object"
+    },
     "v1Card": {
       "type": "object",
       "properties": {
@@ -7665,6 +7860,37 @@
         "startDate": {
           "type": "string",
           "description": "start_date optionally anchors the first NextRun (RFC3339). When\nempty the first run is one cadence interval from now."
+        }
+      }
+    },
+    "v1CreateScheduledInterbankPaymentRequest": {
+      "type": "object",
+      "properties": {
+        "sourceAccountId": {
+          "type": "string"
+        },
+        "destBankCode": {
+          "type": "string"
+        },
+        "destAccountNumber": {
+          "type": "string"
+        },
+        "currency": {
+          "$ref": "#/definitions/bankaTradingV1Currency"
+        },
+        "amount": {
+          "type": "string"
+        },
+        "purpose": {
+          "type": "string"
+        },
+        "cadence": {
+          "type": "string",
+          "description": "cadence is one of ONCE / DAILY / WEEKLY / MONTHLY."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "start_date (RFC3339) anchors the first run. Required for ONCE\n(validated to be in the future); optional for recurring cadences."
         }
       }
     },
@@ -8952,6 +9178,50 @@
       },
       "description": "InterbankMessage is the supervisor projection of a recorded inbound\npartner message (the comms / audit history). message_type is the\nstored \"NEW_TX\" / \"COMMIT_TX\" / \"ROLLBACK_TX\" string."
     },
+    "v1InterbankRetryEntry": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "string"
+        },
+        "partnerBankCode": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "attemptCount": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "nextRetryAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deadlineAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "title": "pending | succeeded | failed"
+        },
+        "lastError": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "v1InterbankTransaction": {
       "type": "object",
       "properties": {
@@ -9388,6 +9658,18 @@
         }
       }
     },
+    "v1ListInterbankRetriesResponse": {
+      "type": "object",
+      "properties": {
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1InterbankRetryEntry"
+          }
+        }
+      }
+    },
     "v1ListInterbankTransactionsResponse": {
       "type": "object",
       "properties": {
@@ -9630,6 +9912,18 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/v1RecurringOrder"
+          }
+        }
+      }
+    },
+    "v1ListScheduledInterbankPaymentsResponse": {
+      "type": "object",
+      "properties": {
+        "scheduledPayments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ScheduledInterbankPayment"
           }
         }
       }
@@ -11174,6 +11468,65 @@
           "type": "string",
           "format": "date-time",
           "description": "Future date the payment should execute on. Server rejects a\nnon-future value (spec: \"Sistem proverava da li je datum u\nbudućnosti\")."
+        }
+      }
+    },
+    "v1ScheduledInterbankPayment": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "sourceAccountId": {
+          "type": "string"
+        },
+        "destBankCode": {
+          "type": "string"
+        },
+        "destAccountNumber": {
+          "type": "string"
+        },
+        "currency": {
+          "$ref": "#/definitions/bankaTradingV1Currency"
+        },
+        "amount": {
+          "type": "string"
+        },
+        "purpose": {
+          "type": "string"
+        },
+        "cadence": {
+          "type": "string",
+          "description": "cadence is one of ONCE / DAILY / WEEKLY / MONTHLY (pkg/schedule.Cadence)."
+        },
+        "nextRun": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "lastStatus": {
+          "type": "string",
+          "title": "most recent run's outcome (running|completed|failed)"
+        },
+        "lastError": {
+          "type": "string"
+        },
+        "lastRunAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
         }
       }
     },

--- a/gen/proto/trading/v1/cross_bank_payments.pb.go
+++ b/gen/proto/trading/v1/cross_bank_payments.pb.go
@@ -24,6 +24,889 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ListInterbankRetriesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInterbankRetriesRequest) Reset() {
+	*x = ListInterbankRetriesRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInterbankRetriesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInterbankRetriesRequest) ProtoMessage() {}
+
+func (x *ListInterbankRetriesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInterbankRetriesRequest.ProtoReflect.Descriptor instead.
+func (*ListInterbankRetriesRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{0}
+}
+
+type ListInterbankRetriesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entries       []*InterbankRetryEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInterbankRetriesResponse) Reset() {
+	*x = ListInterbankRetriesResponse{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInterbankRetriesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInterbankRetriesResponse) ProtoMessage() {}
+
+func (x *ListInterbankRetriesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInterbankRetriesResponse.ProtoReflect.Descriptor instead.
+func (*ListInterbankRetriesResponse) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ListInterbankRetriesResponse) GetEntries() []*InterbankRetryEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+type InterbankRetryEntry struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TransactionId   string                 `protobuf:"bytes,2,opt,name=transaction_id,json=transactionId,proto3" json:"transaction_id,omitempty"`
+	PartnerBankCode string                 `protobuf:"bytes,3,opt,name=partner_bank_code,json=partnerBankCode,proto3" json:"partner_bank_code,omitempty"`
+	Operation       string                 `protobuf:"bytes,4,opt,name=operation,proto3" json:"operation,omitempty"`
+	AttemptCount    int32                  `protobuf:"varint,5,opt,name=attempt_count,json=attemptCount,proto3" json:"attempt_count,omitempty"`
+	NextRetryAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=next_retry_at,json=nextRetryAt,proto3" json:"next_retry_at,omitempty"`
+	DeadlineAt      *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=deadline_at,json=deadlineAt,proto3" json:"deadline_at,omitempty"`
+	Status          string                 `protobuf:"bytes,8,opt,name=status,proto3" json:"status,omitempty"` // pending | succeeded | failed
+	LastError       string                 `protobuf:"bytes,9,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	CreatedAt       *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt       *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *InterbankRetryEntry) Reset() {
+	*x = InterbankRetryEntry{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterbankRetryEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterbankRetryEntry) ProtoMessage() {}
+
+func (x *InterbankRetryEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterbankRetryEntry.ProtoReflect.Descriptor instead.
+func (*InterbankRetryEntry) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *InterbankRetryEntry) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetTransactionId() string {
+	if x != nil {
+		return x.TransactionId
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetPartnerBankCode() string {
+	if x != nil {
+		return x.PartnerBankCode
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetOperation() string {
+	if x != nil {
+		return x.Operation
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetAttemptCount() int32 {
+	if x != nil {
+		return x.AttemptCount
+	}
+	return 0
+}
+
+func (x *InterbankRetryEntry) GetNextRetryAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.NextRetryAt
+	}
+	return nil
+}
+
+func (x *InterbankRetryEntry) GetDeadlineAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.DeadlineAt
+	}
+	return nil
+}
+
+func (x *InterbankRetryEntry) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+func (x *InterbankRetryEntry) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *InterbankRetryEntry) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+type RunInterbankRetryTickRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunInterbankRetryTickRequest) Reset() {
+	*x = RunInterbankRetryTickRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunInterbankRetryTickRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunInterbankRetryTickRequest) ProtoMessage() {}
+
+func (x *RunInterbankRetryTickRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunInterbankRetryTickRequest.ProtoReflect.Descriptor instead.
+func (*RunInterbankRetryTickRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{3}
+}
+
+type RunInterbankRetryTickResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// settled is the number of entries that reached a terminal state this
+	// tick (succeeded + failed).
+	Settled       int32 `protobuf:"varint,1,opt,name=settled,proto3" json:"settled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunInterbankRetryTickResponse) Reset() {
+	*x = RunInterbankRetryTickResponse{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunInterbankRetryTickResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunInterbankRetryTickResponse) ProtoMessage() {}
+
+func (x *RunInterbankRetryTickResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunInterbankRetryTickResponse.ProtoReflect.Descriptor instead.
+func (*RunInterbankRetryTickResponse) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *RunInterbankRetryTickResponse) GetSettled() int32 {
+	if x != nil {
+		return x.Settled
+	}
+	return 0
+}
+
+type ScheduledInterbankPayment struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	UserId            string                 `protobuf:"bytes,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	SourceAccountId   string                 `protobuf:"bytes,3,opt,name=source_account_id,json=sourceAccountId,proto3" json:"source_account_id,omitempty"`
+	DestBankCode      string                 `protobuf:"bytes,4,opt,name=dest_bank_code,json=destBankCode,proto3" json:"dest_bank_code,omitempty"`
+	DestAccountNumber string                 `protobuf:"bytes,5,opt,name=dest_account_number,json=destAccountNumber,proto3" json:"dest_account_number,omitempty"`
+	Currency          Currency               `protobuf:"varint,6,opt,name=currency,proto3,enum=banka.trading.v1.Currency" json:"currency,omitempty"`
+	Amount            string                 `protobuf:"bytes,7,opt,name=amount,proto3" json:"amount,omitempty"`
+	Purpose           string                 `protobuf:"bytes,8,opt,name=purpose,proto3" json:"purpose,omitempty"`
+	// cadence is one of ONCE / DAILY / WEEKLY / MONTHLY (pkg/schedule.Cadence).
+	Cadence       string                 `protobuf:"bytes,9,opt,name=cadence,proto3" json:"cadence,omitempty"`
+	NextRun       *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=next_run,json=nextRun,proto3" json:"next_run,omitempty"`
+	Active        bool                   `protobuf:"varint,11,opt,name=active,proto3" json:"active,omitempty"`
+	LastStatus    string                 `protobuf:"bytes,12,opt,name=last_status,json=lastStatus,proto3" json:"last_status,omitempty"` // most recent run's outcome (running|completed|failed)
+	LastError     string                 `protobuf:"bytes,13,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	LastRunAt     *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=last_run_at,json=lastRunAt,proto3" json:"last_run_at,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScheduledInterbankPayment) Reset() {
+	*x = ScheduledInterbankPayment{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScheduledInterbankPayment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScheduledInterbankPayment) ProtoMessage() {}
+
+func (x *ScheduledInterbankPayment) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScheduledInterbankPayment.ProtoReflect.Descriptor instead.
+func (*ScheduledInterbankPayment) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ScheduledInterbankPayment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetSourceAccountId() string {
+	if x != nil {
+		return x.SourceAccountId
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetDestBankCode() string {
+	if x != nil {
+		return x.DestBankCode
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetDestAccountNumber() string {
+	if x != nil {
+		return x.DestAccountNumber
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetCurrency() Currency {
+	if x != nil {
+		return x.Currency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ScheduledInterbankPayment) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetPurpose() string {
+	if x != nil {
+		return x.Purpose
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetCadence() string {
+	if x != nil {
+		return x.Cadence
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetNextRun() *timestamppb.Timestamp {
+	if x != nil {
+		return x.NextRun
+	}
+	return nil
+}
+
+func (x *ScheduledInterbankPayment) GetActive() bool {
+	if x != nil {
+		return x.Active
+	}
+	return false
+}
+
+func (x *ScheduledInterbankPayment) GetLastStatus() string {
+	if x != nil {
+		return x.LastStatus
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+func (x *ScheduledInterbankPayment) GetLastRunAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastRunAt
+	}
+	return nil
+}
+
+func (x *ScheduledInterbankPayment) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *ScheduledInterbankPayment) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+type CreateScheduledInterbankPaymentRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	SourceAccountId   string                 `protobuf:"bytes,1,opt,name=source_account_id,json=sourceAccountId,proto3" json:"source_account_id,omitempty"`
+	DestBankCode      string                 `protobuf:"bytes,2,opt,name=dest_bank_code,json=destBankCode,proto3" json:"dest_bank_code,omitempty"`
+	DestAccountNumber string                 `protobuf:"bytes,3,opt,name=dest_account_number,json=destAccountNumber,proto3" json:"dest_account_number,omitempty"`
+	Currency          Currency               `protobuf:"varint,4,opt,name=currency,proto3,enum=banka.trading.v1.Currency" json:"currency,omitempty"`
+	Amount            string                 `protobuf:"bytes,5,opt,name=amount,proto3" json:"amount,omitempty"`
+	Purpose           string                 `protobuf:"bytes,6,opt,name=purpose,proto3" json:"purpose,omitempty"`
+	// cadence is one of ONCE / DAILY / WEEKLY / MONTHLY.
+	Cadence string `protobuf:"bytes,7,opt,name=cadence,proto3" json:"cadence,omitempty"`
+	// start_date (RFC3339) anchors the first run. Required for ONCE
+	// (validated to be in the future); optional for recurring cadences.
+	StartDate     string `protobuf:"bytes,8,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) Reset() {
+	*x = CreateScheduledInterbankPaymentRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateScheduledInterbankPaymentRequest) ProtoMessage() {}
+
+func (x *CreateScheduledInterbankPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateScheduledInterbankPaymentRequest.ProtoReflect.Descriptor instead.
+func (*CreateScheduledInterbankPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetSourceAccountId() string {
+	if x != nil {
+		return x.SourceAccountId
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetDestBankCode() string {
+	if x != nil {
+		return x.DestBankCode
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetDestAccountNumber() string {
+	if x != nil {
+		return x.DestAccountNumber
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetCurrency() Currency {
+	if x != nil {
+		return x.Currency
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetPurpose() string {
+	if x != nil {
+		return x.Purpose
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetCadence() string {
+	if x != nil {
+		return x.Cadence
+	}
+	return ""
+}
+
+func (x *CreateScheduledInterbankPaymentRequest) GetStartDate() string {
+	if x != nil {
+		return x.StartDate
+	}
+	return ""
+}
+
+type ListScheduledInterbankPaymentsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListScheduledInterbankPaymentsRequest) Reset() {
+	*x = ListScheduledInterbankPaymentsRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListScheduledInterbankPaymentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListScheduledInterbankPaymentsRequest) ProtoMessage() {}
+
+func (x *ListScheduledInterbankPaymentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListScheduledInterbankPaymentsRequest.ProtoReflect.Descriptor instead.
+func (*ListScheduledInterbankPaymentsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{7}
+}
+
+type ListScheduledInterbankPaymentsResponse struct {
+	state             protoimpl.MessageState       `protogen:"open.v1"`
+	ScheduledPayments []*ScheduledInterbankPayment `protobuf:"bytes,1,rep,name=scheduled_payments,json=scheduledPayments,proto3" json:"scheduled_payments,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ListScheduledInterbankPaymentsResponse) Reset() {
+	*x = ListScheduledInterbankPaymentsResponse{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListScheduledInterbankPaymentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListScheduledInterbankPaymentsResponse) ProtoMessage() {}
+
+func (x *ListScheduledInterbankPaymentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListScheduledInterbankPaymentsResponse.ProtoReflect.Descriptor instead.
+func (*ListScheduledInterbankPaymentsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListScheduledInterbankPaymentsResponse) GetScheduledPayments() []*ScheduledInterbankPayment {
+	if x != nil {
+		return x.ScheduledPayments
+	}
+	return nil
+}
+
+type PauseScheduledInterbankPaymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PauseScheduledInterbankPaymentRequest) Reset() {
+	*x = PauseScheduledInterbankPaymentRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PauseScheduledInterbankPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PauseScheduledInterbankPaymentRequest) ProtoMessage() {}
+
+func (x *PauseScheduledInterbankPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PauseScheduledInterbankPaymentRequest.ProtoReflect.Descriptor instead.
+func (*PauseScheduledInterbankPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *PauseScheduledInterbankPaymentRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ResumeScheduledInterbankPaymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeScheduledInterbankPaymentRequest) Reset() {
+	*x = ResumeScheduledInterbankPaymentRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeScheduledInterbankPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeScheduledInterbankPaymentRequest) ProtoMessage() {}
+
+func (x *ResumeScheduledInterbankPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeScheduledInterbankPaymentRequest.ProtoReflect.Descriptor instead.
+func (*ResumeScheduledInterbankPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ResumeScheduledInterbankPaymentRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type CancelScheduledInterbankPaymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelScheduledInterbankPaymentRequest) Reset() {
+	*x = CancelScheduledInterbankPaymentRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelScheduledInterbankPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelScheduledInterbankPaymentRequest) ProtoMessage() {}
+
+func (x *CancelScheduledInterbankPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelScheduledInterbankPaymentRequest.ProtoReflect.Descriptor instead.
+func (*CancelScheduledInterbankPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *CancelScheduledInterbankPaymentRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type CancelScheduledInterbankPaymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelScheduledInterbankPaymentResponse) Reset() {
+	*x = CancelScheduledInterbankPaymentResponse{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelScheduledInterbankPaymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelScheduledInterbankPaymentResponse) ProtoMessage() {}
+
+func (x *CancelScheduledInterbankPaymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelScheduledInterbankPaymentResponse.ProtoReflect.Descriptor instead.
+func (*CancelScheduledInterbankPaymentResponse) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{12}
+}
+
+type RunDueInterbankPaymentsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunDueInterbankPaymentsRequest) Reset() {
+	*x = RunDueInterbankPaymentsRequest{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunDueInterbankPaymentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunDueInterbankPaymentsRequest) ProtoMessage() {}
+
+func (x *RunDueInterbankPaymentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunDueInterbankPaymentsRequest.ProtoReflect.Descriptor instead.
+func (*RunDueInterbankPaymentsRequest) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{13}
+}
+
+type RunDueInterbankPaymentsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// submitted is the number of payments successfully submitted this run.
+	Submitted     int32 `protobuf:"varint,1,opt,name=submitted,proto3" json:"submitted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunDueInterbankPaymentsResponse) Reset() {
+	*x = RunDueInterbankPaymentsResponse{}
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunDueInterbankPaymentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunDueInterbankPaymentsResponse) ProtoMessage() {}
+
+func (x *RunDueInterbankPaymentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunDueInterbankPaymentsResponse.ProtoReflect.Descriptor instead.
+func (*RunDueInterbankPaymentsResponse) Descriptor() ([]byte, []int) {
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RunDueInterbankPaymentsResponse) GetSubmitted() int32 {
+	if x != nil {
+		return x.Submitted
+	}
+	return 0
+}
+
 type SubmitCrossBankPaymentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Stable across retries; combined with (user_id, source_account_id)
@@ -44,7 +927,7 @@ type SubmitCrossBankPaymentRequest struct {
 
 func (x *SubmitCrossBankPaymentRequest) Reset() {
 	*x = SubmitCrossBankPaymentRequest{}
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[0]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -56,7 +939,7 @@ func (x *SubmitCrossBankPaymentRequest) String() string {
 func (*SubmitCrossBankPaymentRequest) ProtoMessage() {}
 
 func (x *SubmitCrossBankPaymentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[0]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -69,7 +952,7 @@ func (x *SubmitCrossBankPaymentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitCrossBankPaymentRequest.ProtoReflect.Descriptor instead.
 func (*SubmitCrossBankPaymentRequest) Descriptor() ([]byte, []int) {
-	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{0}
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SubmitCrossBankPaymentRequest) GetIdempotencyKey() string {
@@ -132,7 +1015,7 @@ type SubmitCrossBankPaymentResponse struct {
 
 func (x *SubmitCrossBankPaymentResponse) Reset() {
 	*x = SubmitCrossBankPaymentResponse{}
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[1]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -144,7 +1027,7 @@ func (x *SubmitCrossBankPaymentResponse) String() string {
 func (*SubmitCrossBankPaymentResponse) ProtoMessage() {}
 
 func (x *SubmitCrossBankPaymentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[1]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -157,7 +1040,7 @@ func (x *SubmitCrossBankPaymentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitCrossBankPaymentResponse.ProtoReflect.Descriptor instead.
 func (*SubmitCrossBankPaymentResponse) Descriptor() ([]byte, []int) {
-	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{1}
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SubmitCrossBankPaymentResponse) GetTransactionId() string {
@@ -190,7 +1073,7 @@ type GetCrossBankPaymentRequest struct {
 
 func (x *GetCrossBankPaymentRequest) Reset() {
 	*x = GetCrossBankPaymentRequest{}
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[2]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -202,7 +1085,7 @@ func (x *GetCrossBankPaymentRequest) String() string {
 func (*GetCrossBankPaymentRequest) ProtoMessage() {}
 
 func (x *GetCrossBankPaymentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[2]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -215,7 +1098,7 @@ func (x *GetCrossBankPaymentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrossBankPaymentRequest.ProtoReflect.Descriptor instead.
 func (*GetCrossBankPaymentRequest) Descriptor() ([]byte, []int) {
-	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{2}
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetCrossBankPaymentRequest) GetTransactionId() string {
@@ -247,7 +1130,7 @@ type CrossBankPayment struct {
 
 func (x *CrossBankPayment) Reset() {
 	*x = CrossBankPayment{}
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[3]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -259,7 +1142,7 @@ func (x *CrossBankPayment) String() string {
 func (*CrossBankPayment) ProtoMessage() {}
 
 func (x *CrossBankPayment) ProtoReflect() protoreflect.Message {
-	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[3]
+	mi := &file_trading_v1_cross_bank_payments_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -272,7 +1155,7 @@ func (x *CrossBankPayment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CrossBankPayment.ProtoReflect.Descriptor instead.
 func (*CrossBankPayment) Descriptor() ([]byte, []int) {
-	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{3}
+	return file_trading_v1_cross_bank_payments_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *CrossBankPayment) GetTransactionId() string {
@@ -377,7 +1260,76 @@ var File_trading_v1_cross_bank_payments_proto protoreflect.FileDescriptor
 
 const file_trading_v1_cross_bank_payments_proto_rawDesc = "" +
 	"\n" +
-	"$trading/v1/cross_bank_payments.proto\x12\x10banka.trading.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18trading/v1/trading.proto\"\xf7\x02\n" +
+	"$trading/v1/cross_bank_payments.proto\x12\x10banka.trading.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18trading/v1/trading.proto\"\x1d\n" +
+	"\x1bListInterbankRetriesRequest\"_\n" +
+	"\x1cListInterbankRetriesResponse\x12?\n" +
+	"\aentries\x18\x01 \x03(\v2%.banka.trading.v1.InterbankRetryEntryR\aentries\"\xe5\x03\n" +
+	"\x13InterbankRetryEntry\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12%\n" +
+	"\x0etransaction_id\x18\x02 \x01(\tR\rtransactionId\x12*\n" +
+	"\x11partner_bank_code\x18\x03 \x01(\tR\x0fpartnerBankCode\x12\x1c\n" +
+	"\toperation\x18\x04 \x01(\tR\toperation\x12#\n" +
+	"\rattempt_count\x18\x05 \x01(\x05R\fattemptCount\x12>\n" +
+	"\rnext_retry_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\vnextRetryAt\x12;\n" +
+	"\vdeadline_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"deadlineAt\x12\x16\n" +
+	"\x06status\x18\b \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\t \x01(\tR\tlastError\x129\n" +
+	"\n" +
+	"created_at\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\x1e\n" +
+	"\x1cRunInterbankRetryTickRequest\"9\n" +
+	"\x1dRunInterbankRetryTickResponse\x12\x18\n" +
+	"\asettled\x18\x01 \x01(\x05R\asettled\"\x8b\x05\n" +
+	"\x19ScheduledInterbankPayment\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
+	"\auser_id\x18\x02 \x01(\tR\x06userId\x12*\n" +
+	"\x11source_account_id\x18\x03 \x01(\tR\x0fsourceAccountId\x12$\n" +
+	"\x0edest_bank_code\x18\x04 \x01(\tR\fdestBankCode\x12.\n" +
+	"\x13dest_account_number\x18\x05 \x01(\tR\x11destAccountNumber\x126\n" +
+	"\bcurrency\x18\x06 \x01(\x0e2\x1a.banka.trading.v1.CurrencyR\bcurrency\x12\x16\n" +
+	"\x06amount\x18\a \x01(\tR\x06amount\x12\x18\n" +
+	"\apurpose\x18\b \x01(\tR\apurpose\x12\x18\n" +
+	"\acadence\x18\t \x01(\tR\acadence\x125\n" +
+	"\bnext_run\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\anextRun\x12\x16\n" +
+	"\x06active\x18\v \x01(\bR\x06active\x12\x1f\n" +
+	"\vlast_status\x18\f \x01(\tR\n" +
+	"lastStatus\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\r \x01(\tR\tlastError\x12:\n" +
+	"\vlast_run_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\tlastRunAt\x129\n" +
+	"\n" +
+	"created_at\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\x88\x03\n" +
+	"&CreateScheduledInterbankPaymentRequest\x124\n" +
+	"\x11source_account_id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x0fsourceAccountId\x12-\n" +
+	"\x0edest_bank_code\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\fdestBankCode\x128\n" +
+	"\x13dest_account_number\x18\x03 \x01(\tB\b\xbaH\x05r\x03\x98\x01\x12R\x11destAccountNumber\x12B\n" +
+	"\bcurrency\x18\x04 \x01(\x0e2\x1a.banka.trading.v1.CurrencyB\n" +
+	"\xbaH\a\x82\x01\x04\x10\x01 \x00R\bcurrency\x12\x1f\n" +
+	"\x06amount\x18\x05 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06amount\x12\x18\n" +
+	"\apurpose\x18\x06 \x01(\tR\apurpose\x12!\n" +
+	"\acadence\x18\a \x01(\tB\a\xbaH\x04r\x02\x10\x01R\acadence\x12\x1d\n" +
+	"\n" +
+	"start_date\x18\b \x01(\tR\tstartDate\"'\n" +
+	"%ListScheduledInterbankPaymentsRequest\"\x84\x01\n" +
+	"&ListScheduledInterbankPaymentsResponse\x12Z\n" +
+	"\x12scheduled_payments\x18\x01 \x03(\v2+.banka.trading.v1.ScheduledInterbankPaymentR\x11scheduledPayments\"A\n" +
+	"%PauseScheduledInterbankPaymentRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\"B\n" +
+	"&ResumeScheduledInterbankPaymentRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\"B\n" +
+	"&CancelScheduledInterbankPaymentRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\")\n" +
+	"'CancelScheduledInterbankPaymentResponse\" \n" +
+	"\x1eRunDueInterbankPaymentsRequest\"?\n" +
+	"\x1fRunDueInterbankPaymentsResponse\x12\x1c\n" +
+	"\tsubmitted\x18\x01 \x01(\x05R\tsubmitted\"\xf7\x02\n" +
 	"\x1dSubmitCrossBankPaymentRequest\x120\n" +
 	"\x0fidempotency_key\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x0eidempotencyKey\x124\n" +
 	"\x11source_account_id\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x0fsourceAccountId\x121\n" +
@@ -411,10 +1363,18 @@ const file_trading_v1_cross_bank_payments_proto_rawDesc = "" +
 	"\x15remote_account_number\x18\x17 \x01(\tR\x13remoteAccountNumber\x126\n" +
 	"\bcurrency\x18\x18 \x01(\x0e2\x1a.banka.trading.v1.CurrencyR\bcurrency\x12\x16\n" +
 	"\x06amount\x18\x19 \x01(\tR\x06amount\x12\x18\n" +
-	"\apurpose\x18\x1a \x01(\tR\apurpose2\xdd\x02\n" +
+	"\apurpose\x18\x1a \x01(\tR\apurpose2\xd9\r\n" +
 	"\x17CrossBankPaymentService\x12\xa2\x01\n" +
 	"\x16SubmitCrossBankPayment\x12/.banka.trading.v1.SubmitCrossBankPaymentRequest\x1a0.banka.trading.v1.SubmitCrossBankPaymentResponse\"%\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/api/v1/payments/interbank\x12\x9c\x01\n" +
-	"\x13GetCrossBankPayment\x12,.banka.trading.v1.GetCrossBankPaymentRequest\x1a\".banka.trading.v1.CrossBankPayment\"3\x82\xd3\xe4\x93\x02-\x12+/api/v1/payments/interbank/{transaction_id}B\xd7\x01\n" +
+	"\x13GetCrossBankPayment\x12,.banka.trading.v1.GetCrossBankPaymentRequest\x1a\".banka.trading.v1.CrossBankPayment\"3\x82\xd3\xe4\x93\x02-\x12+/api/v1/payments/interbank/{transaction_id}\x12\xa1\x01\n" +
+	"\x14ListInterbankRetries\x12-.banka.trading.v1.ListInterbankRetriesRequest\x1a..banka.trading.v1.ListInterbankRetriesResponse\"*\x82\xd3\xe4\x93\x02$\x12\"/api/v1/payments/interbank/retries\x12x\n" +
+	"\x15RunInterbankRetryTick\x12..banka.trading.v1.RunInterbankRetryTickRequest\x1a/.banka.trading.v1.RunInterbankRetryTickResponse\x12\xba\x01\n" +
+	"\x1fCreateScheduledInterbankPayment\x128.banka.trading.v1.CreateScheduledInterbankPaymentRequest\x1a+.banka.trading.v1.ScheduledInterbankPayment\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/api/v1/cross-bank-payments/scheduled\x12\xc2\x01\n" +
+	"\x1eListScheduledInterbankPayments\x127.banka.trading.v1.ListScheduledInterbankPaymentsRequest\x1a8.banka.trading.v1.ListScheduledInterbankPaymentsResponse\"-\x82\xd3\xe4\x93\x02'\x12%/api/v1/cross-bank-payments/scheduled\x12\xc3\x01\n" +
+	"\x1ePauseScheduledInterbankPayment\x127.banka.trading.v1.PauseScheduledInterbankPaymentRequest\x1a+.banka.trading.v1.ScheduledInterbankPayment\";\x82\xd3\xe4\x93\x025:\x01*\"0/api/v1/cross-bank-payments/scheduled/{id}/pause\x12\xc6\x01\n" +
+	"\x1fResumeScheduledInterbankPayment\x128.banka.trading.v1.ResumeScheduledInterbankPaymentRequest\x1a+.banka.trading.v1.ScheduledInterbankPayment\"<\x82\xd3\xe4\x93\x026:\x01*\"1/api/v1/cross-bank-payments/scheduled/{id}/resume\x12\xca\x01\n" +
+	"\x1fCancelScheduledInterbankPayment\x128.banka.trading.v1.CancelScheduledInterbankPaymentRequest\x1a9.banka.trading.v1.CancelScheduledInterbankPaymentResponse\"2\x82\xd3\xe4\x93\x02,**/api/v1/cross-bank-payments/scheduled/{id}\x12~\n" +
+	"\x17RunDueInterbankPayments\x120.banka.trading.v1.RunDueInterbankPaymentsRequest\x1a1.banka.trading.v1.RunDueInterbankPaymentsResponseB\xd7\x01\n" +
 	"\x14com.banka.trading.v1B\x16CrossBankPaymentsProtoP\x01ZEgithub.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1;tradingv1\xa2\x02\x03BTX\xaa\x02\x10Banka.Trading.V1\xca\x02\x10Banka\\Trading\\V1\xe2\x02\x1cBanka\\Trading\\V1\\GPBMetadata\xea\x02\x12Banka::Trading::V1b\x06proto3"
 
 var (
@@ -429,29 +1389,72 @@ func file_trading_v1_cross_bank_payments_proto_rawDescGZIP() []byte {
 	return file_trading_v1_cross_bank_payments_proto_rawDescData
 }
 
-var file_trading_v1_cross_bank_payments_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_trading_v1_cross_bank_payments_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_trading_v1_cross_bank_payments_proto_goTypes = []any{
-	(*SubmitCrossBankPaymentRequest)(nil),  // 0: banka.trading.v1.SubmitCrossBankPaymentRequest
-	(*SubmitCrossBankPaymentResponse)(nil), // 1: banka.trading.v1.SubmitCrossBankPaymentResponse
-	(*GetCrossBankPaymentRequest)(nil),     // 2: banka.trading.v1.GetCrossBankPaymentRequest
-	(*CrossBankPayment)(nil),               // 3: banka.trading.v1.CrossBankPayment
-	(Currency)(0),                          // 4: banka.trading.v1.Currency
-	(*timestamppb.Timestamp)(nil),          // 5: google.protobuf.Timestamp
+	(*ListInterbankRetriesRequest)(nil),             // 0: banka.trading.v1.ListInterbankRetriesRequest
+	(*ListInterbankRetriesResponse)(nil),            // 1: banka.trading.v1.ListInterbankRetriesResponse
+	(*InterbankRetryEntry)(nil),                     // 2: banka.trading.v1.InterbankRetryEntry
+	(*RunInterbankRetryTickRequest)(nil),            // 3: banka.trading.v1.RunInterbankRetryTickRequest
+	(*RunInterbankRetryTickResponse)(nil),           // 4: banka.trading.v1.RunInterbankRetryTickResponse
+	(*ScheduledInterbankPayment)(nil),               // 5: banka.trading.v1.ScheduledInterbankPayment
+	(*CreateScheduledInterbankPaymentRequest)(nil),  // 6: banka.trading.v1.CreateScheduledInterbankPaymentRequest
+	(*ListScheduledInterbankPaymentsRequest)(nil),   // 7: banka.trading.v1.ListScheduledInterbankPaymentsRequest
+	(*ListScheduledInterbankPaymentsResponse)(nil),  // 8: banka.trading.v1.ListScheduledInterbankPaymentsResponse
+	(*PauseScheduledInterbankPaymentRequest)(nil),   // 9: banka.trading.v1.PauseScheduledInterbankPaymentRequest
+	(*ResumeScheduledInterbankPaymentRequest)(nil),  // 10: banka.trading.v1.ResumeScheduledInterbankPaymentRequest
+	(*CancelScheduledInterbankPaymentRequest)(nil),  // 11: banka.trading.v1.CancelScheduledInterbankPaymentRequest
+	(*CancelScheduledInterbankPaymentResponse)(nil), // 12: banka.trading.v1.CancelScheduledInterbankPaymentResponse
+	(*RunDueInterbankPaymentsRequest)(nil),          // 13: banka.trading.v1.RunDueInterbankPaymentsRequest
+	(*RunDueInterbankPaymentsResponse)(nil),         // 14: banka.trading.v1.RunDueInterbankPaymentsResponse
+	(*SubmitCrossBankPaymentRequest)(nil),           // 15: banka.trading.v1.SubmitCrossBankPaymentRequest
+	(*SubmitCrossBankPaymentResponse)(nil),          // 16: banka.trading.v1.SubmitCrossBankPaymentResponse
+	(*GetCrossBankPaymentRequest)(nil),              // 17: banka.trading.v1.GetCrossBankPaymentRequest
+	(*CrossBankPayment)(nil),                        // 18: banka.trading.v1.CrossBankPayment
+	(*timestamppb.Timestamp)(nil),                   // 19: google.protobuf.Timestamp
+	(Currency)(0),                                   // 20: banka.trading.v1.Currency
 }
 var file_trading_v1_cross_bank_payments_proto_depIdxs = []int32{
-	4, // 0: banka.trading.v1.SubmitCrossBankPaymentRequest.currency:type_name -> banka.trading.v1.Currency
-	5, // 1: banka.trading.v1.CrossBankPayment.created_at:type_name -> google.protobuf.Timestamp
-	5, // 2: banka.trading.v1.CrossBankPayment.updated_at:type_name -> google.protobuf.Timestamp
-	4, // 3: banka.trading.v1.CrossBankPayment.currency:type_name -> banka.trading.v1.Currency
-	0, // 4: banka.trading.v1.CrossBankPaymentService.SubmitCrossBankPayment:input_type -> banka.trading.v1.SubmitCrossBankPaymentRequest
-	2, // 5: banka.trading.v1.CrossBankPaymentService.GetCrossBankPayment:input_type -> banka.trading.v1.GetCrossBankPaymentRequest
-	1, // 6: banka.trading.v1.CrossBankPaymentService.SubmitCrossBankPayment:output_type -> banka.trading.v1.SubmitCrossBankPaymentResponse
-	3, // 7: banka.trading.v1.CrossBankPaymentService.GetCrossBankPayment:output_type -> banka.trading.v1.CrossBankPayment
-	6, // [6:8] is the sub-list for method output_type
-	4, // [4:6] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	2,  // 0: banka.trading.v1.ListInterbankRetriesResponse.entries:type_name -> banka.trading.v1.InterbankRetryEntry
+	19, // 1: banka.trading.v1.InterbankRetryEntry.next_retry_at:type_name -> google.protobuf.Timestamp
+	19, // 2: banka.trading.v1.InterbankRetryEntry.deadline_at:type_name -> google.protobuf.Timestamp
+	19, // 3: banka.trading.v1.InterbankRetryEntry.created_at:type_name -> google.protobuf.Timestamp
+	19, // 4: banka.trading.v1.InterbankRetryEntry.updated_at:type_name -> google.protobuf.Timestamp
+	20, // 5: banka.trading.v1.ScheduledInterbankPayment.currency:type_name -> banka.trading.v1.Currency
+	19, // 6: banka.trading.v1.ScheduledInterbankPayment.next_run:type_name -> google.protobuf.Timestamp
+	19, // 7: banka.trading.v1.ScheduledInterbankPayment.last_run_at:type_name -> google.protobuf.Timestamp
+	19, // 8: banka.trading.v1.ScheduledInterbankPayment.created_at:type_name -> google.protobuf.Timestamp
+	19, // 9: banka.trading.v1.ScheduledInterbankPayment.updated_at:type_name -> google.protobuf.Timestamp
+	20, // 10: banka.trading.v1.CreateScheduledInterbankPaymentRequest.currency:type_name -> banka.trading.v1.Currency
+	5,  // 11: banka.trading.v1.ListScheduledInterbankPaymentsResponse.scheduled_payments:type_name -> banka.trading.v1.ScheduledInterbankPayment
+	20, // 12: banka.trading.v1.SubmitCrossBankPaymentRequest.currency:type_name -> banka.trading.v1.Currency
+	19, // 13: banka.trading.v1.CrossBankPayment.created_at:type_name -> google.protobuf.Timestamp
+	19, // 14: banka.trading.v1.CrossBankPayment.updated_at:type_name -> google.protobuf.Timestamp
+	20, // 15: banka.trading.v1.CrossBankPayment.currency:type_name -> banka.trading.v1.Currency
+	15, // 16: banka.trading.v1.CrossBankPaymentService.SubmitCrossBankPayment:input_type -> banka.trading.v1.SubmitCrossBankPaymentRequest
+	17, // 17: banka.trading.v1.CrossBankPaymentService.GetCrossBankPayment:input_type -> banka.trading.v1.GetCrossBankPaymentRequest
+	0,  // 18: banka.trading.v1.CrossBankPaymentService.ListInterbankRetries:input_type -> banka.trading.v1.ListInterbankRetriesRequest
+	3,  // 19: banka.trading.v1.CrossBankPaymentService.RunInterbankRetryTick:input_type -> banka.trading.v1.RunInterbankRetryTickRequest
+	6,  // 20: banka.trading.v1.CrossBankPaymentService.CreateScheduledInterbankPayment:input_type -> banka.trading.v1.CreateScheduledInterbankPaymentRequest
+	7,  // 21: banka.trading.v1.CrossBankPaymentService.ListScheduledInterbankPayments:input_type -> banka.trading.v1.ListScheduledInterbankPaymentsRequest
+	9,  // 22: banka.trading.v1.CrossBankPaymentService.PauseScheduledInterbankPayment:input_type -> banka.trading.v1.PauseScheduledInterbankPaymentRequest
+	10, // 23: banka.trading.v1.CrossBankPaymentService.ResumeScheduledInterbankPayment:input_type -> banka.trading.v1.ResumeScheduledInterbankPaymentRequest
+	11, // 24: banka.trading.v1.CrossBankPaymentService.CancelScheduledInterbankPayment:input_type -> banka.trading.v1.CancelScheduledInterbankPaymentRequest
+	13, // 25: banka.trading.v1.CrossBankPaymentService.RunDueInterbankPayments:input_type -> banka.trading.v1.RunDueInterbankPaymentsRequest
+	16, // 26: banka.trading.v1.CrossBankPaymentService.SubmitCrossBankPayment:output_type -> banka.trading.v1.SubmitCrossBankPaymentResponse
+	18, // 27: banka.trading.v1.CrossBankPaymentService.GetCrossBankPayment:output_type -> banka.trading.v1.CrossBankPayment
+	1,  // 28: banka.trading.v1.CrossBankPaymentService.ListInterbankRetries:output_type -> banka.trading.v1.ListInterbankRetriesResponse
+	4,  // 29: banka.trading.v1.CrossBankPaymentService.RunInterbankRetryTick:output_type -> banka.trading.v1.RunInterbankRetryTickResponse
+	5,  // 30: banka.trading.v1.CrossBankPaymentService.CreateScheduledInterbankPayment:output_type -> banka.trading.v1.ScheduledInterbankPayment
+	8,  // 31: banka.trading.v1.CrossBankPaymentService.ListScheduledInterbankPayments:output_type -> banka.trading.v1.ListScheduledInterbankPaymentsResponse
+	5,  // 32: banka.trading.v1.CrossBankPaymentService.PauseScheduledInterbankPayment:output_type -> banka.trading.v1.ScheduledInterbankPayment
+	5,  // 33: banka.trading.v1.CrossBankPaymentService.ResumeScheduledInterbankPayment:output_type -> banka.trading.v1.ScheduledInterbankPayment
+	12, // 34: banka.trading.v1.CrossBankPaymentService.CancelScheduledInterbankPayment:output_type -> banka.trading.v1.CancelScheduledInterbankPaymentResponse
+	14, // 35: banka.trading.v1.CrossBankPaymentService.RunDueInterbankPayments:output_type -> banka.trading.v1.RunDueInterbankPaymentsResponse
+	26, // [26:36] is the sub-list for method output_type
+	16, // [16:26] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_trading_v1_cross_bank_payments_proto_init() }
@@ -466,7 +1469,7 @@ func file_trading_v1_cross_bank_payments_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_trading_v1_cross_bank_payments_proto_rawDesc), len(file_trading_v1_cross_bank_payments_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/trading/v1/cross_bank_payments.pb.gw.go
+++ b/gen/proto/trading/v1/cross_bank_payments.pb.gw.go
@@ -101,6 +101,204 @@ func local_request_CrossBankPaymentService_GetCrossBankPayment_0(ctx context.Con
 	return msg, metadata, err
 }
 
+func request_CrossBankPaymentService_ListInterbankRetries_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInterbankRetriesRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListInterbankRetries(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_ListInterbankRetries_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInterbankRetriesRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListInterbankRetries(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrossBankPaymentService_CreateScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateScheduledInterbankPayment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_CreateScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateScheduledInterbankPayment(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrossBankPaymentService_ListScheduledInterbankPayments_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListScheduledInterbankPaymentsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListScheduledInterbankPayments(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_ListScheduledInterbankPayments_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListScheduledInterbankPaymentsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListScheduledInterbankPayments(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrossBankPaymentService_PauseScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PauseScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.PauseScheduledInterbankPayment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_PauseScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PauseScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.PauseScheduledInterbankPayment(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResumeScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.ResumeScheduledInterbankPayment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResumeScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.ResumeScheduledInterbankPayment(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrossBankPaymentService_CancelScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, client CrossBankPaymentServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.CancelScheduledInterbankPayment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrossBankPaymentService_CancelScheduledInterbankPayment_0(ctx context.Context, marshaler runtime.Marshaler, server CrossBankPaymentServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelScheduledInterbankPaymentRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.CancelScheduledInterbankPayment(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterCrossBankPaymentServiceHandlerServer registers the http handlers for service CrossBankPaymentService to "mux".
 // UnaryRPC     :call CrossBankPaymentServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -146,6 +344,126 @@ func RegisterCrossBankPaymentServiceHandlerServer(ctx context.Context, mux *runt
 			return
 		}
 		forward_CrossBankPaymentService_GetCrossBankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrossBankPaymentService_ListInterbankRetries_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ListInterbankRetries", runtime.WithHTTPPathPattern("/api/v1/payments/interbank/retries"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_ListInterbankRetries_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ListInterbankRetries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_CreateScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/CreateScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_CreateScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_CreateScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrossBankPaymentService_ListScheduledInterbankPayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ListScheduledInterbankPayments", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_ListScheduledInterbankPayments_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ListScheduledInterbankPayments_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_PauseScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/PauseScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}/pause"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_PauseScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_PauseScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_ResumeScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ResumeScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}/resume"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_CrossBankPaymentService_CancelScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/CancelScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrossBankPaymentService_CancelScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_CancelScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -221,15 +539,129 @@ func RegisterCrossBankPaymentServiceHandlerClient(ctx context.Context, mux *runt
 		}
 		forward_CrossBankPaymentService_GetCrossBankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_CrossBankPaymentService_ListInterbankRetries_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ListInterbankRetries", runtime.WithHTTPPathPattern("/api/v1/payments/interbank/retries"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_ListInterbankRetries_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ListInterbankRetries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_CreateScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/CreateScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_CreateScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_CreateScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrossBankPaymentService_ListScheduledInterbankPayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ListScheduledInterbankPayments", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_ListScheduledInterbankPayments_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ListScheduledInterbankPayments_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_PauseScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/PauseScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}/pause"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_PauseScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_PauseScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrossBankPaymentService_ResumeScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/ResumeScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}/resume"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_ResumeScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_CrossBankPaymentService_CancelScheduledInterbankPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.trading.v1.CrossBankPaymentService/CancelScheduledInterbankPayment", runtime.WithHTTPPathPattern("/api/v1/cross-bank-payments/scheduled/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrossBankPaymentService_CancelScheduledInterbankPayment_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrossBankPaymentService_CancelScheduledInterbankPayment_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_CrossBankPaymentService_SubmitCrossBankPayment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "payments", "interbank"}, ""))
-	pattern_CrossBankPaymentService_GetCrossBankPayment_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "v1", "payments", "interbank", "transaction_id"}, ""))
+	pattern_CrossBankPaymentService_SubmitCrossBankPayment_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "payments", "interbank"}, ""))
+	pattern_CrossBankPaymentService_GetCrossBankPayment_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "v1", "payments", "interbank", "transaction_id"}, ""))
+	pattern_CrossBankPaymentService_ListInterbankRetries_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"api", "v1", "payments", "interbank", "retries"}, ""))
+	pattern_CrossBankPaymentService_CreateScheduledInterbankPayment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "cross-bank-payments", "scheduled"}, ""))
+	pattern_CrossBankPaymentService_ListScheduledInterbankPayments_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "cross-bank-payments", "scheduled"}, ""))
+	pattern_CrossBankPaymentService_PauseScheduledInterbankPayment_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "cross-bank-payments", "scheduled", "id", "pause"}, ""))
+	pattern_CrossBankPaymentService_ResumeScheduledInterbankPayment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "cross-bank-payments", "scheduled", "id", "resume"}, ""))
+	pattern_CrossBankPaymentService_CancelScheduledInterbankPayment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "v1", "cross-bank-payments", "scheduled", "id"}, ""))
 )
 
 var (
-	forward_CrossBankPaymentService_SubmitCrossBankPayment_0 = runtime.ForwardResponseMessage
-	forward_CrossBankPaymentService_GetCrossBankPayment_0    = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_SubmitCrossBankPayment_0          = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_GetCrossBankPayment_0             = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_ListInterbankRetries_0            = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_CreateScheduledInterbankPayment_0 = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_ListScheduledInterbankPayments_0  = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_PauseScheduledInterbankPayment_0  = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_ResumeScheduledInterbankPayment_0 = runtime.ForwardResponseMessage
+	forward_CrossBankPaymentService_CancelScheduledInterbankPayment_0 = runtime.ForwardResponseMessage
 )

--- a/gen/proto/trading/v1/cross_bank_payments_grpc.pb.go
+++ b/gen/proto/trading/v1/cross_bank_payments_grpc.pb.go
@@ -19,8 +19,16 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	CrossBankPaymentService_SubmitCrossBankPayment_FullMethodName = "/banka.trading.v1.CrossBankPaymentService/SubmitCrossBankPayment"
-	CrossBankPaymentService_GetCrossBankPayment_FullMethodName    = "/banka.trading.v1.CrossBankPaymentService/GetCrossBankPayment"
+	CrossBankPaymentService_SubmitCrossBankPayment_FullMethodName          = "/banka.trading.v1.CrossBankPaymentService/SubmitCrossBankPayment"
+	CrossBankPaymentService_GetCrossBankPayment_FullMethodName             = "/banka.trading.v1.CrossBankPaymentService/GetCrossBankPayment"
+	CrossBankPaymentService_ListInterbankRetries_FullMethodName            = "/banka.trading.v1.CrossBankPaymentService/ListInterbankRetries"
+	CrossBankPaymentService_RunInterbankRetryTick_FullMethodName           = "/banka.trading.v1.CrossBankPaymentService/RunInterbankRetryTick"
+	CrossBankPaymentService_CreateScheduledInterbankPayment_FullMethodName = "/banka.trading.v1.CrossBankPaymentService/CreateScheduledInterbankPayment"
+	CrossBankPaymentService_ListScheduledInterbankPayments_FullMethodName  = "/banka.trading.v1.CrossBankPaymentService/ListScheduledInterbankPayments"
+	CrossBankPaymentService_PauseScheduledInterbankPayment_FullMethodName  = "/banka.trading.v1.CrossBankPaymentService/PauseScheduledInterbankPayment"
+	CrossBankPaymentService_ResumeScheduledInterbankPayment_FullMethodName = "/banka.trading.v1.CrossBankPaymentService/ResumeScheduledInterbankPayment"
+	CrossBankPaymentService_CancelScheduledInterbankPayment_FullMethodName = "/banka.trading.v1.CrossBankPaymentService/CancelScheduledInterbankPayment"
+	CrossBankPaymentService_RunDueInterbankPayments_FullMethodName         = "/banka.trading.v1.CrossBankPaymentService/RunDueInterbankPayments"
 )
 
 // CrossBankPaymentServiceClient is the client API for CrossBankPaymentService service.
@@ -52,6 +60,32 @@ type CrossBankPaymentServiceClient interface {
 	// GetCrossBankPayment fetches a saga row by transaction_id.
 	// Auth: only the originator (or admin) sees their payment.
 	GetCrossBankPayment(ctx context.Context, in *GetCrossBankPaymentRequest, opts ...grpc.CallOption) (*CrossBankPayment, error)
+	// ListInterbankRetries returns the caller's own retry-queue entries.
+	// When a partner bank is unavailable the cross-bank payment is parked
+	// and retried every 5s; after 30s without success it fails and the
+	// client is notified. This surfaces those entries for transparency.
+	ListInterbankRetries(ctx context.Context, in *ListInterbankRetriesRequest, opts ...grpc.CallOption) (*ListInterbankRetriesResponse, error)
+	// RunInterbankRetryTick re-drives every due pending retry entry.
+	// Internal-only RPC driven by the scheduler's 5s `trading-interbank-retry`
+	// job (no http annotation).
+	RunInterbankRetryTick(ctx context.Context, in *RunInterbankRetryTickRequest, opts ...grpc.CallOption) (*RunInterbankRetryTickResponse, error)
+	// CreateScheduledInterbankPayment schedules a cross-bank payment to run
+	// once on a future date or to repeat on a cadence. Spec example:
+	// "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+	CreateScheduledInterbankPayment(ctx context.Context, in *CreateScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error)
+	// ListScheduledInterbankPayments returns the caller's own scheduled
+	// payments (active + paused).
+	ListScheduledInterbankPayments(ctx context.Context, in *ListScheduledInterbankPaymentsRequest, opts ...grpc.CallOption) (*ListScheduledInterbankPaymentsResponse, error)
+	// PauseScheduledInterbankPayment flips active=false so the sweep skips it.
+	PauseScheduledInterbankPayment(ctx context.Context, in *PauseScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error)
+	// ResumeScheduledInterbankPayment flips active=true so the sweep resumes it.
+	ResumeScheduledInterbankPayment(ctx context.Context, in *ResumeScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error)
+	// CancelScheduledInterbankPayment deletes a scheduled payment permanently.
+	CancelScheduledInterbankPayment(ctx context.Context, in *CancelScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*CancelScheduledInterbankPaymentResponse, error)
+	// RunDueInterbankPayments submits every due scheduled payment.
+	// Internal-only RPC driven by the scheduler's daily
+	// `trading-scheduled-interbank` job (no http annotation).
+	RunDueInterbankPayments(ctx context.Context, in *RunDueInterbankPaymentsRequest, opts ...grpc.CallOption) (*RunDueInterbankPaymentsResponse, error)
 }
 
 type crossBankPaymentServiceClient struct {
@@ -76,6 +110,86 @@ func (c *crossBankPaymentServiceClient) GetCrossBankPayment(ctx context.Context,
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CrossBankPayment)
 	err := c.cc.Invoke(ctx, CrossBankPaymentService_GetCrossBankPayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) ListInterbankRetries(ctx context.Context, in *ListInterbankRetriesRequest, opts ...grpc.CallOption) (*ListInterbankRetriesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListInterbankRetriesResponse)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_ListInterbankRetries_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) RunInterbankRetryTick(ctx context.Context, in *RunInterbankRetryTickRequest, opts ...grpc.CallOption) (*RunInterbankRetryTickResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunInterbankRetryTickResponse)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_RunInterbankRetryTick_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) CreateScheduledInterbankPayment(ctx context.Context, in *CreateScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScheduledInterbankPayment)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_CreateScheduledInterbankPayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) ListScheduledInterbankPayments(ctx context.Context, in *ListScheduledInterbankPaymentsRequest, opts ...grpc.CallOption) (*ListScheduledInterbankPaymentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListScheduledInterbankPaymentsResponse)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_ListScheduledInterbankPayments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) PauseScheduledInterbankPayment(ctx context.Context, in *PauseScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScheduledInterbankPayment)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_PauseScheduledInterbankPayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) ResumeScheduledInterbankPayment(ctx context.Context, in *ResumeScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*ScheduledInterbankPayment, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScheduledInterbankPayment)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_ResumeScheduledInterbankPayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) CancelScheduledInterbankPayment(ctx context.Context, in *CancelScheduledInterbankPaymentRequest, opts ...grpc.CallOption) (*CancelScheduledInterbankPaymentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CancelScheduledInterbankPaymentResponse)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_CancelScheduledInterbankPayment_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crossBankPaymentServiceClient) RunDueInterbankPayments(ctx context.Context, in *RunDueInterbankPaymentsRequest, opts ...grpc.CallOption) (*RunDueInterbankPaymentsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunDueInterbankPaymentsResponse)
+	err := c.cc.Invoke(ctx, CrossBankPaymentService_RunDueInterbankPayments_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +225,32 @@ type CrossBankPaymentServiceServer interface {
 	// GetCrossBankPayment fetches a saga row by transaction_id.
 	// Auth: only the originator (or admin) sees their payment.
 	GetCrossBankPayment(context.Context, *GetCrossBankPaymentRequest) (*CrossBankPayment, error)
+	// ListInterbankRetries returns the caller's own retry-queue entries.
+	// When a partner bank is unavailable the cross-bank payment is parked
+	// and retried every 5s; after 30s without success it fails and the
+	// client is notified. This surfaces those entries for transparency.
+	ListInterbankRetries(context.Context, *ListInterbankRetriesRequest) (*ListInterbankRetriesResponse, error)
+	// RunInterbankRetryTick re-drives every due pending retry entry.
+	// Internal-only RPC driven by the scheduler's 5s `trading-interbank-retry`
+	// job (no http annotation).
+	RunInterbankRetryTick(context.Context, *RunInterbankRetryTickRequest) (*RunInterbankRetryTickResponse, error)
+	// CreateScheduledInterbankPayment schedules a cross-bank payment to run
+	// once on a future date or to repeat on a cadence. Spec example:
+	// "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+	CreateScheduledInterbankPayment(context.Context, *CreateScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error)
+	// ListScheduledInterbankPayments returns the caller's own scheduled
+	// payments (active + paused).
+	ListScheduledInterbankPayments(context.Context, *ListScheduledInterbankPaymentsRequest) (*ListScheduledInterbankPaymentsResponse, error)
+	// PauseScheduledInterbankPayment flips active=false so the sweep skips it.
+	PauseScheduledInterbankPayment(context.Context, *PauseScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error)
+	// ResumeScheduledInterbankPayment flips active=true so the sweep resumes it.
+	ResumeScheduledInterbankPayment(context.Context, *ResumeScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error)
+	// CancelScheduledInterbankPayment deletes a scheduled payment permanently.
+	CancelScheduledInterbankPayment(context.Context, *CancelScheduledInterbankPaymentRequest) (*CancelScheduledInterbankPaymentResponse, error)
+	// RunDueInterbankPayments submits every due scheduled payment.
+	// Internal-only RPC driven by the scheduler's daily
+	// `trading-scheduled-interbank` job (no http annotation).
+	RunDueInterbankPayments(context.Context, *RunDueInterbankPaymentsRequest) (*RunDueInterbankPaymentsResponse, error)
 }
 
 // UnimplementedCrossBankPaymentServiceServer should be embedded to have
@@ -125,6 +265,30 @@ func (UnimplementedCrossBankPaymentServiceServer) SubmitCrossBankPayment(context
 }
 func (UnimplementedCrossBankPaymentServiceServer) GetCrossBankPayment(context.Context, *GetCrossBankPaymentRequest) (*CrossBankPayment, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCrossBankPayment not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) ListInterbankRetries(context.Context, *ListInterbankRetriesRequest) (*ListInterbankRetriesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListInterbankRetries not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) RunInterbankRetryTick(context.Context, *RunInterbankRetryTickRequest) (*RunInterbankRetryTickResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunInterbankRetryTick not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) CreateScheduledInterbankPayment(context.Context, *CreateScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateScheduledInterbankPayment not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) ListScheduledInterbankPayments(context.Context, *ListScheduledInterbankPaymentsRequest) (*ListScheduledInterbankPaymentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListScheduledInterbankPayments not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) PauseScheduledInterbankPayment(context.Context, *PauseScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error) {
+	return nil, status.Error(codes.Unimplemented, "method PauseScheduledInterbankPayment not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) ResumeScheduledInterbankPayment(context.Context, *ResumeScheduledInterbankPaymentRequest) (*ScheduledInterbankPayment, error) {
+	return nil, status.Error(codes.Unimplemented, "method ResumeScheduledInterbankPayment not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) CancelScheduledInterbankPayment(context.Context, *CancelScheduledInterbankPaymentRequest) (*CancelScheduledInterbankPaymentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelScheduledInterbankPayment not implemented")
+}
+func (UnimplementedCrossBankPaymentServiceServer) RunDueInterbankPayments(context.Context, *RunDueInterbankPaymentsRequest) (*RunDueInterbankPaymentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunDueInterbankPayments not implemented")
 }
 func (UnimplementedCrossBankPaymentServiceServer) testEmbeddedByValue() {}
 
@@ -182,6 +346,150 @@ func _CrossBankPaymentService_GetCrossBankPayment_Handler(srv interface{}, ctx c
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CrossBankPaymentService_ListInterbankRetries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListInterbankRetriesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).ListInterbankRetries(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_ListInterbankRetries_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).ListInterbankRetries(ctx, req.(*ListInterbankRetriesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_RunInterbankRetryTick_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunInterbankRetryTickRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).RunInterbankRetryTick(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_RunInterbankRetryTick_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).RunInterbankRetryTick(ctx, req.(*RunInterbankRetryTickRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_CreateScheduledInterbankPayment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateScheduledInterbankPaymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).CreateScheduledInterbankPayment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_CreateScheduledInterbankPayment_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).CreateScheduledInterbankPayment(ctx, req.(*CreateScheduledInterbankPaymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_ListScheduledInterbankPayments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListScheduledInterbankPaymentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).ListScheduledInterbankPayments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_ListScheduledInterbankPayments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).ListScheduledInterbankPayments(ctx, req.(*ListScheduledInterbankPaymentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_PauseScheduledInterbankPayment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PauseScheduledInterbankPaymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).PauseScheduledInterbankPayment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_PauseScheduledInterbankPayment_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).PauseScheduledInterbankPayment(ctx, req.(*PauseScheduledInterbankPaymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_ResumeScheduledInterbankPayment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResumeScheduledInterbankPaymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).ResumeScheduledInterbankPayment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_ResumeScheduledInterbankPayment_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).ResumeScheduledInterbankPayment(ctx, req.(*ResumeScheduledInterbankPaymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_CancelScheduledInterbankPayment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelScheduledInterbankPaymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).CancelScheduledInterbankPayment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_CancelScheduledInterbankPayment_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).CancelScheduledInterbankPayment(ctx, req.(*CancelScheduledInterbankPaymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrossBankPaymentService_RunDueInterbankPayments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunDueInterbankPaymentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrossBankPaymentServiceServer).RunDueInterbankPayments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrossBankPaymentService_RunDueInterbankPayments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrossBankPaymentServiceServer).RunDueInterbankPayments(ctx, req.(*RunDueInterbankPaymentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CrossBankPaymentService_ServiceDesc is the grpc.ServiceDesc for CrossBankPaymentService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -196,6 +504,38 @@ var CrossBankPaymentService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetCrossBankPayment",
 			Handler:    _CrossBankPaymentService_GetCrossBankPayment_Handler,
+		},
+		{
+			MethodName: "ListInterbankRetries",
+			Handler:    _CrossBankPaymentService_ListInterbankRetries_Handler,
+		},
+		{
+			MethodName: "RunInterbankRetryTick",
+			Handler:    _CrossBankPaymentService_RunInterbankRetryTick_Handler,
+		},
+		{
+			MethodName: "CreateScheduledInterbankPayment",
+			Handler:    _CrossBankPaymentService_CreateScheduledInterbankPayment_Handler,
+		},
+		{
+			MethodName: "ListScheduledInterbankPayments",
+			Handler:    _CrossBankPaymentService_ListScheduledInterbankPayments_Handler,
+		},
+		{
+			MethodName: "PauseScheduledInterbankPayment",
+			Handler:    _CrossBankPaymentService_PauseScheduledInterbankPayment_Handler,
+		},
+		{
+			MethodName: "ResumeScheduledInterbankPayment",
+			Handler:    _CrossBankPaymentService_ResumeScheduledInterbankPayment_Handler,
+		},
+		{
+			MethodName: "CancelScheduledInterbankPayment",
+			Handler:    _CrossBankPaymentService_CancelScheduledInterbankPayment_Handler,
+		},
+		{
+			MethodName: "RunDueInterbankPayments",
+			Handler:    _CrossBankPaymentService_RunDueInterbankPayments_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/trading/v1/cross_bank_payments.proto
+++ b/proto/trading/v1/cross_bank_payments.proto
@@ -40,6 +40,162 @@ service CrossBankPaymentService {
   rpc GetCrossBankPayment(GetCrossBankPaymentRequest) returns (CrossBankPayment) {
     option (google.api.http) = {get: "/api/v1/payments/interbank/{transaction_id}"};
   }
+
+  // --- Retry queue (celina 5 — todoSpec "Retry queue") ---
+
+  // ListInterbankRetries returns the caller's own retry-queue entries.
+  // When a partner bank is unavailable the cross-bank payment is parked
+  // and retried every 5s; after 30s without success it fails and the
+  // client is notified. This surfaces those entries for transparency.
+  rpc ListInterbankRetries(ListInterbankRetriesRequest) returns (ListInterbankRetriesResponse) {
+    option (google.api.http) = {get: "/api/v1/payments/interbank/retries"};
+  }
+
+  // RunInterbankRetryTick re-drives every due pending retry entry.
+  // Internal-only RPC driven by the scheduler's 5s `trading-interbank-retry`
+  // job (no http annotation).
+  rpc RunInterbankRetryTick(RunInterbankRetryTickRequest) returns (RunInterbankRetryTickResponse);
+
+  // --- Scheduled / periodic inter-bank payments (celina 5 —
+  // todoSpec "Scheduled/periodic inter-bank payments") ---
+
+  // CreateScheduledInterbankPayment schedules a cross-bank payment to run
+  // once on a future date or to repeat on a cadence. Spec example:
+  // "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+  rpc CreateScheduledInterbankPayment(CreateScheduledInterbankPaymentRequest) returns (ScheduledInterbankPayment) {
+    option (google.api.http) = {
+      post: "/api/v1/cross-bank-payments/scheduled"
+      body: "*"
+    };
+  }
+
+  // ListScheduledInterbankPayments returns the caller's own scheduled
+  // payments (active + paused).
+  rpc ListScheduledInterbankPayments(ListScheduledInterbankPaymentsRequest) returns (ListScheduledInterbankPaymentsResponse) {
+    option (google.api.http) = {get: "/api/v1/cross-bank-payments/scheduled"};
+  }
+
+  // PauseScheduledInterbankPayment flips active=false so the sweep skips it.
+  rpc PauseScheduledInterbankPayment(PauseScheduledInterbankPaymentRequest) returns (ScheduledInterbankPayment) {
+    option (google.api.http) = {
+      post: "/api/v1/cross-bank-payments/scheduled/{id}/pause"
+      body: "*"
+    };
+  }
+
+  // ResumeScheduledInterbankPayment flips active=true so the sweep resumes it.
+  rpc ResumeScheduledInterbankPayment(ResumeScheduledInterbankPaymentRequest) returns (ScheduledInterbankPayment) {
+    option (google.api.http) = {
+      post: "/api/v1/cross-bank-payments/scheduled/{id}/resume"
+      body: "*"
+    };
+  }
+
+  // CancelScheduledInterbankPayment deletes a scheduled payment permanently.
+  rpc CancelScheduledInterbankPayment(CancelScheduledInterbankPaymentRequest) returns (CancelScheduledInterbankPaymentResponse) {
+    option (google.api.http) = {delete: "/api/v1/cross-bank-payments/scheduled/{id}"};
+  }
+
+  // RunDueInterbankPayments submits every due scheduled payment.
+  // Internal-only RPC driven by the scheduler's daily
+  // `trading-scheduled-interbank` job (no http annotation).
+  rpc RunDueInterbankPayments(RunDueInterbankPaymentsRequest) returns (RunDueInterbankPaymentsResponse);
+}
+
+// --- Retry queue messages ---
+
+message ListInterbankRetriesRequest {}
+
+message ListInterbankRetriesResponse {
+  repeated InterbankRetryEntry entries = 1;
+}
+
+message InterbankRetryEntry {
+  string id = 1;
+  string transaction_id = 2;
+  string partner_bank_code = 3;
+  string operation = 4;
+  int32 attempt_count = 5;
+  google.protobuf.Timestamp next_retry_at = 6;
+  google.protobuf.Timestamp deadline_at = 7;
+  string status = 8; // pending | succeeded | failed
+  string last_error = 9;
+  google.protobuf.Timestamp created_at = 10;
+  google.protobuf.Timestamp updated_at = 11;
+}
+
+message RunInterbankRetryTickRequest {}
+
+message RunInterbankRetryTickResponse {
+  // settled is the number of entries that reached a terminal state this
+  // tick (succeeded + failed).
+  int32 settled = 1;
+}
+
+// --- Scheduled inter-bank payment messages ---
+
+message ScheduledInterbankPayment {
+  string id = 1;
+  string user_id = 2;
+  string source_account_id = 3;
+  string dest_bank_code = 4;
+  string dest_account_number = 5;
+  Currency currency = 6;
+  string amount = 7;
+  string purpose = 8;
+  // cadence is one of ONCE / DAILY / WEEKLY / MONTHLY (pkg/schedule.Cadence).
+  string cadence = 9;
+  google.protobuf.Timestamp next_run = 10;
+  bool active = 11;
+  string last_status = 12; // most recent run's outcome (running|completed|failed)
+  string last_error = 13;
+  google.protobuf.Timestamp last_run_at = 14;
+  google.protobuf.Timestamp created_at = 15;
+  google.protobuf.Timestamp updated_at = 16;
+}
+
+message CreateScheduledInterbankPaymentRequest {
+  string source_account_id = 1 [(buf.validate.field).string.uuid = true];
+  string dest_bank_code = 2 [(buf.validate.field).string.min_len = 1];
+  string dest_account_number = 3 [(buf.validate.field).string.len = 18];
+  Currency currency = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+  string amount = 5 [(buf.validate.field).string.min_len = 1];
+  string purpose = 6;
+  // cadence is one of ONCE / DAILY / WEEKLY / MONTHLY.
+  string cadence = 7 [(buf.validate.field).string.min_len = 1];
+  // start_date (RFC3339) anchors the first run. Required for ONCE
+  // (validated to be in the future); optional for recurring cadences.
+  string start_date = 8;
+}
+
+message ListScheduledInterbankPaymentsRequest {}
+
+message ListScheduledInterbankPaymentsResponse {
+  repeated ScheduledInterbankPayment scheduled_payments = 1;
+}
+
+message PauseScheduledInterbankPaymentRequest {
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+message ResumeScheduledInterbankPaymentRequest {
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+message CancelScheduledInterbankPaymentRequest {
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+message CancelScheduledInterbankPaymentResponse {}
+
+message RunDueInterbankPaymentsRequest {}
+
+message RunDueInterbankPaymentsResponse {
+  // submitted is the number of payments successfully submitted this run.
+  int32 submitted = 1;
 }
 
 message SubmitCrossBankPaymentRequest {

--- a/services/scheduler/internal/app/app.go
+++ b/services/scheduler/internal/app/app.go
@@ -29,11 +29,14 @@ import (
 // App holds the scheduler's dependencies: the service clients it drives
 // and a fixed location for calendar jobs.
 type App struct {
-	log      *slog.Logger
-	loc      *time.Location
-	bank     bankpb.BankServiceClient
-	trading  tradingpb.TradingServiceClient
-	exchange exchangepb.ExchangeServiceClient
+	log     *slog.Logger
+	loc     *time.Location
+	bank    bankpb.BankServiceClient
+	trading tradingpb.TradingServiceClient
+	// crossBank drives celina-5 cross-bank payment jobs (retry queue +
+	// scheduled inter-bank payments). Shares the trading connection.
+	crossBank tradingpb.CrossBankPaymentServiceClient
+	exchange  exchangepb.ExchangeServiceClient
 }
 
 // Run blocks until the process is signalled to terminate.
@@ -80,6 +83,7 @@ func Run() error {
 	}
 	if c := dial("trading", config.String("TRADING_GRPC_ADDR", "")); c != nil {
 		a.trading = tradingpb.NewTradingServiceClient(c)
+		a.crossBank = tradingpb.NewCrossBankPaymentServiceClient(c)
 	}
 	if c := dial("exchange", config.String("EXCHANGE_GRPC_ADDR", "")); c != nil {
 		a.exchange = exchangepb.NewExchangeServiceClient(c)

--- a/services/scheduler/internal/app/jobs.go
+++ b/services/scheduler/internal/app/jobs.go
@@ -67,6 +67,15 @@ func (a *App) buildJobs() []job {
 			// Fired daily; RunDividendPayout no-ops unless the call lands
 			// on the last business day of the quarter (todoSpec C3 S54).
 			a.daily("trading-dividends", 23, 45, a.tradingDividends),
+			// Celina 5 — inter-bank retry queue: re-drive parked
+			// cross-bank payments every 5s (spec: retry every 5s, abort
+			// after 30s). fireNow so the worker picks up entries promptly
+			// on leader acquisition.
+			a.interval("trading-interbank-retry", config.Duration("INTERBANK_RETRY_TICK", 5*time.Second), true, a.tradingInterbankRetry),
+			// Celina 5 — scheduled/periodic inter-bank payments: submit
+			// every due scheduled cross-bank payment. Daily sweep (the
+			// finest cadence is DAILY).
+			a.daily("trading-scheduled-interbank", 0, 15, a.tradingScheduledInterbank),
 		)
 	}
 	if a.exchange != nil {
@@ -344,6 +353,28 @@ func (a *App) tradingDCA(ctx context.Context) error {
 	}
 	if r.GetCreated() > 0 {
 		a.log.Info("dca recurring orders ran", "created", r.GetCreated())
+	}
+	return nil
+}
+
+func (a *App) tradingInterbankRetry(ctx context.Context) error {
+	r, err := a.crossBank.RunInterbankRetryTick(ctx, &tradingpb.RunInterbankRetryTickRequest{})
+	if err != nil {
+		return err
+	}
+	if r.GetSettled() > 0 {
+		a.log.Info("interbank retry tick", "settled", r.GetSettled())
+	}
+	return nil
+}
+
+func (a *App) tradingScheduledInterbank(ctx context.Context) error {
+	r, err := a.crossBank.RunDueInterbankPayments(ctx, &tradingpb.RunDueInterbankPaymentsRequest{})
+	if err != nil {
+		return err
+	}
+	if r.GetSubmitted() > 0 {
+		a.log.Info("scheduled interbank payments ran", "submitted", r.GetSubmitted())
 	}
 	return nil
 }

--- a/services/trading/internal/domain/domain.go
+++ b/services/trading/internal/domain/domain.go
@@ -815,6 +815,65 @@ type RecurringOrder struct {
 	UpdatedAt time.Time
 }
 
+// InterbankRetryStatus is the lifecycle of one retry-queue entry.
+type InterbankRetryStatus string
+
+const (
+	// InterbankRetryPending — still being retried (or due for retry).
+	InterbankRetryPending InterbankRetryStatus = "pending"
+	// InterbankRetrySucceeded — the underlying saga completed.
+	InterbankRetrySucceeded InterbankRetryStatus = "succeeded"
+	// InterbankRetryFailed — the 30s deadline passed without success;
+	// the saga was rolled back and the client notified.
+	InterbankRetryFailed InterbankRetryStatus = "failed"
+)
+
+// InterbankRetryEntry is one parked cross-bank payment awaiting retry
+// (celina 5 — todoSpec "Retry queue"). When a partner bank is
+// unavailable the originating request enqueues one of these; a 5s worker
+// re-drives the underlying saga until it completes or the 30s deadline
+// elapses, at which point the entry fails and the client is notified.
+type InterbankRetryEntry struct {
+	ID              string
+	TransactionID   string
+	PartnerBankCode string
+	Operation       string
+	UserID          string
+	UserKind        UserKind
+	AttemptCount    int32
+	NextRetryAt     time.Time
+	DeadlineAt      time.Time
+	Status          InterbankRetryStatus
+	LastError       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// ScheduledInterbankPayment is a client-scheduled cross-bank cash
+// payment (celina 5 — todoSpec "Scheduled/periodic inter-bank
+// payments"). It runs once on a future date or repeats on a cadence;
+// each due run drives the existing SubmitCrossBankPayment path.
+// Spec example: "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+type ScheduledInterbankPayment struct {
+	ID                string
+	UserID            string
+	UserKind          UserKind
+	SourceAccountID   string
+	DestBankCode      string
+	DestAccountNumber string
+	Currency          Currency
+	Amount            string
+	Purpose           string
+	Cadence           string
+	NextRun           time.Time
+	Active            bool
+	LastStatus        string
+	LastError         string
+	LastRunAt         *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
 // Watchlist is a user-owned, named collection of securities the user
 // wants to keep an eye on (todoSpec C3 S35-S39). A user can have many
 // (S36). Items hang off the list and cascade-delete with it.

--- a/services/trading/internal/server/cross_bank_payments.go
+++ b/services/trading/internal/server/cross_bank_payments.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/schedule"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/service"
 
@@ -57,4 +58,152 @@ func (s *Server) GetCrossBankPayment(ctx context.Context, in *tradingpb.GetCross
 		Amount:              v.Amount,
 		Purpose:             v.Purpose,
 	}, nil
+}
+
+// --- Retry queue ---
+
+// ListInterbankRetries handles GET /api/v1/payments/interbank/retries.
+func (s *Server) ListInterbankRetries(ctx context.Context, _ *tradingpb.ListInterbankRetriesRequest) (*tradingpb.ListInterbankRetriesResponse, error) {
+	rows, err := s.Svc.ListInterbankRetries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := &tradingpb.ListInterbankRetriesResponse{Entries: make([]*tradingpb.InterbankRetryEntry, 0, len(rows))}
+	for _, r := range rows {
+		out.Entries = append(out.Entries, interbankRetryToProto(r))
+	}
+	return out, nil
+}
+
+// RunInterbankRetryTick re-drives every due retry entry. Internal-only
+// RPC driven by the scheduler service.
+func (s *Server) RunInterbankRetryTick(ctx context.Context, _ *tradingpb.RunInterbankRetryTickRequest) (*tradingpb.RunInterbankRetryTickResponse, error) {
+	if err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+	n, err := s.Svc.RunInterbankRetryTick(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &tradingpb.RunInterbankRetryTickResponse{Settled: int32(n)}, nil
+}
+
+func interbankRetryToProto(r *domain.InterbankRetryEntry) *tradingpb.InterbankRetryEntry {
+	if r == nil {
+		return nil
+	}
+	return &tradingpb.InterbankRetryEntry{
+		Id:              r.ID,
+		TransactionId:   r.TransactionID,
+		PartnerBankCode: r.PartnerBankCode,
+		Operation:       r.Operation,
+		AttemptCount:    r.AttemptCount,
+		NextRetryAt:     timestamppb.New(r.NextRetryAt),
+		DeadlineAt:      timestamppb.New(r.DeadlineAt),
+		Status:          string(r.Status),
+		LastError:       r.LastError,
+		CreatedAt:       timestamppb.New(r.CreatedAt),
+		UpdatedAt:       timestamppb.New(r.UpdatedAt),
+	}
+}
+
+// --- Scheduled / periodic inter-bank payments ---
+
+// CreateScheduledInterbankPayment handles POST /api/v1/cross-bank-payments/scheduled.
+func (s *Server) CreateScheduledInterbankPayment(ctx context.Context, in *tradingpb.CreateScheduledInterbankPaymentRequest) (*tradingpb.ScheduledInterbankPayment, error) {
+	p, err := s.Svc.CreateScheduledInterbankPayment(ctx, service.CreateScheduledInterbankPaymentInput{
+		SourceAccountID:   in.GetSourceAccountId(),
+		DestBankCode:      in.GetDestBankCode(),
+		DestAccountNumber: in.GetDestAccountNumber(),
+		Currency:          currencyFromProto(in.GetCurrency()),
+		Amount:            in.GetAmount(),
+		Purpose:           in.GetPurpose(),
+		Cadence:           schedule.Cadence(in.GetCadence()),
+		StartDate:         in.GetStartDate(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return scheduledInterbankToProto(p), nil
+}
+
+// ListScheduledInterbankPayments handles GET /api/v1/cross-bank-payments/scheduled.
+func (s *Server) ListScheduledInterbankPayments(ctx context.Context, _ *tradingpb.ListScheduledInterbankPaymentsRequest) (*tradingpb.ListScheduledInterbankPaymentsResponse, error) {
+	rows, err := s.Svc.ListScheduledInterbankPayments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := &tradingpb.ListScheduledInterbankPaymentsResponse{
+		ScheduledPayments: make([]*tradingpb.ScheduledInterbankPayment, 0, len(rows)),
+	}
+	for _, r := range rows {
+		out.ScheduledPayments = append(out.ScheduledPayments, scheduledInterbankToProto(r))
+	}
+	return out, nil
+}
+
+// PauseScheduledInterbankPayment handles POST .../scheduled/{id}/pause.
+func (s *Server) PauseScheduledInterbankPayment(ctx context.Context, in *tradingpb.PauseScheduledInterbankPaymentRequest) (*tradingpb.ScheduledInterbankPayment, error) {
+	p, err := s.Svc.PauseScheduledInterbankPayment(ctx, in.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return scheduledInterbankToProto(p), nil
+}
+
+// ResumeScheduledInterbankPayment handles POST .../scheduled/{id}/resume.
+func (s *Server) ResumeScheduledInterbankPayment(ctx context.Context, in *tradingpb.ResumeScheduledInterbankPaymentRequest) (*tradingpb.ScheduledInterbankPayment, error) {
+	p, err := s.Svc.ResumeScheduledInterbankPayment(ctx, in.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return scheduledInterbankToProto(p), nil
+}
+
+// CancelScheduledInterbankPayment handles DELETE .../scheduled/{id}.
+func (s *Server) CancelScheduledInterbankPayment(ctx context.Context, in *tradingpb.CancelScheduledInterbankPaymentRequest) (*tradingpb.CancelScheduledInterbankPaymentResponse, error) {
+	if err := s.Svc.CancelScheduledInterbankPayment(ctx, in.GetId()); err != nil {
+		return nil, err
+	}
+	return &tradingpb.CancelScheduledInterbankPaymentResponse{}, nil
+}
+
+// RunDueInterbankPayments submits every due scheduled payment.
+// Internal-only RPC driven by the scheduler service.
+func (s *Server) RunDueInterbankPayments(ctx context.Context, _ *tradingpb.RunDueInterbankPaymentsRequest) (*tradingpb.RunDueInterbankPaymentsResponse, error) {
+	if err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+	n, err := s.Svc.RunDueInterbankPayments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &tradingpb.RunDueInterbankPaymentsResponse{Submitted: int32(n)}, nil
+}
+
+func scheduledInterbankToProto(p *domain.ScheduledInterbankPayment) *tradingpb.ScheduledInterbankPayment {
+	if p == nil {
+		return nil
+	}
+	out := &tradingpb.ScheduledInterbankPayment{
+		Id:                p.ID,
+		UserId:            p.UserID,
+		SourceAccountId:   p.SourceAccountID,
+		DestBankCode:      p.DestBankCode,
+		DestAccountNumber: p.DestAccountNumber,
+		Currency:          currencyToProto(p.Currency),
+		Amount:            p.Amount,
+		Purpose:           p.Purpose,
+		Cadence:           p.Cadence,
+		NextRun:           timestamppb.New(p.NextRun),
+		Active:            p.Active,
+		LastStatus:        p.LastStatus,
+		LastError:         p.LastError,
+		CreatedAt:         timestamppb.New(p.CreatedAt),
+		UpdatedAt:         timestamppb.New(p.UpdatedAt),
+	}
+	if p.LastRunAt != nil {
+		out.LastRunAt = timestamppb.New(*p.LastRunAt)
+	}
+	return out
 }

--- a/services/trading/internal/service/cross_bank_payment.go
+++ b/services/trading/internal/service/cross_bank_payment.go
@@ -144,6 +144,16 @@ func (s *Service) SubmitCrossBankPayment(ctx context.Context, in SubmitCrossBank
 	if err != nil {
 		return nil, err
 	}
+	// Retry queue (todoSpec): a saga left parked (status=running) means a
+	// transient failure — typically the partner bank being unavailable at
+	// prepare_partner. Enqueue a retry entry so the 5s/30s worker drives
+	// it to completion (or aborts + notifies the client after 30s). The
+	// saga's own attempt budget would eventually fail the row but without
+	// releasing the local reservation, so the retry queue owns that
+	// give-up path. Idempotent on txID.
+	if row.Status == saga.StatusRunning {
+		s.enqueueInterbankRetry(ctx, txID, in.RemoteBankCode, p.UserID, domain.UserKind(p.UserKind))
+	}
 	return &SubmitCrossBankPaymentResult{
 		TransactionID: txID,
 		Status:        string(row.Status),

--- a/services/trading/internal/service/interbank_retry.go
+++ b/services/trading/internal/service/interbank_retry.go
@@ -1,0 +1,257 @@
+// Inter-bank retry queue (celina 5 — todoSpec "Retry queue").
+//
+// When a partner bank is unavailable mid cross-bank payment, the saga
+// parks (status=running, transient error) instead of failing. The
+// SubmitCrossBankPayment path then enqueues one retry entry here. A
+// worker re-drives the parked saga every 5s; after 30s without success
+// it aborts (rolls the saga back) and notifies the client the
+// transaction failed.
+//
+// Re-attempt mechanism: the entry references the saga transaction_id;
+// retrying just resumes the saga via the orchestrator (the saga steps
+// are idempotent, so a re-fire after the partner recovers is safe). We
+// read the post-resume saga status to decide the entry's fate:
+//   * completed              → succeeded
+//   * still running (parked) → reschedule +5s (unless past deadline)
+//   * compensated / failed   → failed (the saga itself gave up)
+//
+// The 5s/30s cadence is fixed by the spec; the worker interval (5s) is
+// the scheduler's, while the 30s deadline is anchored to the entry's
+// created_at so re-enqueues never extend the window.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/saga"
+)
+
+const (
+	// interbankRetryInterval is the spec's 5s re-attempt cadence.
+	interbankRetryInterval = 5 * time.Second
+	// interbankRetryDeadline is the spec's 30s give-up window.
+	interbankRetryDeadline = 30 * time.Second
+)
+
+// enqueueInterbankRetry records a parked cross-bank payment for retry.
+// Called from the SubmitCrossBankPayment path when the saga ends up
+// parked (partner unavailable). Best-effort: a queueing failure is
+// logged but never fails the originating request (the saga is already
+// persisted and the recovery worker is a backstop). Idempotent on the
+// saga transaction_id.
+func (s *Service) enqueueInterbankRetry(ctx context.Context, txID, partnerBankCode, userID string, userKind domain.UserKind) {
+	if s.Store == nil {
+		return
+	}
+	now := s.now()
+	_, err := s.Store.EnqueueInterbankRetry(ctx, &domain.InterbankRetryEntry{
+		TransactionID:   txID,
+		PartnerBankCode: partnerBankCode,
+		Operation:       crossBankPaymentSagaType,
+		UserID:          userID,
+		UserKind:        userKind,
+		NextRetryAt:     now.Add(interbankRetryInterval),
+		DeadlineAt:      now.Add(interbankRetryDeadline),
+	})
+	if err != nil {
+		s.Log.Warn("interbank retry: enqueue failed",
+			"transaction_id", txID, "err", err.Error())
+	}
+}
+
+// RunInterbankRetryTick re-drives every pending retry entry that is due.
+// Driven by the scheduler's `trading-interbank-retry` job (5s interval).
+// Returns the number of entries that reached a terminal state this tick
+// (succeeded + failed) for log visibility.
+//
+// Per entry:
+//   - resume the parked saga (idempotent re-fire)
+//   - if the saga completed → mark succeeded
+//   - if the saga is terminal-failed → mark failed + notify client
+//   - else if now > deadline_at → roll the saga back, mark failed + notify
+//   - else → reschedule next_retry_at = now + 5s
+func (s *Service) RunInterbankRetryTick(ctx context.Context) (int, error) {
+	if s.SagaOrch == nil || s.SagaStore == nil {
+		return 0, nil
+	}
+	now := s.now()
+	entries, err := s.Store.ListDueInterbankRetries(ctx, now)
+	if err != nil {
+		return 0, err
+	}
+	settled := 0
+	for _, e := range entries {
+		if s.processInterbankRetry(ctx, e, now) {
+			settled++
+		}
+	}
+	return settled, nil
+}
+
+// retryAction is the decision the retry state machine makes for one
+// entry after a saga re-fire: keep retrying, succeed, or give up.
+type retryAction int
+
+const (
+	// retryReschedule — saga still parked, deadline not reached: arm +5s.
+	retryReschedule retryAction = iota
+	// retrySucceed — saga completed.
+	retrySucceed
+	// retryExpire — saga terminal-failed OR the 30s deadline passed:
+	// abort (release the local reservation) + fail + notify.
+	retryExpire
+)
+
+// decideRetryAction is the pure 5s/30s state machine: given a saga
+// status (empty string = unreadable) and the entry's deadline relative
+// to `now`, it returns what the worker should do. Kept side-effect-free
+// so the retry semantics are unit-testable without a DB or live saga.
+func decideRetryAction(sagaStatus saga.Status, deadlineAt, now time.Time) retryAction {
+	switch sagaStatus {
+	case saga.StatusCompleted:
+		return retrySucceed
+	case saga.StatusFailed, saga.StatusCompensated:
+		// The saga itself gave up — give up too, regardless of deadline.
+		return retryExpire
+	default:
+		// Still running / parked / unreadable: keep retrying until the 30s
+		// window elapses, then abort.
+		if !now.Before(deadlineAt) {
+			return retryExpire
+		}
+		return retryReschedule
+	}
+}
+
+// processInterbankRetry handles one due entry. Returns true when the
+// entry reached a terminal state (succeeded/failed) this tick.
+func (s *Service) processInterbankRetry(ctx context.Context, e *domain.InterbankRetryEntry, now time.Time) bool {
+	// Re-fire the saga. Resume is idempotent and lock-guarded; a transient
+	// failure leaves the row at status=running (parked again).
+	if err := s.SagaOrch.Resume(ctx, e.TransactionID); err != nil {
+		s.Log.Debug("interbank retry: resume returned error (will re-check status)",
+			"transaction_id", e.TransactionID, "err", err.Error())
+	}
+
+	var (
+		sagaStatus saga.Status
+		reason     = "partnerska banka je nedostupna"
+	)
+	row, err := s.SagaStore.Get(ctx, e.TransactionID)
+	switch {
+	case err != nil:
+		reason = err.Error()
+	case row == nil:
+		reason = "saga nije pronađena"
+	default:
+		sagaStatus = row.Status
+		reason = saneError(row.LastError, reason)
+	}
+
+	switch decideRetryAction(sagaStatus, e.DeadlineAt, now) {
+	case retrySucceed:
+		if mErr := s.Store.MarkInterbankRetrySucceeded(ctx, e.ID); mErr != nil {
+			s.Log.Warn("interbank retry: mark succeeded failed",
+				"transaction_id", e.TransactionID, "err", mErr.Error())
+			return false
+		}
+		s.Log.Info("interbank retry: succeeded",
+			"transaction_id", e.TransactionID, "attempts", e.AttemptCount)
+		return true
+	case retryExpire:
+		// Past the 30s window (or the saga gave up). Release the local
+		// reservation (saga step prepare_local's compensation) so the
+		// user's funds are freed, then fail + notify. We release directly
+		// rather than through the orchestrator: a saga parked on
+		// prepare_partner that exhausts its own attempt budget transitions
+		// to StatusFailed WITHOUT running compensations, so the reservation
+		// would otherwise leak. RollbackPayment is idempotent.
+		s.releaseLocalReservation(ctx, e.TransactionID)
+		s.failInterbankRetry(ctx, e, reason)
+		return true
+	default: // retryReschedule
+		next := now.Add(interbankRetryInterval)
+		if rErr := s.Store.RescheduleInterbankRetry(ctx, e.ID, next, reason); rErr != nil {
+			s.Log.Warn("interbank retry: reschedule failed",
+				"transaction_id", e.TransactionID, "err", rErr.Error())
+		}
+		return false
+	}
+}
+
+// failInterbankRetry marks the entry failed and notifies the client the
+// cross-bank payment did not go through. Notification is best-effort.
+func (s *Service) failInterbankRetry(ctx context.Context, e *domain.InterbankRetryEntry, reason string) {
+	if mErr := s.Store.MarkInterbankRetryFailed(ctx, e.ID, reason); mErr != nil {
+		s.Log.Warn("interbank retry: mark failed failed",
+			"transaction_id", e.TransactionID, "err", mErr.Error())
+	}
+	s.Log.Warn("interbank retry: aborted after deadline",
+		"transaction_id", e.TransactionID, "reason", reason)
+	s.notifyInterbankFailure(ctx, e, reason)
+}
+
+// releaseLocalReservation rolls back the local prepare_local leg of a
+// parked cross-bank payment saga so the user's reserved funds are freed
+// when the retry queue gives up. Reads the saga payload for the sender
+// routing number; best-effort + idempotent (RollbackPayment 404s safely
+// when there was no reservation, e.g. the saga never got past validate).
+func (s *Service) releaseLocalReservation(ctx context.Context, txID string) {
+	if s.InterbankPayer == nil || s.SagaStore == nil {
+		return
+	}
+	row, err := s.SagaStore.Get(ctx, txID)
+	if err != nil || row == nil {
+		return
+	}
+	var payload crossBankPaymentPayload
+	if err := json.Unmarshal(row.State, &payload); err != nil {
+		s.Log.Warn("interbank retry: decode saga state for rollback failed",
+			"transaction_id", txID, "err", err.Error())
+		return
+	}
+	if rErr := s.InterbankPayer.RollbackPayment(ctx,
+		payload.SenderRoutingNumber, txID, "cross-bank payment retry deadline reached"); rErr != nil {
+		s.Log.Warn("interbank retry: local rollback failed",
+			"transaction_id", txID, "err", rErr.Error())
+	}
+}
+
+// notifyInterbankFailure tells the originator their cross-bank payment
+// failed (in-app; the trading service has no email resolver wired for
+// this path, same posture as the recurring-order skip notice). Never
+// returns an error.
+func (s *Service) notifyInterbankFailure(ctx context.Context, e *domain.InterbankRetryEntry, reason string) {
+	if s.Notifier == nil {
+		return
+	}
+	title := "Inostrana uplata nije uspela"
+	body := fmt.Sprintf("Plaćanje banci %s nije uspelo: %s.", e.PartnerBankCode, reason)
+	if err := s.Notifier.InApp(ctx, e.UserID, e.UserKind, "cross_bank_payment", title, body); err != nil {
+		s.Log.Warn("interbank retry: in-app notify failed",
+			"transaction_id", e.TransactionID, "err", err.Error())
+	}
+}
+
+// ListInterbankRetries returns the caller's own retry-queue entries,
+// newest first — surfaced on the FE for transparency.
+func (s *Service) ListInterbankRetries(ctx context.Context) ([]*domain.InterbankRetryEntry, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.Store.ListInterbankRetriesByUser(ctx, p.UserID)
+}
+
+// saneError returns msg when non-empty, otherwise fallback.
+func saneError(msg, fallback string) string {
+	if msg == "" {
+		return fallback
+	}
+	return msg
+}

--- a/services/trading/internal/service/interbank_retry_unit_test.go
+++ b/services/trading/internal/service/interbank_retry_unit_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/schedule"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/saga"
+)
+
+// TestRetryConstants pins the spec's 5s re-attempt cadence and 30s
+// give-up window so a refactor can't silently change the SLA.
+func TestRetryConstants(t *testing.T) {
+	if interbankRetryInterval != 5*time.Second {
+		t.Fatalf("retry interval = %v, want 5s", interbankRetryInterval)
+	}
+	if interbankRetryDeadline != 30*time.Second {
+		t.Fatalf("retry deadline = %v, want 30s", interbankRetryDeadline)
+	}
+}
+
+// TestDecideRetryAction exercises the 5s/30s retry state machine across
+// every saga status and deadline position.
+func TestDecideRetryAction(t *testing.T) {
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	// Entry created at base; deadline = base + 30s.
+	deadline := base.Add(interbankRetryDeadline)
+
+	cases := []struct {
+		name   string
+		status saga.Status
+		now    time.Time
+		want   retryAction
+	}{
+		{
+			name:   "completed → succeed",
+			status: saga.StatusCompleted,
+			now:    base.Add(5 * time.Second),
+			want:   retrySucceed,
+		},
+		{
+			name:   "completed after deadline still succeeds",
+			status: saga.StatusCompleted,
+			now:    base.Add(40 * time.Second),
+			want:   retrySucceed,
+		},
+		{
+			name:   "saga failed → expire (give up)",
+			status: saga.StatusFailed,
+			now:    base.Add(5 * time.Second),
+			want:   retryExpire,
+		},
+		{
+			name:   "saga compensated → expire",
+			status: saga.StatusCompensated,
+			now:    base.Add(5 * time.Second),
+			want:   retryExpire,
+		},
+		{
+			name:   "still running within window → reschedule",
+			status: saga.StatusRunning,
+			now:    base.Add(5 * time.Second),
+			want:   retryReschedule,
+		},
+		{
+			name:   "still running just before deadline → reschedule",
+			status: saga.StatusRunning,
+			now:    base.Add(29 * time.Second),
+			want:   retryReschedule,
+		},
+		{
+			name:   "still running exactly at deadline → expire",
+			status: saga.StatusRunning,
+			now:    deadline,
+			want:   retryExpire,
+		},
+		{
+			name:   "still running past deadline → expire",
+			status: saga.StatusRunning,
+			now:    base.Add(31 * time.Second),
+			want:   retryExpire,
+		},
+		{
+			name:   "unreadable saga (empty status) within window → reschedule",
+			status: saga.Status(""),
+			now:    base.Add(10 * time.Second),
+			want:   retryReschedule,
+		},
+		{
+			name:   "unreadable saga past deadline → expire",
+			status: saga.Status(""),
+			now:    base.Add(35 * time.Second),
+			want:   retryExpire,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideRetryAction(tc.status, deadline, tc.now); got != tc.want {
+				t.Fatalf("decideRetryAction(%q, deadline, now=+%v) = %v, want %v",
+					tc.status, tc.now.Sub(base), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRetryRescheduleAdvancesByInterval verifies that a rescheduled
+// entry's next_retry_at lands exactly one 5s interval ahead of now —
+// the cadence the worker re-arms with.
+func TestRetryRescheduleAdvancesByInterval(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	next := now.Add(interbankRetryInterval)
+	if got := next.Sub(now); got != 5*time.Second {
+		t.Fatalf("reschedule delta = %v, want 5s", got)
+	}
+}
+
+// TestScheduledInterbankCadenceAdvance pins the periodic-payment cadence
+// advance: ONCE deactivates without recurring, the recurring cadences
+// advance to the next future slot and stay active. This is the decision
+// RunDueInterbankPayments makes per row via schedule.AfterRun.
+func TestScheduledInterbankCadenceAdvance(t *testing.T) {
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	due := now // a row exactly due
+
+	t.Run("once deactivates", func(t *testing.T) {
+		next, deactivate := schedule.AfterRun(due, schedule.Once, now)
+		if !deactivate {
+			t.Fatal("ONCE must deactivate after running")
+		}
+		if !next.Equal(due) {
+			t.Fatalf("ONCE next_run should be unchanged, got %v", next)
+		}
+	})
+
+	recurring := []struct {
+		name    string
+		cadence schedule.Cadence
+		wantGap time.Duration
+	}{
+		{"daily", schedule.Daily, 24 * time.Hour},
+		{"weekly", schedule.Weekly, 7 * 24 * time.Hour},
+	}
+	for _, tc := range recurring {
+		t.Run(tc.name+" advances + stays active", func(t *testing.T) {
+			next, deactivate := schedule.AfterRun(due, tc.cadence, now)
+			if deactivate {
+				t.Fatalf("%s must stay active", tc.cadence)
+			}
+			if !next.After(now) {
+				t.Fatalf("%s next_run must be in the future, got %v", tc.cadence, next)
+			}
+			if got := next.Sub(due); got != tc.wantGap {
+				t.Fatalf("%s gap = %v, want %v", tc.cadence, got, tc.wantGap)
+			}
+		})
+	}
+
+	t.Run("monthly advances one calendar month", func(t *testing.T) {
+		next, deactivate := schedule.AfterRun(due, schedule.Monthly, now)
+		if deactivate {
+			t.Fatal("MONTHLY must stay active")
+		}
+		if next.Month() != now.Month()+1 {
+			t.Fatalf("MONTHLY next month = %v, want %v", next.Month(), now.Month()+1)
+		}
+	})
+}

--- a/services/trading/internal/service/scheduled_interbank.go
+++ b/services/trading/internal/service/scheduled_interbank.go
@@ -1,0 +1,256 @@
+// Scheduled / periodic inter-bank payments (celina 5 — todoSpec
+// "Scheduled/periodic inter-bank payments").
+//
+// A client schedules a cross-bank cash payment to run once on a future
+// date or to repeat on a cadence (DAILY/WEEKLY/MONTHLY). Spec example:
+// "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+//
+// On each NextRun the sweep (RunDueInterbankPayments, driven by the
+// scheduler's daily `trading-scheduled-interbank` job) drives the
+// EXISTING SubmitCrossBankPayment path under a principal scoped to the
+// row's owner, then advances NextRun via schedule.AfterRun (ONCE →
+// deactivate; recurring → next future slot). Each run reuses the
+// cross-bank 2PC saga + retry queue, so a partner outage at run time is
+// handled exactly like a user-initiated payment.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/schedule"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
+)
+
+// CreateScheduledInterbankPaymentInput is the create surface.
+type CreateScheduledInterbankPaymentInput struct {
+	SourceAccountID   string
+	DestBankCode      string
+	DestAccountNumber string
+	Currency          domain.Currency
+	Amount            string
+	Purpose           string
+	Cadence           schedule.Cadence
+	// StartDate (RFC3339) anchors the first NextRun. Required for ONCE
+	// (validated to be in the future); for recurring cadences it's
+	// optional — empty means the first run is one cadence interval ahead.
+	StartDate string
+}
+
+// CreateScheduledInterbankPayment registers a scheduled cross-bank
+// payment for the caller. Validates the destination shape (same checks
+// as the immediate SubmitCrossBankPayment path), the cadence, and the
+// start date (future for ONCE via schedule.ValidateFuture). The row is
+// Active=true with NextRun set to the chosen start. Principal-scoped:
+// only clients with payment.write (or admin) may schedule.
+func (s *Service) CreateScheduledInterbankPayment(ctx context.Context, in CreateScheduledInterbankPaymentInput) (*domain.ScheduledInterbankPayment, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !permissions.HasAny(p.Permissions, permissions.PaymentWrite, permissions.Admin) {
+		return nil, apperr.PermissionDenied("nedovoljne permisije")
+	}
+	if in.SourceAccountID == "" {
+		return nil, apperr.Validation("source_account_id je obavezan")
+	}
+	if in.DestBankCode == "" {
+		return nil, apperr.Validation("destinacijska banka je obavezna")
+	}
+	if len(in.DestAccountNumber) != 18 {
+		return nil, apperr.Validation("destinacijski račun mora imati 18 cifara")
+	}
+	if !accountNumberChecksumOK(in.DestAccountNumber) {
+		return nil, apperr.Validation("checksum destinacijskog računa nije validan")
+	}
+	if !strings.HasPrefix(in.DestAccountNumber, in.DestBankCode) {
+		return nil, apperr.Validation("destinacijski račun ne pripada navedenoj banci")
+	}
+	if !in.Currency.Supported() {
+		return nil, apperr.Validation("nepodržana valuta")
+	}
+	amt, perr := money.Parse(in.Amount)
+	if perr != nil || !money.IsPositive(amt) {
+		return nil, apperr.Validation("iznos mora biti pozitivan")
+	}
+	if !in.Cadence.Valid() {
+		return nil, apperr.Validation("učestalost mora biti ONCE, DAILY, WEEKLY ili MONTHLY")
+	}
+
+	now := s.now()
+	var nextRun time.Time
+	switch {
+	case in.StartDate != "":
+		start, terr := time.Parse(time.RFC3339, in.StartDate)
+		if terr != nil {
+			return nil, apperr.Validation("neispravan datum početka")
+		}
+		if verr := schedule.ValidateFuture(start, now); verr != nil {
+			return nil, apperr.Validation("datum početka mora biti u budućnosti")
+		}
+		nextRun = start
+	case in.Cadence == schedule.Once:
+		// A one-off without a start date has no defined run time.
+		return nil, apperr.Validation("datum izvršenja je obavezan za jednokratnu uplatu")
+	default:
+		// Recurring without an explicit start → first run one interval out.
+		nextRun = schedule.Advance(now, in.Cadence)
+	}
+
+	return s.Store.InsertScheduledInterbankPayment(ctx, &domain.ScheduledInterbankPayment{
+		UserID:            p.UserID,
+		UserKind:          domain.UserKind(p.UserKind),
+		SourceAccountID:   in.SourceAccountID,
+		DestBankCode:      in.DestBankCode,
+		DestAccountNumber: in.DestAccountNumber,
+		Currency:          in.Currency,
+		Amount:            money.FormatAmount(amt),
+		Purpose:           in.Purpose,
+		Cadence:           string(in.Cadence),
+		NextRun:           nextRun,
+	})
+}
+
+// ListScheduledInterbankPayments returns the caller's own scheduled
+// payments (active + paused), newest first.
+func (s *Service) ListScheduledInterbankPayments(ctx context.Context) ([]*domain.ScheduledInterbankPayment, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.Store.ListScheduledInterbankPaymentsByUser(ctx, p.UserID)
+}
+
+// PauseScheduledInterbankPayment flips Active=false so the sweep skips it.
+func (s *Service) PauseScheduledInterbankPayment(ctx context.Context, id string) (*domain.ScheduledInterbankPayment, error) {
+	return s.setScheduledInterbankActive(ctx, id, false)
+}
+
+// ResumeScheduledInterbankPayment flips Active=true so the sweep picks it
+// back up.
+func (s *Service) ResumeScheduledInterbankPayment(ctx context.Context, id string) (*domain.ScheduledInterbankPayment, error) {
+	return s.setScheduledInterbankActive(ctx, id, true)
+}
+
+func (s *Service) setScheduledInterbankActive(ctx context.Context, id string, active bool) (*domain.ScheduledInterbankPayment, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.Store.GetScheduledInterbankPayment(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if row.UserID != p.UserID && !permissions.Has(p.Permissions, permissions.Admin) {
+		return nil, apperr.PermissionDenied("nedovoljne permisije")
+	}
+	if err := s.Store.SetScheduledInterbankPaymentActive(ctx, id, active); err != nil {
+		return nil, err
+	}
+	row.Active = active
+	return row, nil
+}
+
+// CancelScheduledInterbankPayment deletes a scheduled payment permanently.
+func (s *Service) CancelScheduledInterbankPayment(ctx context.Context, id string) error {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return err
+	}
+	row, err := s.Store.GetScheduledInterbankPayment(ctx, id)
+	if err != nil {
+		return err
+	}
+	if row.UserID != p.UserID && !permissions.Has(p.Permissions, permissions.Admin) {
+		return apperr.PermissionDenied("nedovoljne permisije")
+	}
+	return s.Store.DeleteScheduledInterbankPayment(ctx, id)
+}
+
+// RunDueInterbankPayments is the sweep entrypoint. For each due + active
+// row it submits one cross-bank payment via the existing
+// SubmitCrossBankPayment path (under the row owner's principal), records
+// the outcome, then advances NextRun via schedule.AfterRun (ONCE →
+// deactivate). Returns the number of payments successfully submitted
+// (skips/errors don't count). Never fails the whole sweep on one bad row.
+func (s *Service) RunDueInterbankPayments(ctx context.Context) (int, error) {
+	now := s.now()
+	rows, err := s.Store.ListDueScheduledInterbankPayments(ctx, now)
+	if err != nil {
+		return 0, err
+	}
+	submitted := 0
+	for _, r := range rows {
+		status, lastErr := s.runOneScheduledInterbank(ctx, r)
+		if lastErr == "" {
+			submitted++
+		}
+		cad := schedule.Cadence(r.Cadence)
+		next, deactivate := schedule.AfterRun(r.NextRun, cad, now)
+		if aerr := s.Store.AdvanceScheduledInterbankPayment(ctx, r.ID, next, deactivate, status, lastErr, now); aerr != nil {
+			s.Log.Warn("scheduled interbank: advance failed",
+				"scheduled_interbank_id", r.ID, "err", aerr.Error())
+		}
+	}
+	return submitted, nil
+}
+
+// runOneScheduledInterbank submits one due row's cross-bank payment.
+// Returns the run's status (the saga status string, or "skipped") and a
+// last-error string ("" on a clean submit). Never returns a Go error;
+// the caller advances NextRun regardless (a recurring schedule keeps
+// firing each cycle, just like the DCA recurring orders).
+func (s *Service) runOneScheduledInterbank(ctx context.Context, r *domain.ScheduledInterbankPayment) (statusOut, lastErr string) {
+	owner, err := s.recurringOwnerPrincipal(ctx, &domain.RecurringOrder{UserID: r.UserID, UserKind: r.UserKind})
+	if err != nil {
+		s.Log.Warn("scheduled interbank: owner principal resolution failed; skipping",
+			"scheduled_interbank_id", r.ID, "err", err.Error())
+		return "skipped", "vlasnik naloga nije mogao biti razrešen"
+	}
+	ownerCtx := auth.WithPrincipal(ctx, owner)
+
+	// Deterministic idempotency key per row+run so a re-fired sweep tick
+	// (or a saga already in flight) never double-charges: keyed by the
+	// scheduled row id + the scheduled run time.
+	idem := fmt.Sprintf("scheduled:%s:%d", r.ID, r.NextRun.Unix())
+	res, err := s.SubmitCrossBankPayment(ownerCtx, SubmitCrossBankPaymentInput{
+		IdempotencyKey:      idem,
+		SourceAccountID:     r.SourceAccountID,
+		RemoteBankCode:      r.DestBankCode,
+		RemoteAccountNumber: r.DestAccountNumber,
+		Currency:            r.Currency,
+		Amount:              r.Amount,
+		Purpose:             r.Purpose,
+	})
+	if err != nil {
+		s.Log.Warn("scheduled interbank: submit failed; skipping cycle",
+			"scheduled_interbank_id", r.ID, "err", err.Error())
+		s.notifyScheduledInterbankSkip(ctx, r, "uplata nije mogla biti izvršena ovog ciklusa")
+		return "failed", err.Error()
+	}
+	// A 'running' status means the partner was unavailable and the retry
+	// queue is now driving it — that's a successful submit from the
+	// sweep's POV (the retry worker owns the outcome + client notice).
+	return res.Status, ""
+}
+
+// notifyScheduledInterbankSkip tells the owner a scheduled cross-bank
+// payment couldn't be submitted this cycle. In-app, best-effort.
+func (s *Service) notifyScheduledInterbankSkip(ctx context.Context, r *domain.ScheduledInterbankPayment, reason string) {
+	if s.Notifier == nil {
+		return
+	}
+	title := "Zakazana inostrana uplata preskočena"
+	body := fmt.Sprintf("Zakazana uplata banci %s nije izvršena: %s.", r.DestBankCode, reason)
+	if err := s.Notifier.InApp(ctx, r.UserID, r.UserKind, "cross_bank_payment", title, body); err != nil {
+		s.Log.Warn("scheduled interbank: in-app notify failed",
+			"scheduled_interbank_id", r.ID, "err", err.Error())
+	}
+}

--- a/services/trading/internal/store/interbank_retry.go
+++ b/services/trading/internal/store/interbank_retry.go
@@ -1,0 +1,133 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
+	"github.com/jackc/pgx/v5"
+)
+
+const interbankRetryCols = `id, transaction_id, partner_bank_code, operation,
+    user_id, user_kind, attempt_count, next_retry_at, deadline_at, status,
+    last_error, created_at, updated_at`
+
+// EnqueueInterbankRetry inserts (or re-arms) one retry-queue entry for a
+// parked cross-bank payment. Idempotent on transaction_id: an existing
+// entry is re-armed to pending with a fresh next_retry_at; the deadline
+// stays anchored to the original created_at (so the 30s window does not
+// reset on every re-enqueue). Returns the resulting row.
+func (s *Store) EnqueueInterbankRetry(ctx context.Context, e *domain.InterbankRetryEntry) (*domain.InterbankRetryEntry, error) {
+	const q = `
+        insert into "trading".interbank_retry_queue
+            (transaction_id, partner_bank_code, operation, user_id, user_kind,
+             attempt_count, next_retry_at, deadline_at, status)
+        values ($1, $2, $3, $4, $5, 0, $6, $7, 'pending')
+        on conflict (transaction_id) do update set
+            next_retry_at = excluded.next_retry_at,
+            status        = case when "trading".interbank_retry_queue.status = 'succeeded'
+                                 then "trading".interbank_retry_queue.status
+                                 else 'pending' end,
+            updated_at    = now()
+        returning ` + interbankRetryCols
+	row := s.DB.QueryRow(ctx, q,
+		e.TransactionID, e.PartnerBankCode, e.Operation, e.UserID,
+		string(e.UserKind), e.NextRetryAt, e.DeadlineAt)
+	out, err := scanInterbankRetry(row)
+	if err != nil {
+		return nil, apperr.Internal("enqueue interbank retry", err)
+	}
+	return out, nil
+}
+
+// ListDueInterbankRetries returns every pending entry whose next_retry_at
+// is at or before `now` — the worker's working set, oldest-due first.
+func (s *Store) ListDueInterbankRetries(ctx context.Context, now time.Time) ([]*domain.InterbankRetryEntry, error) {
+	q := `select ` + interbankRetryCols + ` from "trading".interbank_retry_queue
+	      where status = 'pending' and next_retry_at <= $1 order by next_retry_at asc`
+	rows, err := s.DB.Query(ctx, q, now)
+	if err != nil {
+		return nil, apperr.Internal("list due interbank retries", err)
+	}
+	defer rows.Close()
+	return scanInterbankRetries(rows)
+}
+
+// ListInterbankRetriesByUser returns every retry entry (any status) for
+// one user, newest first — surfaced on the FE for transparency.
+func (s *Store) ListInterbankRetriesByUser(ctx context.Context, userID string) ([]*domain.InterbankRetryEntry, error) {
+	q := `select ` + interbankRetryCols + ` from "trading".interbank_retry_queue
+	      where user_id = $1 order by created_at desc`
+	rows, err := s.DB.Query(ctx, q, userID)
+	if err != nil {
+		return nil, apperr.Internal("list interbank retries", err)
+	}
+	defer rows.Close()
+	return scanInterbankRetries(rows)
+}
+
+// MarkInterbankRetrySucceeded flips an entry to succeeded.
+func (s *Store) MarkInterbankRetrySucceeded(ctx context.Context, id string) error {
+	const q = `update "trading".interbank_retry_queue
+	           set status = 'succeeded', updated_at = now() where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		return apperr.Internal("mark interbank retry succeeded", err)
+	}
+	return nil
+}
+
+// MarkInterbankRetryFailed flips an entry to failed and records the error.
+func (s *Store) MarkInterbankRetryFailed(ctx context.Context, id, lastErr string) error {
+	const q = `update "trading".interbank_retry_queue
+	           set status = 'failed', last_error = $2, updated_at = now() where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id, lastErr); err != nil {
+		return apperr.Internal("mark interbank retry failed", err)
+	}
+	return nil
+}
+
+// RescheduleInterbankRetry bumps attempt_count, records the last error,
+// and arms next_retry_at for another attempt (next = now + 5s).
+func (s *Store) RescheduleInterbankRetry(ctx context.Context, id string, nextRetryAt time.Time, lastErr string) error {
+	const q = `update "trading".interbank_retry_queue
+	           set attempt_count = attempt_count + 1,
+	               next_retry_at = $2,
+	               last_error = $3,
+	               updated_at = now()
+	           where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id, nextRetryAt, lastErr); err != nil {
+		return apperr.Internal("reschedule interbank retry", err)
+	}
+	return nil
+}
+
+func scanInterbankRetries(rows pgx.Rows) ([]*domain.InterbankRetryEntry, error) {
+	var out []*domain.InterbankRetryEntry
+	for rows.Next() {
+		e, err := scanInterbankRetry(rows)
+		if err != nil {
+			return nil, apperr.Internal("scan interbank retry", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func scanInterbankRetry(row pgx.Row) (*domain.InterbankRetryEntry, error) {
+	var (
+		e      domain.InterbankRetryEntry
+		kind   string
+		status string
+	)
+	if err := row.Scan(
+		&e.ID, &e.TransactionID, &e.PartnerBankCode, &e.Operation,
+		&e.UserID, &kind, &e.AttemptCount, &e.NextRetryAt, &e.DeadlineAt,
+		&status, &e.LastError, &e.CreatedAt, &e.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	e.UserKind = domain.UserKind(kind)
+	e.Status = domain.InterbankRetryStatus(status)
+	return &e, nil
+}

--- a/services/trading/internal/store/scheduled_interbank.go
+++ b/services/trading/internal/store/scheduled_interbank.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
+	"github.com/jackc/pgx/v5"
+)
+
+const scheduledInterbankCols = `id, user_id, user_kind, source_account_id,
+    dest_bank_code, dest_account_number, currency, amount::text, purpose,
+    cadence, next_run, active, last_status, last_error, last_run_at,
+    created_at, updated_at`
+
+// InsertScheduledInterbankPayment creates one scheduled cross-bank
+// payment row and returns it.
+func (s *Store) InsertScheduledInterbankPayment(ctx context.Context, p *domain.ScheduledInterbankPayment) (*domain.ScheduledInterbankPayment, error) {
+	const q = `
+        insert into "trading".scheduled_interbank_payments
+            (user_id, user_kind, source_account_id, dest_bank_code,
+             dest_account_number, currency, amount, purpose, cadence, next_run)
+        values ($1, $2, $3, $4, $5, $6, $7::numeric, $8, $9, $10)
+        returning ` + scheduledInterbankCols
+	row := s.DB.QueryRow(ctx, q,
+		p.UserID, string(p.UserKind), p.SourceAccountID, p.DestBankCode,
+		p.DestAccountNumber, string(p.Currency), p.Amount, p.Purpose,
+		p.Cadence, p.NextRun)
+	out, err := scanScheduledInterbank(row)
+	if err != nil {
+		return nil, apperr.Internal("insert scheduled interbank payment", err)
+	}
+	return out, nil
+}
+
+// ListScheduledInterbankPaymentsByUser returns every scheduled payment
+// (active + paused) for one user, newest first.
+func (s *Store) ListScheduledInterbankPaymentsByUser(ctx context.Context, userID string) ([]*domain.ScheduledInterbankPayment, error) {
+	q := `select ` + scheduledInterbankCols + ` from "trading".scheduled_interbank_payments
+	      where user_id = $1 order by created_at desc`
+	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID)
+	if err != nil {
+		return nil, apperr.Internal("list scheduled interbank payments", err)
+	}
+	defer rows.Close()
+	return scanScheduledInterbanks(rows)
+}
+
+// ListDueScheduledInterbankPayments returns every active row whose
+// next_run is at or before `now` — the sweep's working set, oldest-due
+// first. Stays on the primary (worker read).
+func (s *Store) ListDueScheduledInterbankPayments(ctx context.Context, now time.Time) ([]*domain.ScheduledInterbankPayment, error) {
+	q := `select ` + scheduledInterbankCols + ` from "trading".scheduled_interbank_payments
+	      where active = true and next_run <= $1 order by next_run asc`
+	rows, err := s.DB.Query(ctx, q, now)
+	if err != nil {
+		return nil, apperr.Internal("list due scheduled interbank payments", err)
+	}
+	defer rows.Close()
+	return scanScheduledInterbanks(rows)
+}
+
+// GetScheduledInterbankPayment returns one row by id. NotFound on miss.
+func (s *Store) GetScheduledInterbankPayment(ctx context.Context, id string) (*domain.ScheduledInterbankPayment, error) {
+	q := `select ` + scheduledInterbankCols + ` from "trading".scheduled_interbank_payments where id = $1`
+	out, err := scanScheduledInterbank(s.DB.QueryRow(postgres.WithRead(ctx), q, id))
+	if err != nil {
+		if noRows(err) {
+			return nil, apperr.NotFound("zakazana inostrana uplata nije pronađena")
+		}
+		return nil, apperr.Internal("get scheduled interbank payment", err)
+	}
+	return out, nil
+}
+
+// SetScheduledInterbankPaymentActive flips the active flag (pause /
+// resume) and bumps updated_at.
+func (s *Store) SetScheduledInterbankPaymentActive(ctx context.Context, id string, active bool) error {
+	const q = `update "trading".scheduled_interbank_payments
+	           set active = $2, updated_at = now() where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id, active); err != nil {
+		return apperr.Internal("set scheduled interbank payment active", err)
+	}
+	return nil
+}
+
+// AdvanceScheduledInterbankPayment records a run's outcome: the new
+// next_run, whether the row should deactivate (ONCE), and the last
+// status/error to surface on the FE. Bumps updated_at + last_run_at.
+func (s *Store) AdvanceScheduledInterbankPayment(ctx context.Context, id string, next time.Time, deactivate bool, lastStatus, lastErr string, ranAt time.Time) error {
+	const q = `update "trading".scheduled_interbank_payments
+	           set next_run = $2,
+	               active = case when $3 then false else active end,
+	               last_status = $4,
+	               last_error = $5,
+	               last_run_at = $6,
+	               updated_at = now()
+	           where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id, next, deactivate, lastStatus, lastErr, ranAt); err != nil {
+		return apperr.Internal("advance scheduled interbank payment", err)
+	}
+	return nil
+}
+
+// DeleteScheduledInterbankPayment removes a scheduled payment permanently
+// (cancel).
+func (s *Store) DeleteScheduledInterbankPayment(ctx context.Context, id string) error {
+	const q = `delete from "trading".scheduled_interbank_payments where id = $1`
+	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		return apperr.Internal("delete scheduled interbank payment", err)
+	}
+	return nil
+}
+
+func scanScheduledInterbanks(rows pgx.Rows) ([]*domain.ScheduledInterbankPayment, error) {
+	var out []*domain.ScheduledInterbankPayment
+	for rows.Next() {
+		p, err := scanScheduledInterbank(rows)
+		if err != nil {
+			return nil, apperr.Internal("scan scheduled interbank payment", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func scanScheduledInterbank(row pgx.Row) (*domain.ScheduledInterbankPayment, error) {
+	var (
+		p        domain.ScheduledInterbankPayment
+		kind     string
+		currency string
+		lastRun  *time.Time
+	)
+	if err := row.Scan(
+		&p.ID, &p.UserID, &kind, &p.SourceAccountID, &p.DestBankCode,
+		&p.DestAccountNumber, &currency, &p.Amount, &p.Purpose, &p.Cadence,
+		&p.NextRun, &p.Active, &p.LastStatus, &p.LastError, &lastRun,
+		&p.CreatedAt, &p.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	p.UserKind = domain.UserKind(kind)
+	p.Currency = domain.Currency(currency)
+	p.LastRunAt = lastRun
+	return &p, nil
+}

--- a/services/trading/migrations/0025_interbank_retry_queue.down.sql
+++ b/services/trading/migrations/0025_interbank_retry_queue.down.sql
@@ -1,0 +1,1 @@
+drop table if exists "trading".interbank_retry_queue;

--- a/services/trading/migrations/0025_interbank_retry_queue.up.sql
+++ b/services/trading/migrations/0025_interbank_retry_queue.up.sql
@@ -1,0 +1,42 @@
+-- Inter-bank retry queue (celina 5 — todoSpec "Retry queue").
+--
+-- When a partner bank is unavailable mid cross-bank payment, the saga
+-- parks (status=running) and the originating request enqueues one row
+-- here. A worker (scheduler job `trading-interbank-retry`, every 5s)
+-- re-drives every pending entry whose next_retry_at <= now by resuming
+-- the underlying saga:
+--   * saga completed  → status='succeeded'
+--   * still parked     → next_retry_at = now + 5s (retry again)
+--   * now > deadline_at (created + 30s) → status='failed', the saga is
+--     rolled back and the client is notified the transaction failed.
+--
+-- One row per saga (transaction_id) — re-enqueue is an idempotent
+-- upsert that re-arms a pending entry instead of inserting a duplicate.
+
+create table "trading".interbank_retry_queue (
+    id              uuid primary key default gen_random_uuid(),
+    -- saga transaction_id this entry drives (also the bank-side
+    -- interbank tx id). Unique so re-enqueue is idempotent.
+    transaction_id  uuid not null unique,
+    -- partner routing/bank code, kept for observability + the failure
+    -- notification copy.
+    partner_bank_code text not null,
+    -- operation being retried; currently always 'cross_bank_payment'.
+    operation       text not null default 'cross_bank_payment',
+    -- who to notify on terminal failure.
+    user_id         text not null,
+    user_kind       text not null,
+    attempt_count   int  not null default 0,
+    next_retry_at   timestamptz not null,
+    -- hard cut-off: created_at + 30s. Past this the entry fails.
+    deadline_at     timestamptz not null,
+    status          text not null default 'pending'
+                    check (status in ('pending', 'succeeded', 'failed')),
+    last_error      text not null default '',
+    created_at      timestamptz not null default now(),
+    updated_at      timestamptz not null default now()
+);
+
+-- The worker's working set: pending entries ordered by when they're due.
+create index interbank_retry_queue_due_idx
+    on "trading".interbank_retry_queue (status, next_retry_at);

--- a/services/trading/migrations/0026_scheduled_interbank_payments.down.sql
+++ b/services/trading/migrations/0026_scheduled_interbank_payments.down.sql
@@ -1,0 +1,1 @@
+drop table if exists "trading".scheduled_interbank_payments;

--- a/services/trading/migrations/0026_scheduled_interbank_payments.up.sql
+++ b/services/trading/migrations/0026_scheduled_interbank_payments.up.sql
@@ -1,0 +1,42 @@
+-- Scheduled / periodic inter-bank payments (celina 5 — todoSpec
+-- "Scheduled/periodic inter-bank payments").
+--
+-- A client schedules a cross-bank cash payment to run once on a future
+-- date or to repeat on a cadence (DAILY/WEEKLY/MONTHLY). Spec example:
+-- "Svakog prvog u mesecu poslati 400 EUR na dati račun."
+--
+-- On each next_run the scheduler job `trading-scheduled-interbank` (a
+-- daily sweep) drives the EXISTING SubmitCrossBankPayment path under the
+-- row's owner principal, then advances next_run via schedule.AfterRun
+-- (ONCE → active=false; recurring → next future slot). Pausing flips
+-- active=false; cancelling deactivates the row permanently.
+--
+-- The sweep walks every due+active row, so (active, next_run) is indexed.
+
+create table "trading".scheduled_interbank_payments (
+    id                  uuid primary key default gen_random_uuid(),
+    user_id             text not null,
+    user_kind           text not null,
+    source_account_id   uuid not null,
+    dest_bank_code      text not null,
+    dest_account_number text not null,
+    currency            text not null,
+    amount              numeric(20, 4) not null check (amount > 0),
+    purpose             text not null default '',
+    cadence             text not null
+                        check (cadence in ('ONCE', 'DAILY', 'WEEKLY', 'MONTHLY')),
+    next_run            timestamptz not null,
+    active              boolean not null default true,
+    -- last_status / last_error surface the most recent run's outcome to
+    -- the FE list (running | completed | failed). Empty until first run.
+    last_status         text not null default '',
+    last_error          text not null default '',
+    last_run_at         timestamptz,
+    created_at          timestamptz not null default now(),
+    updated_at          timestamptz not null default now()
+);
+
+create index scheduled_interbank_payments_active_next_run_idx
+    on "trading".scheduled_interbank_payments (active, next_run);
+create index scheduled_interbank_payments_user_id_idx
+    on "trading".scheduled_interbank_payments (user_id);


### PR DESCRIPTION
Retry queue (partner-unavailable → retry every 5s, abort at 30s + notify client) + scheduled/periodic inter-bank payments (reuses pkg/schedule; reuses the existing cross-bank payment path). New RPCs on the registered CrossBankPaymentService + scheduler jobs. Trading migrations 0025/0026.

todoSpec C5: retry queue, scheduled/delayed payments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)