### PR TITLE
feat(interbank): Banka-2 OTC accept/exercise settlement + buyer-side inbound

### DIFF
--- a/gen/openapi/banka.swagger.json
+++ b/gen/openapi/banka.swagger.json
@@ -4589,6 +4589,13 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "remoteBankCode",
+            "description": "Optional. When set and thread_id is not one of OUR local ids, resolve\nthe thread by its remote ref (remote_bank_code, remote_thread_id=thread_id)\ninstead. Used by the Banka-2 inbound shim for buyer-side (OUTGOING)\nthreads, where the partner addresses us by the id THEY minted.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/gen/proto/bank/v1/interbank_2pc.pb.go
+++ b/gen/proto/bank/v1/interbank_2pc.pb.go
@@ -189,7 +189,12 @@ type PreparePaymentRequest struct {
 	// local_account_number is the 18-digit account number on this bank;
 	// validated against the spec sum(digits)%11 checksum at the gateway
 	// before the RPC fires.
-	LocalAccountNumber  string   `protobuf:"bytes,4,opt,name=local_account_number,json=localAccountNumber,proto3" json:"local_account_number,omitempty"`
+	LocalAccountNumber string `protobuf:"bytes,4,opt,name=local_account_number,json=localAccountNumber,proto3" json:"local_account_number,omitempty"`
+	// remote_account_number is audit-only (the money moves between
+	// local_account_number and the bank's per-currency system account). It is
+	// 18 digits for account-addressed cash payments, but EMPTY for PERSON-
+	// addressed OTC settlements (si-tx-proto/Banka-2), where the counterparty
+	// is identified by foreign-bank id, not an account number. So: 18 or empty.
 	RemoteAccountNumber string   `protobuf:"bytes,5,opt,name=remote_account_number,json=remoteAccountNumber,proto3" json:"remote_account_number,omitempty"`
 	Currency            Currency `protobuf:"varint,6,opt,name=currency,proto3,enum=banka.bank.v1.Currency" json:"currency,omitempty"`
 	Amount              string   `protobuf:"bytes,7,opt,name=amount,proto3" json:"amount,omitempty"`
@@ -886,14 +891,14 @@ var File_bank_v1_interbank_2pc_proto protoreflect.FileDescriptor
 
 const file_bank_v1_interbank_2pc_proto_rawDesc = "" +
 	"\n" +
-	"\x1bbank/v1/interbank_2pc.proto\x12\rbanka.bank.v1\x1a\x12bank/v1/bank.proto\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf9\x03\n" +
+	"\x1bbank/v1/interbank_2pc.proto\x12\rbanka.bank.v1\x1a\x12bank/v1/bank.proto\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf8\x03\n" +
 	"\x15PreparePaymentRequest\x12;\n" +
 	"\x15sender_routing_number\x18\x01 \x01(\x05B\a\xbaH\x04\x1a\x02 \x00R\x13senderRoutingNumber\x12.\n" +
 	"\x0etransaction_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\rtransactionId\x12R\n" +
 	"\tdirection\x18\x03 \x01(\x0e2(.banka.bank.v1.InterbankPaymentDirectionB\n" +
 	"\xbaH\a\x82\x01\x04\x10\x01 \x00R\tdirection\x12:\n" +
-	"\x14local_account_number\x18\x04 \x01(\tB\b\xbaH\x05r\x03\x98\x01\x12R\x12localAccountNumber\x12<\n" +
-	"\x15remote_account_number\x18\x05 \x01(\tB\b\xbaH\x05r\x03\x98\x01\x12R\x13remoteAccountNumber\x12?\n" +
+	"\x14local_account_number\x18\x04 \x01(\tB\b\xbaH\x05r\x03\x98\x01\x12R\x12localAccountNumber\x12;\n" +
+	"\x15remote_account_number\x18\x05 \x01(\tB\a\xbaH\x04r\x02\x18\x12R\x13remoteAccountNumber\x12?\n" +
 	"\bcurrency\x18\x06 \x01(\x0e2\x17.banka.bank.v1.CurrencyB\n" +
 	"\xbaH\a\x82\x01\x04\x10\x01 \x00R\bcurrency\x12\x1f\n" +
 	"\x06amount\x18\a \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06amount\x12)\n" +

--- a/gen/proto/trading/v1/external_otc.pb.go
+++ b/gen/proto/trading/v1/external_otc.pb.go
@@ -1472,10 +1472,15 @@ func (x *ListExternalOTCThreadsResponse) GetThreads() []*ExternalOTCThread {
 }
 
 type GetExternalOTCThreadRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ThreadId      string                 `protobuf:"bytes,1,opt,name=thread_id,json=threadId,proto3" json:"thread_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	ThreadId string                 `protobuf:"bytes,1,opt,name=thread_id,json=threadId,proto3" json:"thread_id,omitempty"`
+	// Optional. When set and thread_id is not one of OUR local ids, resolve
+	// the thread by its remote ref (remote_bank_code, remote_thread_id=thread_id)
+	// instead. Used by the Banka-2 inbound shim for buyer-side (OUTGOING)
+	// threads, where the partner addresses us by the id THEY minted.
+	RemoteBankCode string `protobuf:"bytes,2,opt,name=remote_bank_code,json=remoteBankCode,proto3" json:"remote_bank_code,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetExternalOTCThreadRequest) Reset() {
@@ -1511,6 +1516,13 @@ func (*GetExternalOTCThreadRequest) Descriptor() ([]byte, []int) {
 func (x *GetExternalOTCThreadRequest) GetThreadId() string {
 	if x != nil {
 		return x.ThreadId
+	}
+	return ""
+}
+
+func (x *GetExternalOTCThreadRequest) GetRemoteBankCode() string {
+	if x != nil {
+		return x.RemoteBankCode
 	}
 	return ""
 }
@@ -2722,9 +2734,10 @@ const file_trading_v1_external_otc_proto_rawDesc = "" +
 	"\x1dListExternalOTCThreadsRequest\x12A\n" +
 	"\x06status\x18\x01 \x01(\x0e2).banka.trading.v1.ExternalOTCThreadStatusR\x06status\"_\n" +
 	"\x1eListExternalOTCThreadsResponse\x12=\n" +
-	"\athreads\x18\x01 \x03(\v2#.banka.trading.v1.ExternalOTCThreadR\athreads\"C\n" +
+	"\athreads\x18\x01 \x03(\v2#.banka.trading.v1.ExternalOTCThreadR\athreads\"m\n" +
 	"\x1bGetExternalOTCThreadRequest\x12$\n" +
-	"\tthread_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\bthreadId\"\xe6\x01\n" +
+	"\tthread_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\bthreadId\x12(\n" +
+	"\x10remote_bank_code\x18\x02 \x01(\tR\x0eremoteBankCode\"\xe6\x01\n" +
 	"\x1cGetExternalOTCThreadResponse\x12;\n" +
 	"\x06thread\x18\x01 \x01(\v2#.banka.trading.v1.ExternalOTCThreadR\x06thread\x12F\n" +
 	"\n" +

--- a/gen/proto/trading/v1/external_otc.pb.gw.go
+++ b/gen/proto/trading/v1/external_otc.pb.gw.go
@@ -132,6 +132,8 @@ func local_request_ExternalOTCService_ListExternalOTCThreads_0(ctx context.Conte
 	return msg, metadata, err
 }
 
+var filter_ExternalOTCService_GetExternalOTCThread_0 = &utilities.DoubleArray{Encoding: map[string]int{"thread_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
 func request_ExternalOTCService_GetExternalOTCThread_0(ctx context.Context, marshaler runtime.Marshaler, client ExternalOTCServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetExternalOTCThreadRequest
@@ -148,6 +150,12 @@ func request_ExternalOTCService_GetExternalOTCThread_0(ctx context.Context, mars
 	protoReq.ThreadId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "thread_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ExternalOTCService_GetExternalOTCThread_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := client.GetExternalOTCThread(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -166,6 +174,12 @@ func local_request_ExternalOTCService_GetExternalOTCThread_0(ctx context.Context
 	protoReq.ThreadId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "thread_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ExternalOTCService_GetExternalOTCThread_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.GetExternalOTCThread(ctx, &protoReq)
 	return msg, metadata, err

--- a/proto/bank/v1/interbank_2pc.proto
+++ b/proto/bank/v1/interbank_2pc.proto
@@ -92,7 +92,12 @@ message PreparePaymentRequest {
   // validated against the spec sum(digits)%11 checksum at the gateway
   // before the RPC fires.
   string local_account_number = 4 [(buf.validate.field).string.len = 18];
-  string remote_account_number = 5 [(buf.validate.field).string.len = 18];
+  // remote_account_number is audit-only (the money moves between
+  // local_account_number and the bank's per-currency system account). It is
+  // 18 digits for account-addressed cash payments, but EMPTY for PERSON-
+  // addressed OTC settlements (si-tx-proto/Banka-2), where the counterparty
+  // is identified by foreign-bank id, not an account number. So: 18 or empty.
+  string remote_account_number = 5 [(buf.validate.field).string.max_len = 18];
   Currency currency = 6 [(buf.validate.field).enum = {
     defined_only: true
     not_in: [0]

--- a/proto/trading/v1/external_otc.proto
+++ b/proto/trading/v1/external_otc.proto
@@ -355,6 +355,11 @@ message ListExternalOTCThreadsResponse {
 
 message GetExternalOTCThreadRequest {
   string thread_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Optional. When set and thread_id is not one of OUR local ids, resolve
+  // the thread by its remote ref (remote_bank_code, remote_thread_id=thread_id)
+  // instead. Used by the Banka-2 inbound shim for buyer-side (OUTGOING)
+  // threads, where the partner addresses us by the id THEY minted.
+  string remote_bank_code = 2;
 }
 
 message GetExternalOTCThreadResponse {

--- a/services/bank/internal/service/interbank_2pc.go
+++ b/services/bank/internal/service/interbank_2pc.go
@@ -138,8 +138,15 @@ func (s *Service) preparePayment(ctx context.Context, in PreparePaymentInput) (*
 		return nil, apperr.FailedPrecondition("partner bank is blacklisted")
 	}
 
-	if len(in.LocalAccountNumber) != 18 || len(in.RemoteAccountNumber) != 18 {
-		return nil, apperr.Validation("account numbers must be 18 digits")
+	// local_account_number is the account whose funds actually move and must
+	// be a real 18-digit number. remote_account_number is audit-only (see the
+	// proto comment): 18 digits for cash payments, empty for PERSON-addressed
+	// OTC settlements where the counterparty has no account number.
+	if len(in.LocalAccountNumber) != 18 {
+		return nil, apperr.Validation("local account number must be 18 digits")
+	}
+	if in.RemoteAccountNumber != "" && len(in.RemoteAccountNumber) != 18 {
+		return nil, apperr.Validation("remote account number must be 18 digits or empty")
 	}
 	if !in.Currency.Supported() {
 		return nil, apperr.Validation("unsupported currency")

--- a/services/bank/migrations/0020_interbank_remote_account_optional.down.sql
+++ b/services/bank/migrations/0020_interbank_remote_account_optional.down.sql
@@ -1,0 +1,6 @@
+alter table "bank".interbank_protocol_transactions
+  drop constraint interbank_protocol_transactions_remote_account_number_check;
+
+alter table "bank".interbank_protocol_transactions
+  add constraint interbank_protocol_transactions_remote_account_number_check
+  check (length(remote_account_number) = 18);

--- a/services/bank/migrations/0020_interbank_remote_account_optional.up.sql
+++ b/services/bank/migrations/0020_interbank_remote_account_optional.up.sql
@@ -1,0 +1,12 @@
+-- remote_account_number is audit-only (the money moves between
+-- local_account_number and the bank's per-currency system account). It is
+-- 18 digits for account-addressed cash payments, but EMPTY for PERSON-
+-- addressed OTC settlements (si-tx-proto / Banka-2), where the counterparty
+-- is identified by foreign-bank id, not an account number. Relax the CHECK
+-- from "exactly 18" to "18 or empty".
+alter table "bank".interbank_protocol_transactions
+  drop constraint interbank_protocol_transactions_remote_account_number_check;
+
+alter table "bank".interbank_protocol_transactions
+  add constraint interbank_protocol_transactions_remote_account_number_check
+  check (remote_account_number = '' or length(remote_account_number) = 18);

--- a/services/gateway/internal/app/app.go
+++ b/services/gateway/internal/app/app.go
@@ -149,6 +149,7 @@ func Run() error {
 			APIKey:            apiKey,
 			BankRoutingNumber: config.String("BANK_ROUTING_NUMBER", "333"),
 			BankDisplayName:   config.String("BANK_DISPLAY_NAME", "Banka 3"),
+			PresentedRouting:  parseCodeValuePairs(config.String("INTERBANK_PRESENTED_ROUTING", "")),
 			Users:             cs.User,
 			Trading:           cs.Trading,
 			TradingOTC:        cs.ExternalOTC,
@@ -293,4 +294,28 @@ func Run() error {
 		return err
 	}
 	return nil
+}
+
+// parseCodeValuePairs parses a "code:value,code:value" string into a map.
+// Shared grammar with trading's INTERBANK_PRESENTED_ROUTING / partner keys;
+// malformed entries are dropped. Used here to tell the Banka-2 inbound shim
+// which routing each partner uses to address us.
+func parseCodeValuePairs(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		code, val, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		code, val = strings.TrimSpace(code), strings.TrimSpace(val)
+		if code == "" || val == "" {
+			continue
+		}
+		out[code] = val
+	}
+	return out
 }

--- a/services/gateway/internal/router/partner_banka2.go
+++ b/services/gateway/internal/router/partner_banka2.go
@@ -57,6 +57,12 @@ type PartnerBanka2 struct {
 	APIKey            string
 	BankRoutingNumber string // ours, e.g. "333"
 	BankDisplayName   string // ours, e.g. "Banka 3"
+	// PresentedRouting maps a partner bank code → the routing number THAT
+	// partner uses to address us (the inverse of trading's outbound presented
+	// routing). Banka-2 knows Banka-3 as 265, so its inbound OTC PERSON/OPTION
+	// legs reference routing 265, not our real 333. From
+	// INTERBANK_PRESENTED_ROUTING; empty means the partner uses our real routing.
+	PresentedRouting map[string]string
 
 	Users      userpb.UserServiceClient
 	Trading    tradingpb.TradingServiceClient
@@ -415,7 +421,16 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 	if ourRouting == 0 {
 		ourRouting = 333
 	}
-	intent, err := parseB2OTCSettlement(tx, ourRouting)
+	// Recognize both our real routing and the routing this partner uses to
+	// address us (Banka-2 → 265): its inbound PERSON/OPTION legs reference the
+	// presented routing, not our 333.
+	ourRoutings := []int{ourRouting}
+	if pr := p.PresentedRouting[strconv.Itoa(key.RoutingNumber)]; pr != "" {
+		if n, err := strconv.Atoi(pr); err == nil && n != ourRouting {
+			ourRoutings = append(ourRoutings, n)
+		}
+	}
+	intent, err := parseB2OTCSettlement(tx, ourRoutings...)
 	if err != nil {
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "UNACCEPTABLE_ASSET", nil)
 		return
@@ -425,6 +440,15 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 		kind = tradingpb.ExternalOTCSettlementKind_EXTERNAL_OTC_SETTLEMENT_KIND_EXERCISE
 	}
 	ctx := partnerCtx(r.Context())
+
+	// Buyer-side accept (we host the buyer): the partner coordinates the 2PC
+	// and this NEW_TX debits our buyer's premium. No seller shares to reserve
+	// — the local contract is recorded by our accept SAGA. Settle the premium
+	// debit against the buyer's bound account and vote.
+	if intent.Kind == b2KindOTCAccept && intent.BuyerSide {
+		p.handleBuyerAcceptNewTX(w, r, key, tx, intent)
+		return
+	}
 
 	// 1. Trading prepare — reserve the seller's shares / validate the contract.
 	res, err := p.TradingOTC.SettleExternalOTCOption(ctx, &tradingpb.SettleExternalOTCOptionRequest{
@@ -479,6 +503,60 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 			p.respondVoteNO(w, r, key, tx.TransactionID.ID, reason, nil)
 			return
 		}
+	}
+	p.respondVoteYES(w, r, key, tx.TransactionID.ID)
+}
+
+// handleBuyerAcceptNewTX settles the buyer side of a partner-coordinated OTC
+// accept (we host the buyer; the partner's bank drives the 2PC). The NEW_TX
+// debits our buyer's premium (PERSON MONAS, amount<0) and grants them the
+// option right (PERSON OPTION, amount>0). We resolve the buyer's bound account
+// from the negotiation thread (the OPTION negotiationId == our remote_thread_id)
+// and reserve the premium debit; the option contract itself is recorded by our
+// accept SAGA. Votes YES once the debit is prepared.
+func (p *PartnerBanka2) handleBuyerAcceptNewTX(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, tx b2Transaction, intent *b2OTCSettlement) {
+	ctx := partnerCtx(r.Context())
+	// Resolve OUR (OUTGOING/buyer) thread by the option negotiationId, which the
+	// partner minted and we stored as remote_thread_id (remote-ref lookup).
+	resp, err := p.TradingOTC.GetExternalOTCThread(ctx, &tradingpb.GetExternalOTCThreadRequest{
+		ThreadId:       intent.OptionRef.ID,
+		RemoteBankCode: strconv.Itoa(key.RoutingNumber),
+	})
+	if err != nil {
+		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "OPTION_NEGOTIATION_NOT_FOUND", nil)
+		return
+	}
+	t := resp.GetThread()
+	if t == nil || t.GetLocalAccountNumber() == "" {
+		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "NO_SUCH_ACCOUNT", nil)
+		return
+	}
+	// Option-only accept with no premium leg — nothing to reserve.
+	if intent.CashAmount == "" {
+		p.respondVoteYES(w, r, key, tx.TransactionID.ID)
+		return
+	}
+	// Reserve the premium debit from the buyer's bound account. Direction
+	// OUTBOUND = our account is the source (the buyer pays); the counterparty
+	// is our per-currency system account, so remote_account_number is empty
+	// (the seller is PERSON-addressed, not account-addressed).
+	prep, perr := p.Interbank.PreparePayment(ctx, &bankpb.PreparePaymentRequest{
+		SenderRoutingNumber: int32(key.RoutingNumber),
+		TransactionId:       tx.TransactionID.ID,
+		Direction:           bankpb.InterbankPaymentDirection_INTERBANK_PAYMENT_DIRECTION_OUTBOUND,
+		LocalAccountNumber:  t.GetLocalAccountNumber(),
+		RemoteAccountNumber: "",
+		Currency:            currencyFromWire(intent.CashCurrency),
+		Amount:              intent.CashAmount,
+		Purpose:             "OTC premija (kupac) — nit " + t.GetId(),
+	})
+	if perr != nil {
+		p.respondVoteNO(w, r, key, tx.TransactionID.ID, banka2NoVoteFromGRPC(perr), nil)
+		return
+	}
+	if prep.GetStatus() != bankpb.InterbankTxStatus_INTERBANK_TX_STATUS_PREPARED {
+		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "INSUFFICIENT_ASSET", nil)
+		return
 	}
 	p.respondVoteYES(w, r, key, tx.TransactionID.ID)
 }
@@ -735,7 +813,8 @@ func (p *PartnerBanka2) handleReadNegotiation(w http.ResponseWriter, r *http.Req
 		return
 	}
 	resp, err := p.TradingOTC.GetExternalOTCThread(partnerCtx(r.Context()), &tradingpb.GetExternalOTCThreadRequest{
-		ThreadId: threadID,
+		ThreadId:       threadID,
+		RemoteBankCode: r.PathValue("routing_number"),
 	})
 	if err != nil {
 		writeGRPCError(w, err)
@@ -790,7 +869,7 @@ func (p *PartnerBanka2) handleCounterNegotiation(w http.ResponseWriter, r *http.
 		return
 	}
 	threadID := r.PathValue("thread_id")
-	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), threadID)
+	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
 		writeGRPCError(w, err)
 		return
@@ -813,7 +892,7 @@ func (p *PartnerBanka2) handleCounterNegotiation(w http.ResponseWriter, r *http.
 
 func (p *PartnerBanka2) handleCloseNegotiation(w http.ResponseWriter, r *http.Request) {
 	threadID := r.PathValue("thread_id")
-	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), threadID)
+	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
 		writeGRPCError(w, err)
 		return
@@ -831,7 +910,7 @@ func (p *PartnerBanka2) handleCloseNegotiation(w http.ResponseWriter, r *http.Re
 
 func (p *PartnerBanka2) handleAcceptNegotiation(w http.ResponseWriter, r *http.Request) {
 	threadID := r.PathValue("thread_id")
-	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), threadID)
+	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
 		writeGRPCError(w, err)
 		return
@@ -866,14 +945,23 @@ func (p *PartnerBanka2) resolveBanka2Holding(ctx context.Context, ticker, seller
 	return "", status.Errorf(codes.NotFound, "no public holding for ticker=%s seller=%s", ticker, sellerUserID)
 }
 
-// lookupRemoteRef returns (remote_bank_code, remote_thread_id) for a
-// thread whose local id we received in the URL. Banka-2 only knows our
-// local id (we minted it on /negotiations POST), so we need to bounce
-// through the service to translate it back into the (sender_bank,
-// sender_thread) pair the receive-side handlers expect.
-func (p *PartnerBanka2) lookupRemoteRef(ctx context.Context, threadID string) (string, string, error) {
+// lookupRemoteRef returns the (sender_bank, sender_thread) = remote ref of the
+// thread addressed by the inbound URL's {routing_number}/{thread_id}, which the
+// receive-side handlers (ReceiveExternalOTCCounter/Withdraw/Accept) key on.
+//
+// The URL id can be EITHER:
+//   - OUR local id — when we're the seller (we minted it on the inbound
+//     /negotiations POST and returned it). GetExternalOTCThread by id resolves.
+//   - the PARTNER's id — when we're the buyer (they minted it; it's our
+//     remote_thread_id). Then the local-id lookup misses, so the service falls
+//     back to a remote-ref lookup keyed by (routing, thread_id).
+//
+// Either way the thread's stored (remote_bank_code, remote_thread_id) is the
+// remote ref the receive-side expects.
+func (p *PartnerBanka2) lookupRemoteRef(ctx context.Context, routing, threadID string) (string, string, error) {
 	resp, err := p.TradingOTC.GetExternalOTCThread(partnerCtx(ctx), &tradingpb.GetExternalOTCThreadRequest{
-		ThreadId: threadID,
+		ThreadId:       threadID,
+		RemoteBankCode: routing,
 	})
 	if err != nil {
 		return "", "", err

--- a/services/gateway/internal/router/partner_otc_settlement.go
+++ b/services/gateway/internal/router/partner_otc_settlement.go
@@ -93,6 +93,13 @@ type b2OTCSettlement struct {
 	// Ticker/Quantity describe the share leg on exercise.
 	Ticker   string
 	Quantity int64
+	// BuyerSide is true when WE host the buyer (an OUTGOING thread): the
+	// partner coordinates the accept 2PC and this NEW_TX debits our buyer's
+	// premium (PERSON MONAS, amount<0) and credits them the option right
+	// (PERSON OPTION, amount>0). Settled by debiting the buyer's bound
+	// account; the contract is recorded by our accept SAGA. The seller-side
+	// SellerID/Ticker/Quantity fields don't apply.
+	BuyerSide bool
 }
 
 // b2AmountSign splits a wire amount into sign + absolute decimal string.
@@ -112,12 +119,25 @@ func b2AmountSign(n json.Number) (positive bool, abs string) {
 // parseB2OTCSettlement extracts the seller-side settlement intent from an
 // accept/exercise envelope. ourRouting is this bank's routing number.
 // Returns an error for a cash envelope or one with no posting touching us.
-func parseB2OTCSettlement(tx b2Transaction, ourRouting int) (*b2OTCSettlement, error) {
+// parseB2OTCSettlement parses a Banka-2 OTC settlement envelope. ourRoutings
+// lists every routing number that identifies US — our real BANK_ROUTING_NUMBER
+// plus any presented routing a partner uses to address us (e.g. Banka-2 knows
+// Banka-3 as 265), so PERSON/OPTION legs the partner addresses to us are
+// recognized as local.
+func parseB2OTCSettlement(tx b2Transaction, ourRoutings ...int) (*b2OTCSettlement, error) {
 	kind := classifyB2Transaction(tx)
 	out := &b2OTCSettlement{Kind: kind}
 
 	ours := func(a b2TxAccount) bool {
-		return a.ID != nil && a.ID.RoutingNumber == ourRouting
+		if a.ID == nil {
+			return false
+		}
+		for _, rn := range ourRoutings {
+			if a.ID.RoutingNumber == rn {
+				return true
+			}
+		}
+		return false
 	}
 
 	switch kind {
@@ -129,21 +149,26 @@ func parseB2OTCSettlement(tx b2Transaction, ourRouting int) (*b2OTCSettlement, e
 			}
 			switch {
 			case p.Asset.Type == "OPTION" && p.Account.Type == "PERSON":
-				// Our seller gives the option right (amount < 0).
-				if pos, _ := b2AmountSign(p.Amount); !pos {
+				// OPTION right on our PERSON. amount<0 = our seller GIVES the
+				// right (we host the seller); amount>0 = our buyer RECEIVES it
+				// (we host the buyer — partner-coordinated accept into us).
+				out.OptionRef = optionNegotiationID(p.Asset)
+				if pos, _ := b2AmountSign(p.Amount); pos {
+					out.BuyerSide = true
+				} else {
 					out.SellerID = *p.Account.ID
-					out.OptionRef = optionNegotiationID(p.Asset)
 				}
 			case p.Asset.Type == "MONAS" && p.Account.Type == "PERSON":
-				// Premium credited to our seller (amount > 0).
-				if pos, abs := b2AmountSign(p.Amount); pos {
-					out.CashAmount = abs
-					out.CashCurrency = banka2CurrencyFromAsset(p.Asset)
-				}
+				// Premium leg on our PERSON — amount>0 credits our seller,
+				// amount<0 debits our buyer. Either way the magnitude is the
+				// premium; the sign is captured by BuyerSide above.
+				_, abs := b2AmountSign(p.Amount)
+				out.CashAmount = abs
+				out.CashCurrency = banka2CurrencyFromAsset(p.Asset)
 			}
 		}
 		if out.OptionRef.ID == "" {
-			return nil, fmt.Errorf("accept settlement: no OPTION posting for routing %d", ourRouting)
+			return nil, fmt.Errorf("accept settlement: no OPTION posting for routings %v", ourRoutings)
 		}
 
 	case b2KindOTCExercise:
@@ -168,7 +193,7 @@ func parseB2OTCSettlement(tx b2Transaction, ourRouting int) (*b2OTCSettlement, e
 			}
 		}
 		if out.OptionRef.ID == "" {
-			return nil, fmt.Errorf("exercise settlement: no OPTION account for routing %d", ourRouting)
+			return nil, fmt.Errorf("exercise settlement: no OPTION account for routings %v", ourRoutings)
 		}
 
 	default:

--- a/services/trading/internal/external/interbank/banka2_exercise.go
+++ b/services/trading/internal/external/interbank/banka2_exercise.go
@@ -1,0 +1,153 @@
+package interbank
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/service"
+)
+
+// =====================================================================
+// Banka-2 dialect — OTC option EXERCISE (buyer-coordinated 2PC).
+//
+// Unlike accept (which the seller's bank coordinates), the BUYER drives
+// exercise: we form the four-posting exercise transaction and run the
+// §2 2PC against the seller's bank, which hosts the OPTION pseudo-account
+// (the contract escrow). On COMMIT the seller's bank releases the
+// reserved shares and credits the seller the strike; we settle our buyer
+// legs (debit strike, credit shares) locally as coordinator.
+//
+//   p1 PERSON{us, buyerRef}      −total  MONAS{ccy}   buyer pays the strike   (local)
+//   p2 OPTION{partner, contract} +total  MONAS{ccy}   credit contract→seller  (remote)
+//   p3 OPTION{partner, contract} −qty    STOCK{tkr}   shares leave the escrow (remote)
+//   p4 PERSON{us, buyerRef}      +qty    STOCK{tkr}   buyer receives shares   (local)
+//
+// Balanced per asset (MONAS: −total+total=0, STOCK: −qty+qty=0). The
+// envelope + COMMIT_TX/ROLLBACK_TX reuse the cash-path plumbing.
+// =====================================================================
+
+// ExercisePartnerInput describes one outbound exercise against a partner.
+type ExercisePartnerInput struct {
+	RemoteBankCode string // partner (seller's bank) routing, e.g. "222"
+	ContractID     string // the OTC reference the partner minted (== our remote_thread_id)
+	TransactionID  string // our id; partner echoes it on COMMIT/ROLLBACK
+	BuyerUserRef   string // our buyer's foreign id (the PERSON id we offered as)
+	Quantity       int32
+	StrikeTotal    string // strike × quantity, positive decimal string
+	Currency       string // ISO code, e.g. "USD"
+	Ticker         string
+}
+
+// Rich posting types for the multi-asset exercise envelope (the cash
+// b2Posting only models MONAS on an ACCOUNT).
+type b2ExAccount struct {
+	Type string       `json:"type"`         // "PERSON" | "OPTION"
+	ID   *b2ForeignID `json:"id,omitempty"` // foreign-bank id of the person / contract
+}
+
+type b2ExAsset struct {
+	Type  string `json:"type"`  // "MONAS" | "STOCK"
+	Asset any    `json:"asset"` // {currency} for MONAS, {ticker} for STOCK
+}
+
+type b2ExPosting struct {
+	Account b2ExAccount `json:"account"`
+	Amount  json.Number `json:"amount"`
+	Asset   b2ExAsset   `json:"asset"`
+}
+
+type b2ExTransaction struct {
+	Postings       []b2ExPosting `json:"postings"`
+	TransactionID  b2ForeignID   `json:"transactionId"`
+	Message        string        `json:"message"`
+	PaymentCode    string        `json:"paymentCode"`
+	PaymentPurpose string        `json:"paymentPurpose"`
+}
+
+// SpeaksBanka2Dialect satisfies service.PartnerOTC — true iff the partner
+// speaks the Banka-2 / si-tx-proto envelope.
+func (c *Client) SpeaksBanka2Dialect(ctx context.Context, bankCode string) bool {
+	return c.Protocol(ctx, bankCode) == ProtocolBanka2
+}
+
+// AcceptCoordinatedByPartner satisfies service.PartnerOTC. For Banka-2 /
+// si-tx-proto partners the SELLER's bank coordinates the OTC accept 2PC, so
+// our buyer-side accept must NOT prepare its own premium payment (the partner
+// debits our buyer via an inbound NEW_TX). Native partners coordinate from the
+// buyer side → false.
+func (c *Client) AcceptCoordinatedByPartner(ctx context.Context, bankCode string) bool {
+	return c.Protocol(ctx, bankCode) == ProtocolBanka2
+}
+
+// ExerciseOption satisfies service.PartnerOTC: relay a buyer-coordinated
+// exercise to a Banka-2 partner. Native partners don't reach here (the saga
+// branches on SpeaksBanka2Dialect).
+func (c *Client) ExerciseOption(ctx context.Context, in service.PartnerExerciseInput) error {
+	return c.ExercisePartnerBanka2(ctx, ExercisePartnerInput{
+		RemoteBankCode: in.RemoteBankCode,
+		ContractID:     in.ContractID,
+		TransactionID:  in.TransactionID,
+		BuyerUserRef:   in.BuyerUserRef,
+		Quantity:       in.Quantity,
+		StrikeTotal:    in.StrikeTotal,
+		Currency:       in.Currency,
+		Ticker:         in.Ticker,
+	})
+}
+
+// ExercisePartnerBanka2 runs the buyer-coordinated exercise 2PC against a
+// Banka-2 dialect partner: NEW_TX → (YES ⇒ COMMIT_TX, NO ⇒ ROLLBACK_TX).
+// Returns nil only when the partner committed.
+func (c *Client) ExercisePartnerBanka2(ctx context.Context, in ExercisePartnerInput) error {
+	ours := c.presentedRouting(in.RemoteBankCode)
+	partner, _ := strconv.Atoi(in.RemoteBankCode)
+
+	buyer := b2ForeignID{RoutingNumber: ours, ID: in.BuyerUserRef}
+	contract := b2ForeignID{RoutingNumber: partner, ID: in.ContractID}
+	monas := func() b2ExAsset { return b2ExAsset{Type: "MONAS", Asset: b2MonetaryAsset{Currency: in.Currency}} }
+	stock := func() b2ExAsset { return b2ExAsset{Type: "STOCK", Asset: banka2Stock{Ticker: in.Ticker}} }
+	qty := json.Number(strconv.Itoa(int(in.Quantity)))
+
+	tx := b2ExTransaction{
+		TransactionID:  b2ForeignID{RoutingNumber: ours, ID: in.TransactionID},
+		Message:        "Peer OTC option exercise",
+		PaymentCode:    "289",
+		PaymentPurpose: "OTC option exercise",
+		Postings: []b2ExPosting{
+			{Account: b2ExAccount{Type: "PERSON", ID: &buyer}, Amount: json.Number("-" + in.StrikeTotal), Asset: monas()},
+			{Account: b2ExAccount{Type: "OPTION", ID: &contract}, Amount: json.Number(in.StrikeTotal), Asset: monas()},
+			{Account: b2ExAccount{Type: "OPTION", ID: &contract}, Amount: json.Number("-" + qty.String()), Asset: stock()},
+			{Account: b2ExAccount{Type: "PERSON", ID: &buyer}, Amount: qty, Asset: stock()},
+		},
+	}
+
+	envelope := b2Envelope{
+		IdempotenceKey: b2IdempotenceKey{RoutingNumber: ours, LocallyGeneratedKey: in.TransactionID + "-prepare"},
+		MessageType:    "NEW_TX",
+		Message:        tx,
+	}
+	url := c.baseURL(in.RemoteBankCode) + "/interbank"
+	status, body, err := c.doJSON(ctx, "POST", url, envelope)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return partnerErrorFromBody(in.RemoteBankCode, status, body)
+	}
+	var vote b2TransactionVote
+	if err := jsonDecode(body, &vote); err != nil {
+		return fmt.Errorf("banka2 exercise NEW_TX decode: %w", err)
+	}
+	if vote.Vote != "YES" {
+		reasons := make([]string, 0, len(vote.Reasons))
+		for _, rr := range vote.Reasons {
+			reasons = append(reasons, rr.Reason)
+		}
+		// Roll the partner's prepared state back before surfacing the refusal.
+		_ = c.rollbackPartnerBanka2(ctx, RollbackPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID})
+		return fmt.Errorf("banka2 exercise refused by %s: %v", in.RemoteBankCode, reasons)
+	}
+	return c.commitPartnerBanka2(ctx, CommitPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID})
+}

--- a/services/trading/internal/server/external_otc.go
+++ b/services/trading/internal/server/external_otc.go
@@ -80,7 +80,7 @@ func (s *Server) ListExternalOTCThreads(ctx context.Context, in *tradingpb.ListE
 }
 
 func (s *Server) GetExternalOTCThread(ctx context.Context, in *tradingpb.GetExternalOTCThreadRequest) (*tradingpb.GetExternalOTCThreadResponse, error) {
-	res, err := s.Svc.GetExternalOTCThread(ctx, in.GetThreadId())
+	res, err := s.Svc.GetExternalOTCThread(ctx, in.GetThreadId(), in.GetRemoteBankCode())
 	if err != nil {
 		return nil, err
 	}

--- a/services/trading/internal/service/external_otc.go
+++ b/services/trading/internal/service/external_otc.go
@@ -56,6 +56,40 @@ type PartnerOTC interface {
 	Counter(ctx context.Context, in PartnerActionInput) error
 	Withdraw(ctx context.Context, in PartnerActionInput) error
 	Accept(ctx context.Context, in PartnerActionInput) error
+
+	// AcceptCoordinatedByPartner reports whether the partner's bank
+	// coordinates the OTC accept premium 2PC itself (the si-tx-proto /
+	// Banka-2 model: the seller's bank forms the accept transaction and
+	// drives the 2PC, debiting our buyer via an inbound NEW_TX). When true,
+	// our buyer-side accept SAGA must NOT also prepare/commit a premium
+	// payment — that would double-debit the buyer. Native partners (the
+	// buyer's bank coordinates) return false.
+	AcceptCoordinatedByPartner(ctx context.Context, bankCode string) bool
+
+	// SpeaksBanka2Dialect reports whether the partner uses the si-tx-proto /
+	// Banka-2 multi-asset envelope rather than our native cash OTC. Gates the
+	// buyer-coordinated exercise path (ExerciseOption).
+	SpeaksBanka2Dialect(ctx context.Context, bankCode string) bool
+
+	// ExerciseOption runs the buyer-coordinated exercise 2PC against a
+	// Banka-2 dialect partner (the seller's bank hosting the OPTION escrow):
+	// it forms the four-posting exercise transaction (buyer pays strike +
+	// receives shares; the partner's OPTION-account legs release the seller's
+	// shares + credit the strike) and drives NEW_TX → COMMIT/ROLLBACK.
+	// Returns nil only on a committed exercise.
+	ExerciseOption(ctx context.Context, in PartnerExerciseInput) error
+}
+
+// PartnerExerciseInput is the buyer-side exercise relayed to the partner.
+type PartnerExerciseInput struct {
+	RemoteBankCode string
+	ContractID     string // the OTC reference the partner minted (our remote_thread_id)
+	TransactionID  string // our 2PC id
+	BuyerUserRef   string // our buyer's foreign id (the PERSON id we offered as)
+	Quantity       int32
+	StrikeTotal    string // strike × quantity, positive decimal string
+	Currency       string
+	Ticker         string
 }
 
 // PartnerHolding is one row from a partner's /otc/public response,
@@ -327,7 +361,12 @@ type GetExternalOTCThreadResult struct {
 
 // GetExternalOTCThread returns one thread + its iterations + the
 // contract (if any).
-func (s *Service) GetExternalOTCThread(ctx context.Context, threadID string) (*GetExternalOTCThreadResult, error) {
+// GetExternalOTCThread resolves a thread by our local id. When the id is not
+// one of ours and remoteBankCode is set, it falls back to a remote-ref lookup
+// (remote_bank_code, remote_thread_id=threadID). The fallback is what lets the
+// Banka-2 inbound shim resolve buyer-side (OUTGOING) threads, where the partner
+// addresses us by the id THEY minted (our remote_thread_id), not our local id.
+func (s *Service) GetExternalOTCThread(ctx context.Context, threadID, remoteBankCode string) (*GetExternalOTCThreadResult, error) {
 	p, err := s.requirePrincipal(ctx)
 	if err != nil {
 		return nil, err
@@ -337,17 +376,24 @@ func (s *Service) GetExternalOTCThread(ctx context.Context, threadID string) (*G
 	}
 	t, err := s.Store.GetExternalOTCThread(ctx, threadID)
 	if err != nil {
-		return nil, err
+		if isAppKind(err, apperr.KindNotFound) && remoteBankCode != "" {
+			t, err = s.Store.GetExternalOTCThreadByRemote(ctx, nil, remoteBankCode, threadID)
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := assertExternalOTCParty(p, t); err != nil {
 		return nil, err
 	}
-	its, err := s.Store.ListExternalOTCIterations(ctx, threadID)
+	// Iterations + contract are keyed by OUR local id, which may differ from
+	// the requested threadID when we resolved via remote ref.
+	its, err := s.Store.ListExternalOTCIterations(ctx, t.ID)
 	if err != nil {
 		return nil, err
 	}
 	res := &GetExternalOTCThreadResult{Thread: t, Iterations: its}
-	if c, err := s.Store.GetExternalOTCContractByThread(ctx, threadID); err == nil {
+	if c, err := s.Store.GetExternalOTCContractByThread(ctx, t.ID); err == nil {
 		res.Contract = c
 	}
 	return res, nil

--- a/services/trading/internal/service/external_otc_accept_saga.go
+++ b/services/trading/internal/service/external_otc_accept_saga.go
@@ -67,6 +67,12 @@ type externalOTCAcceptPayload struct {
 	Currency            string `json:"currency"`
 	SettlementDate      string `json:"settlement_date"`
 	SenderRoutingNumber int    `json:"sender_routing_number"`
+
+	// PartnerCoordinatesAccept is true when the partner's bank coordinates
+	// the accept 2PC (si-tx-proto / Banka-2). Then prepare_premium and
+	// commit_premium are no-ops — the partner debits our buyer via an
+	// inbound NEW_TX; we only notify accept + record the local contract.
+	PartnerCoordinatesAccept bool `json:"partner_coordinates_accept"`
 }
 
 var externalOTCAcceptNS = uuid.MustParse("c5ac0030-7e62-4f00-9c1d-1f24f2d8a401")
@@ -121,6 +127,11 @@ func (s *Service) acceptExternalOutgoing(ctx context.Context, thread *domain.Ext
 		Currency:            string(thread.Currency),
 		SettlementDate:      thread.SettlementDate.Format("2006-01-02"),
 		SenderRoutingNumber: s.Cfg.OwnRoutingNumber,
+		// si-tx-proto / Banka-2 partners coordinate the accept 2PC from the
+		// seller side, debiting our buyer via an inbound NEW_TX. Detect once
+		// here and persist in the saga state so the premium steps stay
+		// no-ops across retries.
+		PartnerCoordinatesAccept: s.PartnerOTC.AcceptCoordinatedByPartner(ctx, thread.RemoteBankCode),
 	}
 
 	ctx = saga.FaultsFromMetadata(ctx, s.Cfg.SagaDebugFaultInjection)
@@ -160,6 +171,12 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "prepare_premium",
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
+					if sc.State.PartnerCoordinatesAccept {
+						// Partner (si-tx-proto/Banka-2) debits our buyer via an
+						// inbound NEW_TX during notify_partner_accept; nothing to
+						// prepare on our side.
+						return nil
+					}
 					_, err := svc.InterbankPayer.PreparePayment(ctx, PrepareInterbankInput{
 						SenderRoutingNumber: sc.State.SenderRoutingNumber,
 						TransactionID:       sc.TransactionID,
@@ -172,6 +189,9 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
+					if sc.State.PartnerCoordinatesAccept {
+						return nil
+					}
 					return svc.InterbankPayer.RollbackPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID,
 						"external otc accept compensation")
@@ -209,6 +229,11 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "commit_premium",
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
+					if sc.State.PartnerCoordinatesAccept {
+						// Premium was settled by the partner-coordinated inbound
+						// NEW_TX; nothing to commit on our side.
+						return nil
+					}
 					_, err := svc.InterbankPayer.CommitPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID)
 					return err

--- a/services/trading/internal/service/external_otc_exercise_saga.go
+++ b/services/trading/internal/service/external_otc_exercise_saga.go
@@ -57,6 +57,16 @@ type externalOTCExercisePayload struct {
 	TotalAmount         string `json:"total_amount"`
 	Currency            string `json:"currency"`
 	SenderRoutingNumber int    `json:"sender_routing_number"`
+
+	// Banka-2 / si-tx-proto fields. When PartnerIsBanka2, exercise is a
+	// buyer-coordinated multi-asset 2PC: we send the partner the exercise
+	// NEW_TX (OPTION-account legs release the seller's shares + credit the
+	// strike) and deliver the shares to our buyer locally.
+	PartnerIsBanka2 bool   `json:"partner_is_banka2"`
+	BuyerUserRef    string `json:"buyer_user_ref"`
+	LocalUserID     string `json:"local_user_id"`
+	LocalUserKind   string `json:"local_user_kind"`
+	SecurityTicker  string `json:"security_ticker"`
 }
 
 var externalOTCExerciseNS = uuid.MustParse("c5e0f130-7e62-4f00-9c1d-1f24f2d8a402")
@@ -103,6 +113,11 @@ func (s *Service) exerciseExternalOutgoing(ctx context.Context, contract *domain
 		TotalAmount:         money.FormatAmount(total),
 		Currency:            string(contract.Currency),
 		SenderRoutingNumber: s.Cfg.OwnRoutingNumber,
+		PartnerIsBanka2:     s.PartnerOTC != nil && s.PartnerOTC.SpeaksBanka2Dialect(ctx, contract.RemoteBankCode),
+		BuyerUserRef:        contract.LocalUserID,
+		LocalUserID:         contract.LocalUserID,
+		LocalUserKind:       string(contract.LocalUserKind),
+		SecurityTicker:      contract.SecurityTicker,
 	}
 
 	ctx = saga.FaultsFromMetadata(ctx, s.Cfg.SagaDebugFaultInjection)
@@ -160,8 +175,26 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 			// with the accept saga.
 			{
 				Name: "notify_partner_exercise",
-				Forward: func(_ context.Context, _ *saga.Context[externalOTCExercisePayload]) error {
-					return nil
+				Forward: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
+					if !sc.State.PartnerIsBanka2 {
+						// Native partners observe our exercise via the strike-leg
+						// 2PC commit (step 3); no dedicated verb. No-op.
+						return nil
+					}
+					// Banka-2 / si-tx-proto: WE coordinate. Send the exercise NEW_TX
+					// (OPTION-account legs release the seller shares + credit the
+					// strike) and drive it to COMMIT. A partner NO surfaces as a
+					// permanent error -> compensate the local strike reservation.
+					return svc.PartnerOTC.ExerciseOption(ctx, PartnerExerciseInput{
+						RemoteBankCode: sc.State.RemoteBankCode,
+						ContractID:     sc.State.RemoteThreadID,
+						TransactionID:  sc.TransactionID,
+						BuyerUserRef:   sc.State.BuyerUserRef,
+						Quantity:       sc.State.Quantity,
+						StrikeTotal:    sc.State.TotalAmount,
+						Currency:       sc.State.Currency,
+						Ticker:         sc.State.SecurityTicker,
+					})
 				},
 				Compensate: nil,
 			},
@@ -171,6 +204,31 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 					_, err := svc.InterbankPayer.CommitPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID)
 					return err
+				},
+				Compensate: nil,
+			},
+			{
+				Name: "deliver_shares",
+				Forward: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
+					if !sc.State.PartnerIsBanka2 || sc.State.SecurityTicker == "" {
+						// Native exercise does not model local share delivery.
+						return nil
+					}
+					// Banka-2 exercise grants the buyer qty shares (PERSON STOCK
+					// +qty). Credit a local holding at strike cost. Idempotent via
+					// the (user, security, account) upsert under the saga txid retry.
+					sec, err := svc.Store.GetSecurityByTicker(ctx, sc.State.SecurityTicker, domain.SecurityStock)
+					if err != nil {
+						// Unknown ticker locally — strike already settled + contract
+						// exercised; skip delivery rather than strand the saga.
+						return nil
+					}
+					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+						_, aerr := svc.Store.ApplyBuyFill(ctx, tx, sc.State.LocalUserID,
+							sc.State.LocalUserKind, sec.ID, sc.State.LocalAccountID,
+							sc.State.Quantity, sc.State.StrikePrice)
+						return aerr
+					})
 				},
 				Compensate: nil,
 			},


### PR DESCRIPTION
Makes the **full cross-bank OTC lifecycle** interoperate with Banka-2's si-tx-proto dialect (our side hosts the buyer). Follow-up to #330 (presented routing), now merged.

## Inbound negotiation resolution
Resolve buyer-side (OUTGOING) threads by remote ref: add `remote_bank_code` to `GetExternalOTCThreadRequest`; the service falls back to `GetExternalOTCThreadByRemote` when the path id is the partner's, not ours. Fixes the 404 on the seller's counter `PUT /negotiations/{rn}/{id}`.

## Accept — settlement-model branch
Banka-2's *seller* bank coordinates the accept 2PC and debits our buyer via an inbound NEW_TX, so the buyer-side accept SAGA **skips** `prepare/commit_premium` (`PartnerOTC.AcceptCoordinatedByPartner`) — no double-debit. Inbound `handleBuyerAcceptNewTX` parses the buyer-side legs (PERSON MONAS premium debit + PERSON OPTION grant) and debits the buyer's bound account, recognizing the partner's presented routing (265) as ours.

## Exercise — buyer-coordinated
New outbound multi-asset exercise envelope (`banka2_exercise.go`): we form the four-posting OPTION/STOCK/PERSON/MONAS NEW_TX and drive NEW_TX → COMMIT. The exercise SAGA sends it for Banka-2 partners and delivers the shares to the buyer (`ApplyBuyFill` at strike cost). Native exercise unchanged.

## Supporting
`remote_account_number` is audit-only → allow empty for PERSON-addressed OTC settlements (proto `max_len`, service "18-or-empty", migration `0020`).

## Verification (live-built Banka-2 stack, through our app)
- **Accept**: buyer premium debited exactly once, local contract recorded.
- **Exercise**: buyer strike debited (−190), buyer receives the share (holding 10→11 @ strike cost), our contract + Banka-2's contract both flip to EXERCISED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)