### PR TITLE
feat(exchange): FX rate history + mobile last-month kursna lista (todoSpec)

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -1974,6 +1974,75 @@
         ]
       }
     },
+    "/api/v1/exchange/rates/history": {
+      "get": {
+        "summary": "ListRateHistory returns the recorded history for a single pair over\nthe last N days, newest first. Backs the mobile \"kursna lista u\nzadnjih mesec dana\" view. Append-only history accrues from the feed\n(see fx_rate_history); the latest-only ListRates is unaffected.",
+        "operationId": "ExchangeService_ListRateHistory",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListRateHistoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "CURRENCY_UNSPECIFIED",
+              "CURRENCY_RSD",
+              "CURRENCY_EUR",
+              "CURRENCY_CHF",
+              "CURRENCY_USD",
+              "CURRENCY_GBP",
+              "CURRENCY_JPY",
+              "CURRENCY_CAD",
+              "CURRENCY_AUD"
+            ],
+            "default": "CURRENCY_UNSPECIFIED"
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "CURRENCY_UNSPECIFIED",
+              "CURRENCY_RSD",
+              "CURRENCY_EUR",
+              "CURRENCY_CHF",
+              "CURRENCY_USD",
+              "CURRENCY_GBP",
+              "CURRENCY_JPY",
+              "CURRENCY_CAD",
+              "CURRENCY_AUD"
+            ],
+            "default": "CURRENCY_UNSPECIFIED"
+          },
+          {
+            "name": "days",
+            "description": "days is the look-back window; defaults to 30 (last month) when 0 or\nnegative. Bound from the ?days= query param.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "ExchangeService"
+        ]
+      }
+    },
     "/api/v1/exchange/rates/refresh": {
       "post": {
         "summary": "RefreshFXRates does one fetch+upsert pass of the external FX feed.\nNormally driven by the scheduler service; exposed so ops can fire it\non demand. Requires ExchangeWrite (or admin).",
@@ -9880,6 +9949,25 @@
         }
       }
     },
+    "v1ListRateHistoryResponse": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/bankaExchangeV1Currency"
+        },
+        "to": {
+          "$ref": "#/definitions/bankaExchangeV1Currency"
+        },
+        "points": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RateHistoryPoint"
+          },
+          "description": "points are ordered newest first."
+        }
+      }
+    },
     "v1ListRatesResponse": {
       "type": "object",
       "properties": {
@@ -11023,6 +11111,21 @@
         }
       },
       "description": "Rate is one row of the FX table. base/quote are decimal strings to\npreserve precision. The pair is directional: from RSD to EUR is a\ndifferent row than from EUR to RSD. The menjačnica formula uses\n(1 ± margin) on the mid; we store the resolved bid/ask so the bank\nservice doesn't need to know the spread policy."
+    },
+    "v1RateHistoryPoint": {
+      "type": "object",
+      "properties": {
+        "bid": {
+          "type": "string"
+        },
+        "ask": {
+          "type": "string"
+        },
+        "recordedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
     },
     "v1RealizedPnLRow": {
       "type": "object",

--- a/gen/proto/exchange/v1/exchange.pb.go
+++ b/gen/proto/exchange/v1/exchange.pb.go
@@ -329,6 +329,189 @@ func (x *ListRatesResponse) GetRates() []*Rate {
 	return nil
 }
 
+type ListRateHistoryRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	From  Currency               `protobuf:"varint,1,opt,name=from,proto3,enum=banka.exchange.v1.Currency" json:"from,omitempty"`
+	To    Currency               `protobuf:"varint,2,opt,name=to,proto3,enum=banka.exchange.v1.Currency" json:"to,omitempty"`
+	// days is the look-back window; defaults to 30 (last month) when 0 or
+	// negative. Bound from the ?days= query param.
+	Days          int32 `protobuf:"varint,3,opt,name=days,proto3" json:"days,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRateHistoryRequest) Reset() {
+	*x = ListRateHistoryRequest{}
+	mi := &file_exchange_v1_exchange_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRateHistoryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRateHistoryRequest) ProtoMessage() {}
+
+func (x *ListRateHistoryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_exchange_v1_exchange_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRateHistoryRequest.ProtoReflect.Descriptor instead.
+func (*ListRateHistoryRequest) Descriptor() ([]byte, []int) {
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ListRateHistoryRequest) GetFrom() Currency {
+	if x != nil {
+		return x.From
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ListRateHistoryRequest) GetTo() Currency {
+	if x != nil {
+		return x.To
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ListRateHistoryRequest) GetDays() int32 {
+	if x != nil {
+		return x.Days
+	}
+	return 0
+}
+
+type RateHistoryPoint struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Bid           string                 `protobuf:"bytes,1,opt,name=bid,proto3" json:"bid,omitempty"`
+	Ask           string                 `protobuf:"bytes,2,opt,name=ask,proto3" json:"ask,omitempty"`
+	RecordedAt    *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=recorded_at,json=recordedAt,proto3" json:"recorded_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RateHistoryPoint) Reset() {
+	*x = RateHistoryPoint{}
+	mi := &file_exchange_v1_exchange_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RateHistoryPoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RateHistoryPoint) ProtoMessage() {}
+
+func (x *RateHistoryPoint) ProtoReflect() protoreflect.Message {
+	mi := &file_exchange_v1_exchange_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RateHistoryPoint.ProtoReflect.Descriptor instead.
+func (*RateHistoryPoint) Descriptor() ([]byte, []int) {
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RateHistoryPoint) GetBid() string {
+	if x != nil {
+		return x.Bid
+	}
+	return ""
+}
+
+func (x *RateHistoryPoint) GetAsk() string {
+	if x != nil {
+		return x.Ask
+	}
+	return ""
+}
+
+func (x *RateHistoryPoint) GetRecordedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RecordedAt
+	}
+	return nil
+}
+
+type ListRateHistoryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	From  Currency               `protobuf:"varint,1,opt,name=from,proto3,enum=banka.exchange.v1.Currency" json:"from,omitempty"`
+	To    Currency               `protobuf:"varint,2,opt,name=to,proto3,enum=banka.exchange.v1.Currency" json:"to,omitempty"`
+	// points are ordered newest first.
+	Points        []*RateHistoryPoint `protobuf:"bytes,3,rep,name=points,proto3" json:"points,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRateHistoryResponse) Reset() {
+	*x = ListRateHistoryResponse{}
+	mi := &file_exchange_v1_exchange_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRateHistoryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRateHistoryResponse) ProtoMessage() {}
+
+func (x *ListRateHistoryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_exchange_v1_exchange_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRateHistoryResponse.ProtoReflect.Descriptor instead.
+func (*ListRateHistoryResponse) Descriptor() ([]byte, []int) {
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListRateHistoryResponse) GetFrom() Currency {
+	if x != nil {
+		return x.From
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ListRateHistoryResponse) GetTo() Currency {
+	if x != nil {
+		return x.To
+	}
+	return Currency_CURRENCY_UNSPECIFIED
+}
+
+func (x *ListRateHistoryResponse) GetPoints() []*RateHistoryPoint {
+	if x != nil {
+		return x.Points
+	}
+	return nil
+}
+
 type QuoteRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	From          Currency               `protobuf:"varint,1,opt,name=from,proto3,enum=banka.exchange.v1.Currency" json:"from,omitempty"`
@@ -339,7 +522,7 @@ type QuoteRequest struct {
 
 func (x *QuoteRequest) Reset() {
 	*x = QuoteRequest{}
-	mi := &file_exchange_v1_exchange_proto_msgTypes[4]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -351,7 +534,7 @@ func (x *QuoteRequest) String() string {
 func (*QuoteRequest) ProtoMessage() {}
 
 func (x *QuoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exchange_v1_exchange_proto_msgTypes[4]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -364,7 +547,7 @@ func (x *QuoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuoteRequest.ProtoReflect.Descriptor instead.
 func (*QuoteRequest) Descriptor() ([]byte, []int) {
-	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{4}
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *QuoteRequest) GetFrom() Currency {
@@ -389,7 +572,7 @@ type RefreshFXRatesRequest struct {
 
 func (x *RefreshFXRatesRequest) Reset() {
 	*x = RefreshFXRatesRequest{}
-	mi := &file_exchange_v1_exchange_proto_msgTypes[5]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +584,7 @@ func (x *RefreshFXRatesRequest) String() string {
 func (*RefreshFXRatesRequest) ProtoMessage() {}
 
 func (x *RefreshFXRatesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exchange_v1_exchange_proto_msgTypes[5]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +597,7 @@ func (x *RefreshFXRatesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshFXRatesRequest.ProtoReflect.Descriptor instead.
 func (*RefreshFXRatesRequest) Descriptor() ([]byte, []int) {
-	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{5}
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{8}
 }
 
 type RefreshFXRatesResponse struct {
@@ -427,7 +610,7 @@ type RefreshFXRatesResponse struct {
 
 func (x *RefreshFXRatesResponse) Reset() {
 	*x = RefreshFXRatesResponse{}
-	mi := &file_exchange_v1_exchange_proto_msgTypes[6]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -439,7 +622,7 @@ func (x *RefreshFXRatesResponse) String() string {
 func (*RefreshFXRatesResponse) ProtoMessage() {}
 
 func (x *RefreshFXRatesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_exchange_v1_exchange_proto_msgTypes[6]
+	mi := &file_exchange_v1_exchange_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -452,7 +635,7 @@ func (x *RefreshFXRatesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshFXRatesResponse.ProtoReflect.Descriptor instead.
 func (*RefreshFXRatesResponse) Descriptor() ([]byte, []int) {
-	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{6}
+	return file_exchange_v1_exchange_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RefreshFXRatesResponse) GetWritten() int32 {
@@ -482,7 +665,20 @@ const file_exchange_v1_exchange_proto_rawDesc = "" +
 	"\x10ListRatesRequest\x12/\n" +
 	"\x04from\x18\x01 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x04from\"B\n" +
 	"\x11ListRatesResponse\x12-\n" +
-	"\x05rates\x18\x01 \x03(\v2\x17.banka.exchange.v1.RateR\x05rates\"l\n" +
+	"\x05rates\x18\x01 \x03(\v2\x17.banka.exchange.v1.RateR\x05rates\"\x8a\x01\n" +
+	"\x16ListRateHistoryRequest\x12/\n" +
+	"\x04from\x18\x01 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x04from\x12+\n" +
+	"\x02to\x18\x02 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x02to\x12\x12\n" +
+	"\x04days\x18\x03 \x01(\x05R\x04days\"s\n" +
+	"\x10RateHistoryPoint\x12\x10\n" +
+	"\x03bid\x18\x01 \x01(\tR\x03bid\x12\x10\n" +
+	"\x03ask\x18\x02 \x01(\tR\x03ask\x12;\n" +
+	"\vrecorded_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"recordedAt\"\xb4\x01\n" +
+	"\x17ListRateHistoryResponse\x12/\n" +
+	"\x04from\x18\x01 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x04from\x12+\n" +
+	"\x02to\x18\x02 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x02to\x12;\n" +
+	"\x06points\x18\x03 \x03(\v2#.banka.exchange.v1.RateHistoryPointR\x06points\"l\n" +
 	"\fQuoteRequest\x12/\n" +
 	"\x04from\x18\x01 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x04from\x12+\n" +
 	"\x02to\x18\x02 \x01(\x0e2\x1b.banka.exchange.v1.CurrencyR\x02to\"\x17\n" +
@@ -498,11 +694,12 @@ const file_exchange_v1_exchange_proto_rawDesc = "" +
 	"\fCURRENCY_GBP\x10\x05\x12\x10\n" +
 	"\fCURRENCY_JPY\x10\x06\x12\x10\n" +
 	"\fCURRENCY_CAD\x10\a\x12\x10\n" +
-	"\fCURRENCY_AUD\x10\b2\xcf\x03\n" +
+	"\fCURRENCY_AUD\x10\b2\xe2\x04\n" +
 	"\x0fExchangeService\x12n\n" +
 	"\n" +
 	"UpsertRate\x12$.banka.exchange.v1.UpsertRateRequest\x1a\x17.banka.exchange.v1.Rate\"!\x82\xd3\xe4\x93\x02\x1b:\x01*\x1a\x16/api/v1/exchange/rates\x12v\n" +
-	"\tListRates\x12#.banka.exchange.v1.ListRatesRequest\x1a$.banka.exchange.v1.ListRatesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/api/v1/exchange/rates\x12A\n" +
+	"\tListRates\x12#.banka.exchange.v1.ListRatesRequest\x1a$.banka.exchange.v1.ListRatesResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/api/v1/exchange/rates\x12\x90\x01\n" +
+	"\x0fListRateHistory\x12).banka.exchange.v1.ListRateHistoryRequest\x1a*.banka.exchange.v1.ListRateHistoryResponse\"&\x82\xd3\xe4\x93\x02 \x12\x1e/api/v1/exchange/rates/history\x12A\n" +
 	"\x05Quote\x12\x1f.banka.exchange.v1.QuoteRequest\x1a\x17.banka.exchange.v1.Rate\x12\x90\x01\n" +
 	"\x0eRefreshFXRates\x12(.banka.exchange.v1.RefreshFXRatesRequest\x1a).banka.exchange.v1.RefreshFXRatesResponse\")\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/api/v1/exchange/rates/refreshB\xd5\x01\n" +
 	"\x15com.banka.exchange.v1B\rExchangeProtoP\x01ZGgithub.com/RAF-SI-2025/Banka-3-Backend/gen/proto/exchange/v1;exchangev1\xa2\x02\x03BEX\xaa\x02\x11Banka.Exchange.V1\xca\x02\x11Banka\\Exchange\\V1\xe2\x02\x1dBanka\\Exchange\\V1\\GPBMetadata\xea\x02\x13Banka::Exchange::V1b\x06proto3"
@@ -520,41 +717,52 @@ func file_exchange_v1_exchange_proto_rawDescGZIP() []byte {
 }
 
 var file_exchange_v1_exchange_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_exchange_v1_exchange_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_exchange_v1_exchange_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_exchange_v1_exchange_proto_goTypes = []any{
-	(Currency)(0),                  // 0: banka.exchange.v1.Currency
-	(*Rate)(nil),                   // 1: banka.exchange.v1.Rate
-	(*UpsertRateRequest)(nil),      // 2: banka.exchange.v1.UpsertRateRequest
-	(*ListRatesRequest)(nil),       // 3: banka.exchange.v1.ListRatesRequest
-	(*ListRatesResponse)(nil),      // 4: banka.exchange.v1.ListRatesResponse
-	(*QuoteRequest)(nil),           // 5: banka.exchange.v1.QuoteRequest
-	(*RefreshFXRatesRequest)(nil),  // 6: banka.exchange.v1.RefreshFXRatesRequest
-	(*RefreshFXRatesResponse)(nil), // 7: banka.exchange.v1.RefreshFXRatesResponse
-	(*timestamppb.Timestamp)(nil),  // 8: google.protobuf.Timestamp
+	(Currency)(0),                   // 0: banka.exchange.v1.Currency
+	(*Rate)(nil),                    // 1: banka.exchange.v1.Rate
+	(*UpsertRateRequest)(nil),       // 2: banka.exchange.v1.UpsertRateRequest
+	(*ListRatesRequest)(nil),        // 3: banka.exchange.v1.ListRatesRequest
+	(*ListRatesResponse)(nil),       // 4: banka.exchange.v1.ListRatesResponse
+	(*ListRateHistoryRequest)(nil),  // 5: banka.exchange.v1.ListRateHistoryRequest
+	(*RateHistoryPoint)(nil),        // 6: banka.exchange.v1.RateHistoryPoint
+	(*ListRateHistoryResponse)(nil), // 7: banka.exchange.v1.ListRateHistoryResponse
+	(*QuoteRequest)(nil),            // 8: banka.exchange.v1.QuoteRequest
+	(*RefreshFXRatesRequest)(nil),   // 9: banka.exchange.v1.RefreshFXRatesRequest
+	(*RefreshFXRatesResponse)(nil),  // 10: banka.exchange.v1.RefreshFXRatesResponse
+	(*timestamppb.Timestamp)(nil),   // 11: google.protobuf.Timestamp
 }
 var file_exchange_v1_exchange_proto_depIdxs = []int32{
 	0,  // 0: banka.exchange.v1.Rate.from:type_name -> banka.exchange.v1.Currency
 	0,  // 1: banka.exchange.v1.Rate.to:type_name -> banka.exchange.v1.Currency
-	8,  // 2: banka.exchange.v1.Rate.updated_at:type_name -> google.protobuf.Timestamp
+	11, // 2: banka.exchange.v1.Rate.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 3: banka.exchange.v1.UpsertRateRequest.from:type_name -> banka.exchange.v1.Currency
 	0,  // 4: banka.exchange.v1.UpsertRateRequest.to:type_name -> banka.exchange.v1.Currency
 	0,  // 5: banka.exchange.v1.ListRatesRequest.from:type_name -> banka.exchange.v1.Currency
 	1,  // 6: banka.exchange.v1.ListRatesResponse.rates:type_name -> banka.exchange.v1.Rate
-	0,  // 7: banka.exchange.v1.QuoteRequest.from:type_name -> banka.exchange.v1.Currency
-	0,  // 8: banka.exchange.v1.QuoteRequest.to:type_name -> banka.exchange.v1.Currency
-	2,  // 9: banka.exchange.v1.ExchangeService.UpsertRate:input_type -> banka.exchange.v1.UpsertRateRequest
-	3,  // 10: banka.exchange.v1.ExchangeService.ListRates:input_type -> banka.exchange.v1.ListRatesRequest
-	5,  // 11: banka.exchange.v1.ExchangeService.Quote:input_type -> banka.exchange.v1.QuoteRequest
-	6,  // 12: banka.exchange.v1.ExchangeService.RefreshFXRates:input_type -> banka.exchange.v1.RefreshFXRatesRequest
-	1,  // 13: banka.exchange.v1.ExchangeService.UpsertRate:output_type -> banka.exchange.v1.Rate
-	4,  // 14: banka.exchange.v1.ExchangeService.ListRates:output_type -> banka.exchange.v1.ListRatesResponse
-	1,  // 15: banka.exchange.v1.ExchangeService.Quote:output_type -> banka.exchange.v1.Rate
-	7,  // 16: banka.exchange.v1.ExchangeService.RefreshFXRates:output_type -> banka.exchange.v1.RefreshFXRatesResponse
-	13, // [13:17] is the sub-list for method output_type
-	9,  // [9:13] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	0,  // 7: banka.exchange.v1.ListRateHistoryRequest.from:type_name -> banka.exchange.v1.Currency
+	0,  // 8: banka.exchange.v1.ListRateHistoryRequest.to:type_name -> banka.exchange.v1.Currency
+	11, // 9: banka.exchange.v1.RateHistoryPoint.recorded_at:type_name -> google.protobuf.Timestamp
+	0,  // 10: banka.exchange.v1.ListRateHistoryResponse.from:type_name -> banka.exchange.v1.Currency
+	0,  // 11: banka.exchange.v1.ListRateHistoryResponse.to:type_name -> banka.exchange.v1.Currency
+	6,  // 12: banka.exchange.v1.ListRateHistoryResponse.points:type_name -> banka.exchange.v1.RateHistoryPoint
+	0,  // 13: banka.exchange.v1.QuoteRequest.from:type_name -> banka.exchange.v1.Currency
+	0,  // 14: banka.exchange.v1.QuoteRequest.to:type_name -> banka.exchange.v1.Currency
+	2,  // 15: banka.exchange.v1.ExchangeService.UpsertRate:input_type -> banka.exchange.v1.UpsertRateRequest
+	3,  // 16: banka.exchange.v1.ExchangeService.ListRates:input_type -> banka.exchange.v1.ListRatesRequest
+	5,  // 17: banka.exchange.v1.ExchangeService.ListRateHistory:input_type -> banka.exchange.v1.ListRateHistoryRequest
+	8,  // 18: banka.exchange.v1.ExchangeService.Quote:input_type -> banka.exchange.v1.QuoteRequest
+	9,  // 19: banka.exchange.v1.ExchangeService.RefreshFXRates:input_type -> banka.exchange.v1.RefreshFXRatesRequest
+	1,  // 20: banka.exchange.v1.ExchangeService.UpsertRate:output_type -> banka.exchange.v1.Rate
+	4,  // 21: banka.exchange.v1.ExchangeService.ListRates:output_type -> banka.exchange.v1.ListRatesResponse
+	7,  // 22: banka.exchange.v1.ExchangeService.ListRateHistory:output_type -> banka.exchange.v1.ListRateHistoryResponse
+	1,  // 23: banka.exchange.v1.ExchangeService.Quote:output_type -> banka.exchange.v1.Rate
+	10, // 24: banka.exchange.v1.ExchangeService.RefreshFXRates:output_type -> banka.exchange.v1.RefreshFXRatesResponse
+	20, // [20:25] is the sub-list for method output_type
+	15, // [15:20] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_exchange_v1_exchange_proto_init() }
@@ -568,7 +776,7 @@ func file_exchange_v1_exchange_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_exchange_v1_exchange_proto_rawDesc), len(file_exchange_v1_exchange_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/exchange/v1/exchange.pb.gw.go
+++ b/gen/proto/exchange/v1/exchange.pb.gw.go
@@ -97,6 +97,41 @@ func local_request_ExchangeService_ListRates_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+var filter_ExchangeService_ListRateHistory_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_ExchangeService_ListRateHistory_0(ctx context.Context, marshaler runtime.Marshaler, client ExchangeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRateHistoryRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ExchangeService_ListRateHistory_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListRateHistory(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ExchangeService_ListRateHistory_0(ctx context.Context, marshaler runtime.Marshaler, server ExchangeServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRateHistoryRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ExchangeService_ListRateHistory_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListRateHistory(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ExchangeService_RefreshFXRates_0(ctx context.Context, marshaler runtime.Marshaler, client ExchangeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq RefreshFXRatesRequest
@@ -169,6 +204,26 @@ func RegisterExchangeServiceHandlerServer(ctx context.Context, mux *runtime.Serv
 			return
 		}
 		forward_ExchangeService_ListRates_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ExchangeService_ListRateHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/banka.exchange.v1.ExchangeService/ListRateHistory", runtime.WithHTTPPathPattern("/api/v1/exchange/rates/history"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ExchangeService_ListRateHistory_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ExchangeService_ListRateHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_ExchangeService_RefreshFXRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -264,6 +319,23 @@ func RegisterExchangeServiceHandlerClient(ctx context.Context, mux *runtime.Serv
 		}
 		forward_ExchangeService_ListRates_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ExchangeService_ListRateHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/banka.exchange.v1.ExchangeService/ListRateHistory", runtime.WithHTTPPathPattern("/api/v1/exchange/rates/history"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ExchangeService_ListRateHistory_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ExchangeService_ListRateHistory_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ExchangeService_RefreshFXRates_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -285,13 +357,15 @@ func RegisterExchangeServiceHandlerClient(ctx context.Context, mux *runtime.Serv
 }
 
 var (
-	pattern_ExchangeService_UpsertRate_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "exchange", "rates"}, ""))
-	pattern_ExchangeService_ListRates_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "exchange", "rates"}, ""))
-	pattern_ExchangeService_RefreshFXRates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"api", "v1", "exchange", "rates", "refresh"}, ""))
+	pattern_ExchangeService_UpsertRate_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "exchange", "rates"}, ""))
+	pattern_ExchangeService_ListRates_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "exchange", "rates"}, ""))
+	pattern_ExchangeService_ListRateHistory_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"api", "v1", "exchange", "rates", "history"}, ""))
+	pattern_ExchangeService_RefreshFXRates_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"api", "v1", "exchange", "rates", "refresh"}, ""))
 )
 
 var (
-	forward_ExchangeService_UpsertRate_0     = runtime.ForwardResponseMessage
-	forward_ExchangeService_ListRates_0      = runtime.ForwardResponseMessage
-	forward_ExchangeService_RefreshFXRates_0 = runtime.ForwardResponseMessage
+	forward_ExchangeService_UpsertRate_0      = runtime.ForwardResponseMessage
+	forward_ExchangeService_ListRates_0       = runtime.ForwardResponseMessage
+	forward_ExchangeService_ListRateHistory_0 = runtime.ForwardResponseMessage
+	forward_ExchangeService_RefreshFXRates_0  = runtime.ForwardResponseMessage
 )

--- a/gen/proto/exchange/v1/exchange_grpc.pb.go
+++ b/gen/proto/exchange/v1/exchange_grpc.pb.go
@@ -19,10 +19,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ExchangeService_UpsertRate_FullMethodName     = "/banka.exchange.v1.ExchangeService/UpsertRate"
-	ExchangeService_ListRates_FullMethodName      = "/banka.exchange.v1.ExchangeService/ListRates"
-	ExchangeService_Quote_FullMethodName          = "/banka.exchange.v1.ExchangeService/Quote"
-	ExchangeService_RefreshFXRates_FullMethodName = "/banka.exchange.v1.ExchangeService/RefreshFXRates"
+	ExchangeService_UpsertRate_FullMethodName      = "/banka.exchange.v1.ExchangeService/UpsertRate"
+	ExchangeService_ListRates_FullMethodName       = "/banka.exchange.v1.ExchangeService/ListRates"
+	ExchangeService_ListRateHistory_FullMethodName = "/banka.exchange.v1.ExchangeService/ListRateHistory"
+	ExchangeService_Quote_FullMethodName           = "/banka.exchange.v1.ExchangeService/Quote"
+	ExchangeService_RefreshFXRates_FullMethodName  = "/banka.exchange.v1.ExchangeService/RefreshFXRates"
 )
 
 // ExchangeServiceClient is the client API for ExchangeService service.
@@ -42,6 +43,11 @@ const (
 type ExchangeServiceClient interface {
 	UpsertRate(ctx context.Context, in *UpsertRateRequest, opts ...grpc.CallOption) (*Rate, error)
 	ListRates(ctx context.Context, in *ListRatesRequest, opts ...grpc.CallOption) (*ListRatesResponse, error)
+	// ListRateHistory returns the recorded history for a single pair over
+	// the last N days, newest first. Backs the mobile "kursna lista u
+	// zadnjih mesec dana" view. Append-only history accrues from the feed
+	// (see fx_rate_history); the latest-only ListRates is unaffected.
+	ListRateHistory(ctx context.Context, in *ListRateHistoryRequest, opts ...grpc.CallOption) (*ListRateHistoryResponse, error)
 	// Quote returns the most recent rate for from→to. Internal: callers
 	// are expected to be other services, not end users. (External quotes
 	// come from ListRates so the FE can render the menjačnica board.)
@@ -74,6 +80,16 @@ func (c *exchangeServiceClient) ListRates(ctx context.Context, in *ListRatesRequ
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListRatesResponse)
 	err := c.cc.Invoke(ctx, ExchangeService_ListRates_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *exchangeServiceClient) ListRateHistory(ctx context.Context, in *ListRateHistoryRequest, opts ...grpc.CallOption) (*ListRateHistoryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRateHistoryResponse)
+	err := c.cc.Invoke(ctx, ExchangeService_ListRateHistory_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +133,11 @@ func (c *exchangeServiceClient) RefreshFXRates(ctx context.Context, in *RefreshF
 type ExchangeServiceServer interface {
 	UpsertRate(context.Context, *UpsertRateRequest) (*Rate, error)
 	ListRates(context.Context, *ListRatesRequest) (*ListRatesResponse, error)
+	// ListRateHistory returns the recorded history for a single pair over
+	// the last N days, newest first. Backs the mobile "kursna lista u
+	// zadnjih mesec dana" view. Append-only history accrues from the feed
+	// (see fx_rate_history); the latest-only ListRates is unaffected.
+	ListRateHistory(context.Context, *ListRateHistoryRequest) (*ListRateHistoryResponse, error)
 	// Quote returns the most recent rate for from→to. Internal: callers
 	// are expected to be other services, not end users. (External quotes
 	// come from ListRates so the FE can render the menjačnica board.)
@@ -139,6 +160,9 @@ func (UnimplementedExchangeServiceServer) UpsertRate(context.Context, *UpsertRat
 }
 func (UnimplementedExchangeServiceServer) ListRates(context.Context, *ListRatesRequest) (*ListRatesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListRates not implemented")
+}
+func (UnimplementedExchangeServiceServer) ListRateHistory(context.Context, *ListRateHistoryRequest) (*ListRateHistoryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRateHistory not implemented")
 }
 func (UnimplementedExchangeServiceServer) Quote(context.Context, *QuoteRequest) (*Rate, error) {
 	return nil, status.Error(codes.Unimplemented, "method Quote not implemented")
@@ -202,6 +226,24 @@ func _ExchangeService_ListRates_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ExchangeService_ListRateHistory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRateHistoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ExchangeServiceServer).ListRateHistory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ExchangeService_ListRateHistory_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ExchangeServiceServer).ListRateHistory(ctx, req.(*ListRateHistoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ExchangeService_Quote_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(QuoteRequest)
 	if err := dec(in); err != nil {
@@ -252,6 +294,10 @@ var ExchangeService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListRates",
 			Handler:    _ExchangeService_ListRates_Handler,
+		},
+		{
+			MethodName: "ListRateHistory",
+			Handler:    _ExchangeService_ListRateHistory_Handler,
 		},
 		{
 			MethodName: "Quote",

--- a/proto/exchange/v1/exchange.proto
+++ b/proto/exchange/v1/exchange.proto
@@ -27,6 +27,14 @@ service ExchangeService {
     option (google.api.http) = {get: "/api/v1/exchange/rates"};
   }
 
+  // ListRateHistory returns the recorded history for a single pair over
+  // the last N days, newest first. Backs the mobile "kursna lista u
+  // zadnjih mesec dana" view. Append-only history accrues from the feed
+  // (see fx_rate_history); the latest-only ListRates is unaffected.
+  rpc ListRateHistory(ListRateHistoryRequest) returns (ListRateHistoryResponse) {
+    option (google.api.http) = {get: "/api/v1/exchange/rates/history"};
+  }
+
   // Quote returns the most recent rate for from→to. Internal: callers
   // are expected to be other services, not end users. (External quotes
   // come from ListRates so the FE can render the menjačnica board.)
@@ -83,6 +91,27 @@ message ListRatesRequest {
 
 message ListRatesResponse {
   repeated Rate rates = 1;
+}
+
+message ListRateHistoryRequest {
+  Currency from = 1;
+  Currency to = 2;
+  // days is the look-back window; defaults to 30 (last month) when 0 or
+  // negative. Bound from the ?days= query param.
+  int32 days = 3;
+}
+
+message RateHistoryPoint {
+  string bid = 1;
+  string ask = 2;
+  google.protobuf.Timestamp recorded_at = 3;
+}
+
+message ListRateHistoryResponse {
+  Currency from = 1;
+  Currency to = 2;
+  // points are ordered newest first.
+  repeated RateHistoryPoint points = 3;
 }
 
 message QuoteRequest {

--- a/services/exchange/internal/domain/domain.go
+++ b/services/exchange/internal/domain/domain.go
@@ -39,3 +39,12 @@ type Rate struct {
 	Ask       string
 	UpdatedAt time.Time
 }
+
+// RateHistoryPoint is one append-only historical observation of a pair's
+// bid/ask. Recorded on every feed refresh; read back for the mobile
+// last-month kursna lista.
+type RateHistoryPoint struct {
+	Bid        string
+	Ask        string
+	RecordedAt time.Time
+}

--- a/services/exchange/internal/feed/feed.go
+++ b/services/exchange/internal/feed/feed.go
@@ -75,15 +75,21 @@ func (f *Feeder) Once(ctx context.Context) (int, error) {
 		}
 		bid := rsdPerUnit * (1 - f.Spread)
 		ask := rsdPerUnit * (1 + f.Spread)
-		_, err := f.Store.UpsertRate(ctx, &domain.Rate{
+		r := &domain.Rate{
 			From: cur,
 			To:   domain.CurrencyRSD,
 			Bid:  formatRate(bid),
 			Ask:  formatRate(ask),
-		})
-		if err != nil {
+		}
+		if _, err := f.Store.UpsertRate(ctx, r); err != nil {
 			f.Log.Warn("fx feed upsert failed", "from", cur, "error", err)
 			continue
+		}
+		// Append an append-only history point so the mobile last-month
+		// kursna lista accrues over time. A history write failure must
+		// not abort the latest-only update — log and carry on.
+		if err := f.Store.InsertRateHistory(ctx, r); err != nil {
+			f.Log.Warn("fx feed history insert failed", "from", cur, "error", err)
 		}
 		written++
 	}

--- a/services/exchange/internal/server/server.go
+++ b/services/exchange/internal/server/server.go
@@ -53,6 +53,28 @@ func (s *Server) ListRates(ctx context.Context, in *exchangepb.ListRatesRequest)
 	return &exchangepb.ListRatesResponse{Rates: out}, nil
 }
 
+func (s *Server) ListRateHistory(ctx context.Context, in *exchangepb.ListRateHistoryRequest) (*exchangepb.ListRateHistoryResponse, error) {
+	from := currencyFromProto(in.GetFrom())
+	to := currencyFromProto(in.GetTo())
+	points, err := s.Svc.ListRateHistory(ctx, from, to, int(in.GetDays()))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*exchangepb.RateHistoryPoint, 0, len(points))
+	for _, p := range points {
+		out = append(out, &exchangepb.RateHistoryPoint{
+			Bid:        p.Bid,
+			Ask:        p.Ask,
+			RecordedAt: timestamppb.New(p.RecordedAt),
+		})
+	}
+	return &exchangepb.ListRateHistoryResponse{
+		From:   currencyToProto(from),
+		To:     currencyToProto(to),
+		Points: out,
+	}, nil
+}
+
 func (s *Server) Quote(ctx context.Context, in *exchangepb.QuoteRequest) (*exchangepb.Rate, error) {
 	r, err := s.Svc.Quote(ctx, currencyFromProto(in.GetFrom()), currencyFromProto(in.GetTo()))
 	if err != nil {

--- a/services/exchange/internal/service/service.go
+++ b/services/exchange/internal/service/service.go
@@ -4,6 +4,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
@@ -68,6 +69,30 @@ func (s *Service) ListRates(ctx context.Context, from domain.Currency) ([]*domai
 		return nil, apperr.Validation("unsupported currency: " + string(from))
 	}
 	return s.Store.ListRates(ctx, from)
+}
+
+// defaultHistoryDays is the look-back window when the caller passes
+// days <= 0 — the mobile "kursna lista u zadnjih mesec dana".
+const defaultHistoryDays = 30
+
+// ListRateHistory returns the recorded history for from→to over the last
+// `days` days (default 30), newest first. Authenticated callers only,
+// like ListRates — no specific permission (clients view the board).
+func (s *Service) ListRateHistory(ctx context.Context, from, to domain.Currency, days int) ([]*domain.RateHistoryPoint, error) {
+	if _, ok := auth.PrincipalFrom(ctx); !ok {
+		return nil, apperr.Unauthenticated("not authenticated")
+	}
+	if !from.Supported() || !to.Supported() {
+		return nil, apperr.Validation("unsupported currency")
+	}
+	if from == to {
+		return nil, apperr.Validation("from and to must differ")
+	}
+	if days <= 0 {
+		days = defaultHistoryDays
+	}
+	since := time.Now().AddDate(0, 0, -days)
+	return s.Store.ListRateHistory(ctx, from, to, since)
 }
 
 // Quote returns the most recent rate for from→to. Internal: callers

--- a/services/exchange/internal/service/service_test.go
+++ b/services/exchange/internal/service/service_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/exchange/internal/domain"
+)
+
+func authed(ctx context.Context) context.Context {
+	return auth.WithPrincipal(ctx, auth.Principal{UserID: "u1", UserKind: auth.KindClient})
+}
+
+// ListRateHistory's pre-store guards are exercised without a DB: an
+// unauthenticated caller, an unsupported currency, and from==to all
+// return before the store is touched, so a nil Store is safe here.
+func TestListRateHistory_Guards(t *testing.T) {
+	svc := &Service{}
+
+	if _, err := svc.ListRateHistory(context.Background(), domain.CurrencyEUR, domain.CurrencyRSD, 30); err == nil {
+		t.Fatal("expected unauthenticated error with no principal")
+	}
+
+	ctx := authed(context.Background())
+
+	if _, err := svc.ListRateHistory(ctx, domain.Currency("XXX"), domain.CurrencyRSD, 30); err == nil {
+		t.Fatal("expected validation error for unsupported currency")
+	}
+
+	if _, err := svc.ListRateHistory(ctx, domain.CurrencyRSD, domain.CurrencyRSD, 30); err == nil {
+		t.Fatal("expected validation error for from==to")
+	}
+}
+
+// defaultHistoryDays is the documented "last month" window.
+func TestDefaultHistoryDays(t *testing.T) {
+	if defaultHistoryDays != 30 {
+		t.Fatalf("defaultHistoryDays = %d, want 30", defaultHistoryDays)
+	}
+}

--- a/services/exchange/internal/store/postgres.go
+++ b/services/exchange/internal/store/postgres.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
@@ -86,6 +87,48 @@ func (s *Store) ListRates(ctx context.Context, from domain.Currency) ([]*domain.
 			return nil, apperr.Internal("scan fx rate", err)
 		}
 		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// InsertRateHistory appends one append-only observation of a pair. Called
+// from the feed alongside the latest-only UpsertRate so history accrues
+// going forward without disturbing the live rate.
+func (s *Store) InsertRateHistory(ctx context.Context, r *domain.Rate) error {
+	const q = `
+        insert into "exchange".fx_rate_history ("from", "to", bid, ask)
+        values ($1,$2,$3,$4)`
+	if _, err := s.DB.Exec(ctx, q, string(r.From), string(r.To), r.Bid, r.Ask); err != nil {
+		var pe interface{ SQLState() string }
+		if errors.As(err, &pe) && pe.SQLState() == "23514" {
+			return apperr.Validation("fx rate history violates a check constraint (positive amounts and ask ≥ bid)")
+		}
+		return apperr.Internal("insert fx rate history", err)
+	}
+	return nil
+}
+
+// ListRateHistory returns the recorded points for a pair on or after
+// since, newest first.
+func (s *Store) ListRateHistory(ctx context.Context, from, to domain.Currency, since time.Time) ([]*domain.RateHistoryPoint, error) {
+	const q = `
+        select bid::text, ask::text, recorded_at
+        from "exchange".fx_rate_history
+        where "from" = $1 and "to" = $2 and recorded_at >= $3
+        order by recorded_at desc`
+	rows, err := s.DB.Query(postgres.WithRead(ctx), q, string(from), string(to), since)
+	if err != nil {
+		return nil, apperr.Internal("list fx rate history", err)
+	}
+	defer rows.Close()
+
+	var out []*domain.RateHistoryPoint
+	for rows.Next() {
+		var p domain.RateHistoryPoint
+		if err := rows.Scan(&p.Bid, &p.Ask, &p.RecordedAt); err != nil {
+			return nil, apperr.Internal("scan fx rate history", err)
+		}
+		out = append(out, &p)
 	}
 	return out, rows.Err()
 }

--- a/services/exchange/migrations/0003_fx_rate_history.down.sql
+++ b/services/exchange/migrations/0003_fx_rate_history.down.sql
@@ -1,0 +1,1 @@
+drop table if exists "exchange".fx_rate_history;

--- a/services/exchange/migrations/0003_fx_rate_history.up.sql
+++ b/services/exchange/migrations/0003_fx_rate_history.up.sql
@@ -1,0 +1,24 @@
+-- Slice: FX rate HISTORY (todoSpec mobile "kursna lista u zadnjih mesec
+-- dana"). The fx_rates table is latest-only (one row per (from,to),
+-- overwritten on every feed refresh — see 0002), so there is no record
+-- of how a pair moved over time. This append-only table accrues one row
+-- per (from,to) on every feed pass going forward, which the mobile app
+-- reads back for its last-month rate view.
+--
+-- Append-only: never updated, never upserted. Rows are queried by pair
+-- over a recent time window (newest first), hence the composite index.
+
+create table "exchange".fx_rate_history (
+    id          bigint generated always as identity primary key,
+    "from"      text not null check ("from" in ('RSD','EUR','CHF','USD','GBP','JPY','CAD','AUD')),
+    "to"        text not null check ("to"   in ('RSD','EUR','CHF','USD','GBP','JPY','CAD','AUD')),
+    bid         numeric(20,8) not null,
+    ask         numeric(20,8) not null,
+    recorded_at timestamptz not null default now(),
+    constraint fx_rate_history_distinct check ("from" <> "to"),
+    constraint fx_rate_history_nonneg   check (bid > 0 and ask > 0),
+    constraint fx_rate_history_spread   check (ask >= bid)
+);
+
+create index fx_rate_history_pair_recorded_idx
+    on "exchange".fx_rate_history ("from", "to", recorded_at desc);


### PR DESCRIPTION
Exchange service stores FX rate history (new fx_rate_history table, mig 0003; feed appends per refresh) + ListRateHistory RPC (GET /api/v1/exchange/rates/history?from=&to=&days=). Mobile kursna-lista gains a per-pair last-30-days view. Closes the last deferred todoSpec item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)