### PR TITLE
feat(observability): structured log coverage across all services

### DIFF
--- a/pkg/auth/grpc.go
+++ b/pkg/auth/grpc.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -91,7 +92,11 @@ func MetadataInterceptor() grpc.UnaryServerInterceptor {
 		}
 		var sv int64
 		if raw := first(md, MDSessionVersion); raw != "" {
-			sv, _ = strconv.ParseInt(raw, 10, 64)
+			var perr error
+			sv, perr = strconv.ParseInt(raw, 10, 64)
+			if perr != nil {
+				slog.WarnContext(ctx, "malformed session-version metadata", "err", perr, "method", info.FullMethod, "user_id", userID)
+			}
 		}
 		p := Principal{
 			UserID:         userID,

--- a/pkg/bizmetric/bizmetric.go
+++ b/pkg/bizmetric/bizmetric.go
@@ -18,6 +18,7 @@ package bizmetric
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -35,18 +36,28 @@ var (
 func ensure() {
 	once.Do(func() {
 		m := otel.Meter("github.com/RAF-SI-2025/Banka-3-Backend/pkg/bizmetric")
-		payments, _ = m.Int64Counter(
+		var err error
+		payments, err = m.Int64Counter(
 			"banka_payments_total",
 			metric.WithDescription("Number of payment/transfer operations the bank service processed."),
 		)
-		trades, _ = m.Int64Counter(
+		if err != nil {
+			slog.Warn("bizmetric counter registration failed", "err", err, "metric", "banka_payments_total")
+		}
+		trades, err = m.Int64Counter(
 			"banka_trades_total",
 			metric.WithDescription("Number of securities trade fills settled by the trading service."),
 		)
-		logins, _ = m.Int64Counter(
+		if err != nil {
+			slog.Warn("bizmetric counter registration failed", "err", err, "metric", "banka_trades_total")
+		}
+		logins, err = m.Int64Counter(
 			"banka_user_logins_total",
 			metric.WithDescription("Number of login attempts handled by the user service, by outcome."),
 		)
+		if err != nil {
+			slog.Warn("bizmetric counter registration failed", "err", err, "metric", "banka_user_logins_total")
+		}
 	})
 }
 

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -17,7 +17,9 @@ package clock
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -159,9 +161,15 @@ func (c *Adjustable) loadFromRedis(ctx context.Context) {
 		// alone. Any other error means redis is flaky and the cache
 		// stays stale — fail-open is safer than resetting business
 		// time mid-flight.
+		if !errors.Is(err, redis.Nil) {
+			slog.WarnContext(ctx, "clock offset refresh failed, keeping cached offset", "err", err)
+		}
 		return
 	}
-	if d, perr := time.ParseDuration(s); perr == nil {
-		c.cachedNS.Store(int64(d))
+	d, perr := time.ParseDuration(s)
+	if perr != nil {
+		slog.WarnContext(ctx, "clock offset malformed in redis, keeping cached offset", "err", perr)
+		return
 	}
+	c.cachedNS.Store(int64(d))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"time"
@@ -76,6 +77,11 @@ func Bool(name string, def bool) bool {
 	switch v {
 	case "1", "true", "TRUE", "yes":
 		return true
+	case "0", "false", "FALSE", "no", "":
+		return false
 	}
+	// Unrecognized value falls back to false (documented behaviour).
+	// Value is intentionally not logged in case the var holds a secret.
+	slog.Warn("unrecognized bool env value, using false", "var", name)
 	return false
 }

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -104,11 +104,13 @@ func (s *SMTPSender) Send(ctx context.Context, m Message) error {
 	select {
 	case r := <-done:
 		if r.err != nil {
+			s.Log.ErrorContext(ctx, "smtp send failed", "err", r.err, "to", m.To, "subject", m.Subject)
 			return fmt.Errorf("smtp send: %w", r.err)
 		}
-		s.Log.Info("email sent", "to", m.To, "subject", m.Subject)
+		s.Log.InfoContext(ctx, "email sent", "to", m.To, "subject", m.Subject)
 		return nil
 	case <-dialCtx.Done():
+		s.Log.ErrorContext(ctx, "smtp send timed out", "err", dialCtx.Err(), "to", m.To, "subject", m.Subject)
 		return fmt.Errorf("smtp send: %w", dialCtx.Err())
 	}
 }

--- a/pkg/grpcserver/server.go
+++ b/pkg/grpcserver/server.go
@@ -126,11 +126,15 @@ func loggingInterceptor(log *slog.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		start := time.Now()
 		resp, err := handler(ctx, req)
-		log.LogAttrs(ctx, levelFor(err), "grpc",
+		attrs := []slog.Attr{
 			slog.String("method", info.FullMethod),
 			slog.Duration("dur", time.Since(start)),
 			slog.String("code", status.Code(err).String()),
-		)
+		}
+		if err != nil {
+			attrs = append(attrs, slog.String("err", err.Error()))
+		}
+		log.LogAttrs(ctx, levelFor(err), "grpc", attrs...)
 		return resp, err
 	}
 }
@@ -171,8 +175,11 @@ func levelFor(err error) slog.Level {
 		return slog.LevelInfo
 	}
 	switch status.Code(err) {
-	case codes.OK, codes.NotFound, codes.AlreadyExists, codes.InvalidArgument, codes.PermissionDenied, codes.Unauthenticated:
+	case codes.OK:
 		return slog.LevelInfo
+	// Expected client-class failures: visible as warnings, not errors.
+	case codes.NotFound, codes.AlreadyExists, codes.InvalidArgument, codes.PermissionDenied, codes.Unauthenticated, codes.FailedPrecondition:
+		return slog.LevelWarn
 	default:
 		return slog.LevelError
 	}

--- a/pkg/idempotency/cache.go
+++ b/pkg/idempotency/cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -59,10 +60,12 @@ func (c *Cache) Get(ctx context.Context, userID, idemKey string) (*Entry, error)
 		return nil, ErrMiss
 	}
 	if err != nil {
+		slog.WarnContext(ctx, "idempotency cache get failed", "err", err, "key", idemKey, "user_id", userID)
 		return nil, err
 	}
 	var e Entry
 	if err := json.Unmarshal(raw, &e); err != nil {
+		slog.WarnContext(ctx, "idempotency cache entry corrupt", "err", err, "key", idemKey, "user_id", userID)
 		return nil, err
 	}
 	return &e, nil
@@ -74,7 +77,12 @@ func (c *Cache) Get(ctx context.Context, userID, idemKey string) (*Entry, error)
 func (c *Cache) Set(ctx context.Context, userID, idemKey string, e *Entry) error {
 	raw, err := json.Marshal(e)
 	if err != nil {
+		slog.WarnContext(ctx, "idempotency entry marshal failed", "err", err, "key", idemKey, "user_id", userID)
 		return err
 	}
-	return c.R.SetNX(ctx, cacheKey(userID, idemKey), raw, c.TTL).Err()
+	if err := c.R.SetNX(ctx, cacheKey(userID, idemKey), raw, c.TTL).Err(); err != nil {
+		slog.WarnContext(ctx, "idempotency cache set failed", "err", err, "key", idemKey, "user_id", userID)
+		return err
+	}
+	return nil
 }

--- a/pkg/otelinit/otelinit.go
+++ b/pkg/otelinit/otelinit.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -103,6 +104,7 @@ func Init(ctx context.Context, serviceName string) (*Provider, error) {
 	if os.Getenv("OTEL_SDK_DISABLED") != "true" {
 		exp, err := newTraceExporter(ctx, endpoint)
 		if err != nil {
+			slog.ErrorContext(ctx, "otel trace exporter init failed", "err", err, "endpoint", endpoint)
 			return nil, fmt.Errorf("otel trace exporter: %w", err)
 		}
 		tpOpts = append(tpOpts,
@@ -127,6 +129,7 @@ func Init(ctx context.Context, serviceName string) (*Provider, error) {
 	reg := prometheus.NewRegistry()
 	promExp, err := otelprom.New(otelprom.WithRegisterer(reg))
 	if err != nil {
+		slog.ErrorContext(ctx, "otel prometheus exporter init failed", "err", err)
 		return nil, fmt.Errorf("otel prom exporter: %w", err)
 	}
 	mp := sdkmetric.NewMeterProvider(
@@ -228,6 +231,7 @@ func headSampler() sdktrace.Sampler {
 	}
 	ratio, err := strconv.ParseFloat(arg, 64)
 	if err != nil || ratio < 0 || ratio > 1 {
+		slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, sampling everything", "err", err, "value", arg)
 		return sdktrace.ParentBased(sdktrace.AlwaysSample())
 	}
 	return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -50,6 +50,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/exaring/otelpgx"
@@ -81,12 +82,16 @@ func Open(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
+		// err may quote the DSN, but pgx redacts the password; the DSN
+		// itself is never logged here.
+		slog.ErrorContext(ctx, "postgres pool open failed", "err", err)
 		return nil, fmt.Errorf("new pool: %w", err)
 	}
 
 	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := pool.Ping(pingCtx); err != nil {
+		slog.ErrorContext(ctx, "postgres ping failed", "err", err)
 		pool.Close()
 		return nil, fmt.Errorf("ping: %w", err)
 	}

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -7,6 +7,7 @@ package probes
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -45,7 +46,10 @@ func (s *Server) Register(name string, c Check) {
 
 // MarkReady flips /readyz to start running checks. Until called, /readyz
 // returns 503.
-func (s *Server) MarkReady() { s.ready.Store(true) }
+func (s *Server) MarkReady() {
+	s.ready.Store(true)
+	slog.Info("probes marked ready", "addr", s.addr)
+}
 
 // ListenAndServe blocks until ctx is cancelled or the server errors.
 func (s *Server) ListenAndServe(ctx context.Context) error {
@@ -68,7 +72,9 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = s.srv.Shutdown(shutdownCtx)
+		if err := s.srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("probe server shutdown failed", "err", err, "addr", s.addr)
+		}
 		return nil
 	case err := <-errCh:
 		return err
@@ -90,6 +96,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		err := c.check(ctx)
 		cancel()
 		if err != nil {
+			slog.WarnContext(r.Context(), "readiness check failed", "err", err, "check", c.name)
 			http.Error(w, c.name+": "+err.Error(), http.StatusServiceUnavailable)
 			return
 		}

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -4,6 +4,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/extra/redisotel/v9"
@@ -24,15 +25,15 @@ func Open(ctx context.Context, addr, password string) (*redis.Client, error) {
 	// request. Failure to install the hook is non-fatal — log only,
 	// keep serving; redis still works, just without trace correlation.
 	if err := redisotel.InstrumentTracing(c); err != nil {
-		// No logger here (pkg/redis is library-level). Swallow — the
-		// service main has the option to wire a logger later if this
-		// turns out to be useful to surface.
-		_ = err
+		slog.WarnContext(ctx, "redis otel instrumentation failed", "err", err, "addr", addr)
 	}
 	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if err := c.Ping(pingCtx).Err(); err != nil {
-		_ = c.Close()
+		slog.ErrorContext(ctx, "redis ping failed", "err", err, "addr", addr)
+		if cerr := c.Close(); cerr != nil {
+			slog.WarnContext(ctx, "redis close after failed ping failed", "err", cerr, "addr", addr)
+		}
 		return nil, fmt.Errorf("ping: %w", err)
 	}
 	return c, nil

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -5,6 +5,7 @@ package shutdown
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -13,5 +14,28 @@ import (
 // Context returns a context cancelled on the first SIGINT or SIGTERM. The
 // returned cancel must be called by the caller (use defer cancel()).
 func Context() (context.Context, context.CancelFunc) {
-	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+
+	// Side channel purely for logging which signal arrived; the cancel
+	// semantics above are untouched. Both registrations receive the
+	// signal, so this never steals it from NotifyContext.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		defer signal.Stop(sigCh)
+		select {
+		case sig := <-sigCh:
+			slog.Info("shutdown signal received", "signal", sig.String())
+		case <-ctx.Done():
+			// Cancelled — drain a signal that raced the cancellation so
+			// it is still logged, then stop listening.
+			select {
+			case sig := <-sigCh:
+				slog.Info("shutdown signal received", "signal", sig.String())
+			default:
+			}
+		}
+	}()
+
+	return ctx, cancel
 }

--- a/pkg/verification/verification.go
+++ b/pkg/verification/verification.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"strconv"
 	"time"
@@ -204,8 +205,12 @@ func (c *Cache) Issue(ctx context.Context, userID string, kind ActionKind) (stri
 	// issuance — the web verification flow doesn't depend on it, and
 	// ListPending prunes stale members lazily anyway.
 	idx := userKey(userID)
-	_ = c.R.ZAdd(ctx, idx, redis.Z{Score: float64(expiresAt.Unix()), Member: id}).Err()
-	_ = c.R.Expire(ctx, idx, CodeTTL).Err()
+	if err := c.R.ZAdd(ctx, idx, redis.Z{Score: float64(expiresAt.Unix()), Member: id}).Err(); err != nil {
+		slog.WarnContext(ctx, "verification pending-index add failed", "err", err, "id", id, "user_id", userID)
+	}
+	if err := c.R.Expire(ctx, idx, CodeTTL).Err(); err != nil {
+		slog.WarnContext(ctx, "verification pending-index expire failed", "err", err, "user_id", userID)
+	}
 	return id, code, expiresAt, nil
 }
 
@@ -216,7 +221,9 @@ func (c *Cache) ListPending(ctx context.Context, userID string) ([]Pending, erro
 	idx := userKey(userID)
 	now := time.Now().Unix()
 	// Drop index members whose expiry score is in the past.
-	_ = c.R.ZRemRangeByScore(ctx, idx, "0", strconv.FormatInt(now-1, 10)).Err()
+	if err := c.R.ZRemRangeByScore(ctx, idx, "0", strconv.FormatInt(now-1, 10)).Err(); err != nil {
+		slog.WarnContext(ctx, "verification pending-index prune failed", "err", err, "user_id", userID)
+	}
 
 	zs, err := c.R.ZRangeByScoreWithScores(ctx, idx, &redis.ZRangeBy{
 		Min: strconv.FormatInt(now, 10),
@@ -235,14 +242,17 @@ func (c *Cache) ListPending(ctx context.Context, userID string) ([]Pending, erro
 		raw, gerr := c.R.Get(ctx, key(id)).Bytes()
 		if errors.Is(gerr, redis.Nil) {
 			// Consumed or expired between the index write and now.
-			_ = c.R.ZRem(ctx, idx, id).Err()
+			if rerr := c.R.ZRem(ctx, idx, id).Err(); rerr != nil {
+				slog.WarnContext(ctx, "verification stale index member remove failed", "err", rerr, "id", id, "user_id", userID)
+			}
 			continue
 		}
 		if gerr != nil {
 			return nil, gerr
 		}
 		var rec record
-		if json.Unmarshal(raw, &rec) != nil {
+		if uerr := json.Unmarshal(raw, &rec); uerr != nil {
+			slog.WarnContext(ctx, "verification record corrupt, skipping", "err", uerr, "id", id, "user_id", userID)
 			continue
 		}
 		out = append(out, Pending{
@@ -278,12 +288,16 @@ func (c *Cache) Consume(ctx context.Context, id, code string, expectedKind Actio
 	}
 	if rec.Code == code {
 		// One-shot: a successful consume retires the record.
-		_ = c.R.Del(ctx, key(id)).Err()
+		if derr := c.R.Del(ctx, key(id)).Err(); derr != nil {
+			slog.WarnContext(ctx, "verification consumed record delete failed", "err", derr, "id", id)
+		}
 		return nil
 	}
 	rec.Attempts++
 	if rec.Attempts >= MaxAttempts {
-		_ = c.R.Del(ctx, key(id)).Err()
+		if derr := c.R.Del(ctx, key(id)).Err(); derr != nil {
+			slog.WarnContext(ctx, "verification exhausted record delete failed", "err", derr, "id", id)
+		}
 		return ErrTooMany
 	}
 	// Persist incremented attempts under the remaining TTL — the spec's
@@ -291,6 +305,9 @@ func (c *Cache) Consume(ctx context.Context, id, code string, expectedKind Actio
 	// expiry per attempt.
 	ttl, terr := c.R.TTL(ctx, key(id)).Result()
 	if terr != nil || ttl <= 0 {
+		if terr != nil {
+			slog.WarnContext(ctx, "verification ttl lookup failed, using full ttl", "err", terr, "id", id)
+		}
 		ttl = CodeTTL
 	}
 	updated, err := json.Marshal(rec)
@@ -331,6 +348,9 @@ func (c *Cache) Approve(ctx context.Context, userID, id string) error {
 	rec.Approved = true
 	ttl, terr := c.R.TTL(ctx, key(id)).Result()
 	if terr != nil || ttl <= 0 {
+		if terr != nil {
+			slog.WarnContext(ctx, "verification ttl lookup failed, using full ttl", "err", terr, "id", id)
+		}
 		ttl = CodeTTL
 	}
 	updated, err := json.Marshal(rec)
@@ -368,7 +388,9 @@ func (c *Cache) ConsumeApproved(ctx context.Context, userID, id string, expected
 		return ErrNotApproved
 	}
 	// One-shot: a successful quick-approve consume retires the record.
-	_ = c.R.Del(ctx, key(id)).Err()
+	if derr := c.R.Del(ctx, key(id)).Err(); derr != nil {
+		slog.WarnContext(ctx, "verification approved record delete failed", "err", derr, "id", id, "user_id", userID)
+	}
 	return nil
 }
 

--- a/services/bank/cmd/bank/main.go
+++ b/services/bank/cmd/bank/main.go
@@ -9,11 +9,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/app"
 )
 
 func main() {
 	if err := app.Run(); err != nil {
+		// Structured record first (k8s log pipelines key off these),
+		// stderr line second so the failure is visible even when stdout
+		// is redirected or the JSON pipeline is misconfigured.
+		logger.New("bank").Error("bank service exited", "err", err)
 		fmt.Fprintf(os.Stderr, "bank: %v\n", err)
 		os.Exit(1)
 	}

--- a/services/bank/internal/app/app.go
+++ b/services/bank/internal/app/app.go
@@ -42,7 +42,11 @@ func Run() error {
 	if err != nil {
 		return fmt.Errorf("otelinit: %w", err)
 	}
-	defer func() { _ = prov.Shutdown(context.Background()) }()
+	defer func() {
+		if err := prov.Shutdown(context.Background()); err != nil {
+			log.Warn("otel provider shutdown failed", "err", err)
+		}
+	}()
 
 	// OpenPair dials the primary (DATABASE_URL → banka-pg-pooler-rw) and,
 	// when set, a hot-standby read pool (DATABASE_READ_URL →

--- a/services/bank/internal/server/interbank_2pc.go
+++ b/services/bank/internal/server/interbank_2pc.go
@@ -7,16 +7,19 @@ import (
 	"context"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func (s *Server) PreparePayment(ctx context.Context, in *bankpb.PreparePaymentRequest) (*bankpb.PreparePaymentResponse, error) {
+	log := logger.From(ctx)
+	dir := interbankDirectionFromProto(in.GetDirection())
 	res, err := s.Svc.PreparePayment(ctx, service.PreparePaymentInput{
 		SenderRoutingNumber: int(in.GetSenderRoutingNumber()),
 		TransactionID:       in.GetTransactionId(),
-		Direction:           interbankDirectionFromProto(in.GetDirection()),
+		Direction:           dir,
 		LocalAccountNumber:  in.GetLocalAccountNumber(),
 		RemoteAccountNumber: in.GetRemoteAccountNumber(),
 		Currency:            currencyFromProto(in.GetCurrency()),
@@ -25,8 +28,10 @@ func (s *Server) PreparePayment(ctx context.Context, in *bankpb.PreparePaymentRe
 		Purpose:             in.GetPurpose(),
 	})
 	if err != nil {
+		log.ErrorContext(ctx, "prepare payment failed", "err", err, "transaction_id", in.GetTransactionId(), "sender_routing", in.GetSenderRoutingNumber(), "direction", string(dir))
 		return nil, err
 	}
+	log.InfoContext(ctx, "interbank payment prepared", "transaction_id", res.TransactionID, "reservation_id", res.ReservationID, "direction", string(dir), "sender_routing", in.GetSenderRoutingNumber(), "status", string(res.Status))
 	return &bankpb.PreparePaymentResponse{
 		TransactionId: res.TransactionID,
 		Status:        interbankTxStatusToProto(res.Status),
@@ -36,10 +41,13 @@ func (s *Server) PreparePayment(ctx context.Context, in *bankpb.PreparePaymentRe
 }
 
 func (s *Server) CommitPayment(ctx context.Context, in *bankpb.CommitPaymentRequest) (*bankpb.CommitPaymentResponse, error) {
+	log := logger.From(ctx)
 	res, err := s.Svc.CommitPayment(ctx, int(in.GetSenderRoutingNumber()), in.GetTransactionId())
 	if err != nil {
+		log.ErrorContext(ctx, "commit payment failed", "err", err, "transaction_id", in.GetTransactionId(), "sender_routing", in.GetSenderRoutingNumber())
 		return nil, err
 	}
+	log.InfoContext(ctx, "interbank payment committed", "transaction_id", res.TransactionID, "op_id", res.OpID, "sender_routing", in.GetSenderRoutingNumber(), "status", string(res.Status))
 	return &bankpb.CommitPaymentResponse{
 		TransactionId: res.TransactionID,
 		Status:        interbankTxStatusToProto(res.Status),
@@ -49,10 +57,13 @@ func (s *Server) CommitPayment(ctx context.Context, in *bankpb.CommitPaymentRequ
 }
 
 func (s *Server) RollbackPayment(ctx context.Context, in *bankpb.RollbackPaymentRequest) (*bankpb.RollbackPaymentResponse, error) {
+	log := logger.From(ctx)
 	res, err := s.Svc.RollbackPayment(ctx, int(in.GetSenderRoutingNumber()), in.GetTransactionId(), in.GetReason())
 	if err != nil {
+		log.ErrorContext(ctx, "rollback payment failed", "err", err, "transaction_id", in.GetTransactionId(), "sender_routing", in.GetSenderRoutingNumber(), "reason", in.GetReason())
 		return nil, err
 	}
+	log.InfoContext(ctx, "interbank payment rolled back", "transaction_id", res.TransactionID, "sender_routing", in.GetSenderRoutingNumber(), "status", string(res.Status), "reason", in.GetReason())
 	return &bankpb.RollbackPaymentResponse{
 		TransactionId: res.TransactionID,
 		Status:        interbankTxStatusToProto(res.Status),
@@ -61,14 +72,16 @@ func (s *Server) RollbackPayment(ctx context.Context, in *bankpb.RollbackPayment
 }
 
 func (s *Server) RecordInboundMessage(ctx context.Context, in *bankpb.RecordInboundMessageRequest) (*bankpb.RecordInboundMessageResponse, error) {
+	mt := interbankMessageTypeFromProto(in.GetMessageType())
 	if err := s.Svc.RecordInboundMessage(ctx, service.RecordInboundMessageInput{
 		SenderRoutingNumber: int(in.GetSenderRoutingNumber()),
 		IdempotenceKey:      in.GetIdempotenceKey(),
-		MessageType:         interbankMessageTypeFromProto(in.GetMessageType()),
+		MessageType:         mt,
 		TransactionID:       in.GetTransactionId(),
 		ResponseStatus:      int(in.GetResponseStatus()),
 		ResponseBody:        in.GetResponseBody(),
 	}); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "record inbound message failed", "err", err, "transaction_id", in.GetTransactionId(), "sender_routing", in.GetSenderRoutingNumber(), "idempotence_key", in.GetIdempotenceKey(), "message_type", string(mt))
 		return nil, err
 	}
 	return &bankpb.RecordInboundMessageResponse{RecordedAt: timestamppb.Now()}, nil
@@ -77,11 +90,13 @@ func (s *Server) RecordInboundMessage(ctx context.Context, in *bankpb.RecordInbo
 func (s *Server) GetInboundMessage(ctx context.Context, in *bankpb.GetInboundMessageRequest) (*bankpb.GetInboundMessageResponse, error) {
 	row, err := s.Svc.GetInboundMessage(ctx, int(in.GetSenderRoutingNumber()), in.GetIdempotenceKey())
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "get inbound message failed", "err", err, "sender_routing", in.GetSenderRoutingNumber(), "idempotence_key", in.GetIdempotenceKey())
 		return nil, err
 	}
 	if row == nil {
 		return &bankpb.GetInboundMessageResponse{Found: false}, nil
 	}
+	logger.From(ctx).WarnContext(ctx, "interbank message replay detected", "transaction_id", row.TransactionID, "sender_routing", in.GetSenderRoutingNumber(), "idempotence_key", in.GetIdempotenceKey(), "message_type", string(row.MessageType))
 	return &bankpb.GetInboundMessageResponse{
 		Found:          true,
 		MessageType:    interbankMessageTypeToProto(row.MessageType),

--- a/services/bank/internal/server/interbank_supervisor.go
+++ b/services/bank/internal/server/interbank_supervisor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -88,16 +89,20 @@ func (s *Server) ListInterbankBlacklist(ctx context.Context, in *bankpb.ListInte
 func (s *Server) BlockInterbankPartner(ctx context.Context, in *bankpb.BlockInterbankPartnerRequest) (*bankpb.InterbankBlacklistEntry, error) {
 	e, err := s.Svc.BlockInterbankPartner(ctx, int(in.GetSenderRoutingNumber()), in.GetReason())
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "block interbank partner failed", "err", err, "sender_routing", in.GetSenderRoutingNumber(), "reason", in.GetReason())
 		return nil, err
 	}
+	logger.From(ctx).InfoContext(ctx, "interbank partner blocked", "sender_routing", in.GetSenderRoutingNumber(), "reason", in.GetReason())
 	return blacklistEntryToProto(e), nil
 }
 
 func (s *Server) UnblockInterbankPartner(ctx context.Context, in *bankpb.UnblockInterbankPartnerRequest) (*bankpb.InterbankBlacklistEntry, error) {
 	e, err := s.Svc.UnblockInterbankPartner(ctx, int(in.GetSenderRoutingNumber()))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "unblock interbank partner failed", "err", err, "sender_routing", in.GetSenderRoutingNumber())
 		return nil, err
 	}
+	logger.From(ctx).InfoContext(ctx, "interbank partner unblocked", "sender_routing", in.GetSenderRoutingNumber())
 	return blacklistEntryToProto(e), nil
 }
 

--- a/services/bank/internal/server/loans.go
+++ b/services/bank/internal/server/loans.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
@@ -161,9 +162,18 @@ func loanToProto(l *domain.Loan) *bankpb.Loan {
 	// effective_rate = base + offset + margin (annual %).
 	effective := ""
 	if l.BaseRate != "" {
-		base, _ := money.Parse(l.BaseRate)
-		offset, _ := money.Parse(l.CurrentOffset)
-		margin, _ := money.Parse(l.Margin)
+		base, err := money.Parse(l.BaseRate)
+		if err != nil {
+			slog.Warn("parse loan base rate failed", "err", err, "loan_id", l.ID)
+		}
+		offset, err := money.Parse(l.CurrentOffset)
+		if err != nil {
+			slog.Warn("parse loan rate offset failed", "err", err, "loan_id", l.ID)
+		}
+		margin, err := money.Parse(l.Margin)
+		if err != nil {
+			slog.Warn("parse loan margin failed", "err", err, "loan_id", l.ID)
+		}
 		effective = money.Format(money.Add(money.Add(base, offset), margin), 4)
 	}
 	out := &bankpb.Loan{

--- a/services/bank/internal/service/accounts.go
+++ b/services/bank/internal/service/accounts.go
@@ -39,11 +39,15 @@ func (s *Service) CreateAccount(ctx context.Context, in CreateAccountInput) (*do
 		return nil, err
 	}
 	if err := s.validateCreateAccount(in); err != nil {
+		s.log().WarnContext(ctx, "create account validation failed",
+			"err", err, "owner_client_id", in.OwnerClientID, "kind", in.Kind, "currency", in.Currency)
 		return nil, err
 	}
 
 	number, err := account.Generate(s.Cfg.BankCode, s.Cfg.Branch, kindAndSubtypeToAccountType(in.Kind, in.Subtype))
 	if err != nil {
+		s.log().ErrorContext(ctx, "create account: generate account number failed",
+			"err", err, "owner_client_id", in.OwnerClientID, "kind", in.Kind)
 		return nil, apperr.Internal("generate account number", err)
 	}
 
@@ -77,8 +81,13 @@ func (s *Service) CreateAccount(ctx context.Context, in CreateAccountInput) (*do
 	}
 	created, err := s.Store.CreateAccount(ctx, a)
 	if err != nil {
+		s.log().ErrorContext(ctx, "create account failed",
+			"err", err, "owner_client_id", in.OwnerClientID, "kind", in.Kind, "currency", in.Currency, "number", number)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "account created",
+		"account_id", created.ID, "number", created.Number, "owner_client_id", created.OwnerClientID,
+		"kind", created.Kind, "currency", created.Currency)
 
 	// Account-opened email (spec E2E "Sistem kreira račun i klijent
 	// dobija email obaveštenje"). Best-effort: failures must not roll
@@ -96,6 +105,8 @@ func (s *Service) CreateAccount(ctx context.Context, in CreateAccountInput) (*do
 			Name:      defaultCompanionCardName(in.Kind),
 			CardLimit: created.DailyLimit,
 		}); err != nil {
+			s.log().ErrorContext(ctx, "create account: companion card create failed",
+				"err", err, "account_id", created.ID, "number", created.Number)
 			return nil, err
 		}
 	}
@@ -177,6 +188,7 @@ func (s *Service) GetAccount(ctx context.Context, id string) (*domain.Account, e
 		return nil, err
 	}
 	if !canSeeAccount(p, a) {
+		s.log().WarnContext(ctx, "get account denied", "account_id", id, "user_id", p.UserID)
 		return nil, apperr.PermissionDenied("nedovoljne permisije")
 	}
 	return a, nil
@@ -195,6 +207,8 @@ func (s *Service) ListAccounts(ctx context.Context, f domain.AccountFilter, page
 		// owner_client_id explicitly and it doesn't match, that's a
 		// permission error rather than a silent re-scope.
 		if f.OwnerClientID != "" && f.OwnerClientID != p.UserID {
+			s.log().WarnContext(ctx, "list accounts denied: owner filter mismatch",
+				"owner_client_id", f.OwnerClientID, "user_id", p.UserID)
 			return nil, 0, apperr.PermissionDenied("nedovoljne permisije")
 		}
 		f.OwnerClientID = p.UserID
@@ -236,9 +250,16 @@ func (s *Service) UpdateAccountLimits(ctx context.Context, id, daily, monthly st
 		return nil, apperr.Unauthenticated("not authenticated")
 	}
 	if current.OwnerClientID != p.UserID {
+		s.log().WarnContext(ctx, "update account limits denied: not owner", "account_id", id, "user_id", p.UserID)
 		return nil, apperr.PermissionDenied("samo vlasnik računa može menjati limit")
 	}
-	return s.Store.UpdateAccountLimits(ctx, id, strings.TrimSpace(daily), strings.TrimSpace(monthly))
+	updated, err := s.Store.UpdateAccountLimits(ctx, id, strings.TrimSpace(daily), strings.TrimSpace(monthly))
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "account limits updated",
+		"account_id", id, "daily_limit", updated.DailyLimit, "monthly_limit", updated.MonthlyLimit)
+	return updated, nil
 }
 
 // UpdateAccountName implements the spec p.20 "Promena naziva računa"
@@ -263,6 +284,7 @@ func (s *Service) UpdateAccountName(ctx context.Context, id, name string) (*doma
 	isOwner := current.OwnerClientID == p.UserID
 	hasEmployeePerm := permissions.Has(p.Permissions, permissions.AccountWrite)
 	if !isOwner && !hasEmployeePerm {
+		s.log().WarnContext(ctx, "update account name denied: not owner", "account_id", id, "user_id", p.UserID)
 		return nil, apperr.PermissionDenied("samo vlasnik računa može menjati naziv")
 	}
 	if name == current.Name {
@@ -274,10 +296,17 @@ func (s *Service) UpdateAccountName(ctx context.Context, id, name string) (*doma
 			return nil, err
 		}
 		if taken {
+			s.log().WarnContext(ctx, "update account name conflict",
+				"account_id", id, "owner_client_id", current.OwnerClientID)
 			return nil, apperr.Conflict("već imate račun sa tim nazivom")
 		}
 	}
-	return s.Store.UpdateAccountName(ctx, id, name)
+	updated, err := s.Store.UpdateAccountName(ctx, id, name)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "account name updated", "account_id", id)
+	return updated, nil
 }
 
 func (s *Service) SetAccountStatus(ctx context.Context, id string, status domain.AccountStatus) (*domain.Account, error) {
@@ -287,7 +316,12 @@ func (s *Service) SetAccountStatus(ctx context.Context, id string, status domain
 	if status != domain.AccountActive && status != domain.AccountInactive {
 		return nil, apperr.Validation("status must be active or inactive")
 	}
-	return s.Store.SetAccountStatus(ctx, id, status)
+	updated, err := s.Store.SetAccountStatus(ctx, id, status)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "account status updated", "account_id", id, "status", status)
+	return updated, nil
 }
 
 // GetSystemAccount returns the bank's house account for currency.
@@ -318,6 +352,7 @@ func (s *Service) CreateFundAccount(ctx context.Context, name string, currency d
 	}
 	number, err := account.Generate(s.Cfg.BankCode, s.Cfg.Branch, account.TypeFund)
 	if err != nil {
+		s.log().ErrorContext(ctx, "create fund account: generate account number failed", "err", err)
 		return nil, apperr.Internal("generate account number", err)
 	}
 	display := strings.TrimSpace(name)
@@ -341,7 +376,13 @@ func (s *Service) CreateFundAccount(ctx context.Context, name string, currency d
 		DailySpent:          "0",
 		MonthlySpent:        "0",
 	}
-	return s.Store.CreateAccount(ctx, a)
+	created, err := s.Store.CreateAccount(ctx, a)
+	if err != nil {
+		s.log().ErrorContext(ctx, "create fund account failed", "err", err, "number", number, "name", display)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "fund account created", "account_id", created.ID, "number", created.Number)
+	return created, nil
 }
 
 // EnsureSystemAccounts is called once at boot. For each supported
@@ -359,10 +400,12 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 		if _, err := s.Store.GetSystemAccount(ctx, c); err == nil {
 			continue
 		} else if !isNotFound(err) {
+			s.log().ErrorContext(ctx, "ensure system accounts: get system account failed", "err", err, "currency", c)
 			return err
 		}
 		number, err := account.Generate(s.Cfg.BankCode, s.Cfg.Branch, account.TypeSystem)
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: generate account number failed", "err", err, "currency", c)
 			return err
 		}
 		_, err = s.Store.CreateAccount(ctx, &domain.Account{
@@ -383,9 +426,11 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 			MonthlySpent:        "0",
 		})
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: create system account failed",
+				"err", err, "currency", c, "number", number)
 			return err
 		}
-		s.Log.Info("seeded system account", "currency", c, "number", number)
+		s.log().InfoContext(ctx, "seeded system account", "currency", c, "number", number)
 	}
 
 	// Spec p.62 capital-gains-tax destination. The state has only an
@@ -394,10 +439,12 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 	// it doesn't muddy the menjačnica's bank-house lookups.
 	if _, err := s.Store.GetStateTaxAccount(ctx); err != nil {
 		if !isNotFound(err) {
+			s.log().ErrorContext(ctx, "ensure system accounts: get state tax account failed", "err", err)
 			return err
 		}
 		number, err := account.Generate(s.Cfg.BankCode, s.Cfg.Branch, account.TypeSystem)
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: generate state tax account number failed", "err", err)
 			return err
 		}
 		_, err = s.Store.CreateAccount(ctx, &domain.Account{
@@ -418,9 +465,10 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 			MonthlySpent:        "0",
 		})
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: create state tax account failed", "err", err, "number", number)
 			return err
 		}
-		s.Log.Info("seeded state tax account", "number", number)
+		s.log().InfoContext(ctx, "seeded state tax account", "number", number)
 	}
 
 	// Spec p.42 forex book — one bank-owned account per supported
@@ -432,10 +480,12 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 		if _, err := s.Store.GetForexBookAccount(ctx, c); err == nil {
 			continue
 		} else if !isNotFound(err) {
+			s.log().ErrorContext(ctx, "ensure system accounts: get forex book account failed", "err", err, "currency", c)
 			return err
 		}
 		number, err := account.Generate(s.Cfg.BankCode, s.Cfg.Branch, account.TypeSystem)
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: generate forex book account number failed", "err", err, "currency", c)
 			return err
 		}
 		_, err = s.Store.CreateAccount(ctx, &domain.Account{
@@ -456,9 +506,11 @@ func (s *Service) EnsureSystemAccounts(ctx context.Context) error {
 			MonthlySpent:        "0",
 		})
 		if err != nil {
+			s.log().ErrorContext(ctx, "ensure system accounts: create forex book account failed",
+				"err", err, "currency", c, "number", number)
 			return err
 		}
-		s.Log.Info("seeded forex book account", "currency", c, "number", number)
+		s.log().InfoContext(ctx, "seeded forex book account", "currency", c, "number", number)
 	}
 	return nil
 }

--- a/services/bank/internal/service/authorized_persons.go
+++ b/services/bank/internal/service/authorized_persons.go
@@ -33,12 +33,14 @@ func (s *Service) CreateAuthorizedPerson(ctx context.Context, in CreateAuthorize
 		return nil, err
 	}
 	if _, err := s.Store.GetCompanyByID(ctx, in.CompanyID); err != nil {
+		s.log().WarnContext(ctx, "create authorized person: company lookup failed", "err", err, "company_id", in.CompanyID)
 		return nil, err
 	}
 	if err := s.validateAP(in); err != nil {
+		s.log().WarnContext(ctx, "create authorized person validation failed", "err", err, "company_id", in.CompanyID)
 		return nil, err
 	}
-	return s.Store.CreateAuthorizedPerson(ctx, &domain.AuthorizedPerson{
+	created, err := s.Store.CreateAuthorizedPerson(ctx, &domain.AuthorizedPerson{
 		CompanyID:   in.CompanyID,
 		FirstName:   strings.TrimSpace(in.FirstName),
 		LastName:    strings.TrimSpace(in.LastName),
@@ -48,6 +50,11 @@ func (s *Service) CreateAuthorizedPerson(ctx context.Context, in CreateAuthorize
 		Phone:       strings.TrimSpace(in.Phone),
 		Address:     strings.TrimSpace(in.Address),
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "authorized person created", "authorized_person_id", created.ID, "company_id", in.CompanyID)
+	return created, nil
 }
 
 func (s *Service) ListAuthorizedPersons(ctx context.Context, companyID string) ([]*domain.AuthorizedPerson, error) {

--- a/services/bank/internal/service/cards.go
+++ b/services/bank/internal/service/cards.go
@@ -53,6 +53,8 @@ func (s *Service) CreateCard(ctx context.Context, in CreateCardInput) (*domain.C
 	// employees with card.write can act on any.
 	if p.UserKind == auth.KindClient {
 		if a.OwnerClientID != p.UserID {
+			s.log().WarnContext(ctx, "create card denied: account not owned by caller",
+				"account_id", in.AccountID, "user_id", p.UserID)
 			return nil, "", apperr.PermissionDenied("nedovoljne permisije")
 		}
 	} else if err := s.requirePermission(ctx, permissions.CardWrite); err != nil {
@@ -60,6 +62,8 @@ func (s *Service) CreateCard(ctx context.Context, in CreateCardInput) (*domain.C
 	}
 
 	if err := s.enforceCardLimits(ctx, a, in.AuthorizedPersonID); err != nil {
+		s.log().WarnContext(ctx, "create card limit check failed",
+			"err", err, "account_id", a.ID, "authorized_person_id", in.AuthorizedPersonID)
 		return nil, "", err
 	}
 
@@ -69,22 +73,30 @@ func (s *Service) CreateCard(ctx context.Context, in CreateCardInput) (*domain.C
 	}
 	number, cvvPlain, err := generateCardCredentials(brand)
 	if err != nil {
+		s.log().ErrorContext(ctx, "create card: generate credentials failed",
+			"err", err, "account_id", a.ID, "brand", brand)
 		return nil, "", err
 	}
 	cvvHash, err := cvv.Hash(cvvPlain, s.Cfg.CVVPepper)
 	if err != nil {
+		s.log().ErrorContext(ctx, "create card: hash cvv failed", "err", err, "account_id", a.ID)
 		return nil, "", apperr.Internal("hash cvv", err)
 	}
 
 	limit := strings.TrimSpace(in.CardLimit)
 	if limit == "" {
+		s.log().WarnContext(ctx, "create card validation failed: missing card limit", "account_id", a.ID)
 		return nil, "", apperr.Validation("limit kartice je obavezan i mora biti veći od 0")
 	}
 	limitRat, err := money.Parse(limit)
 	if err != nil {
+		s.log().WarnContext(ctx, "create card validation failed: bad card limit",
+			"err", err, "account_id", a.ID, "card_limit", limit)
 		return nil, "", apperr.Validation("limit kartice nije validan iznos")
 	}
 	if !money.IsPositive(limitRat) {
+		s.log().WarnContext(ctx, "create card validation failed: non-positive card limit",
+			"account_id", a.ID, "card_limit", limit)
 		return nil, "", apperr.Validation("limit kartice mora biti veći od 0")
 	}
 	name := strings.TrimSpace(in.Name)
@@ -104,8 +116,12 @@ func (s *Service) CreateCard(ctx context.Context, in CreateCardInput) (*domain.C
 		Status:             domain.CardActive,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "create card failed", "err", err, "account_id", a.ID, "brand", brand)
 		return nil, "", err
 	}
+	s.log().InfoContext(ctx, "card issued",
+		"card_id", c.ID, "account_id", a.ID, "brand", brand,
+		"authorized_person_id", c.AuthorizedPersonID)
 	return c, cvvPlain, nil
 }
 
@@ -178,6 +194,8 @@ func (s *Service) ListCards(ctx context.Context, accountID string) ([]*domain.Ca
 		}
 		if p.UserKind == auth.KindClient {
 			if a.OwnerClientID != p.UserID {
+				s.log().WarnContext(ctx, "list cards denied: account not owned by caller",
+					"account_id", accountID, "user_id", p.UserID)
 				return nil, apperr.PermissionDenied("nedovoljne permisije")
 			}
 		} else if !permissions.HasAny(p.Permissions, permissions.CardRead, permissions.Admin) {
@@ -211,6 +229,7 @@ func (s *Service) SetCardStatus(ctx context.Context, id string, status domain.Ca
 		return nil, err
 	}
 	if target.Status == domain.CardDeactivated {
+		s.log().WarnContext(ctx, "set card status rejected: card deactivated", "card_id", id, "status", status)
 		return nil, apperr.FailedPrecondition("deaktivirana kartica se ne može menjati")
 	}
 
@@ -221,10 +240,14 @@ func (s *Service) SetCardStatus(ctx context.Context, id string, status domain.Ca
 			return nil, err
 		}
 		if a.OwnerClientID != p.UserID {
+			s.log().WarnContext(ctx, "set card status denied: card not owned by caller",
+				"card_id", id, "user_id", p.UserID)
 			return nil, apperr.PermissionDenied("nedovoljne permisije")
 		}
 		// Clients can only request blocking.
 		if status != domain.CardBlocked {
+			s.log().WarnContext(ctx, "set card status denied: client may only block",
+				"card_id", id, "status", status, "user_id", p.UserID)
 			return nil, apperr.PermissionDenied("klijent može samo da blokira karticu; deblokiranje obavlja zaposleni")
 		}
 	} else if err := s.requirePermission(ctx, permissions.CardWrite); err != nil {
@@ -234,17 +257,24 @@ func (s *Service) SetCardStatus(ctx context.Context, id string, status domain.Ca
 	switch status {
 	case domain.CardActive, domain.CardBlocked, domain.CardDeactivated:
 	default:
+		s.log().WarnContext(ctx, "set card status validation failed: invalid status", "card_id", id, "status", status)
 		return nil, apperr.Validation("invalid card status")
 	}
 	oldStatus := target.Status
 	updated, err := s.Store.SetCardStatus(ctx, id, status)
 	if err != nil {
+		s.log().ErrorContext(ctx, "set card status failed", "err", err, "card_id", id, "status", status)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "card status updated",
+		"card_id", id, "old_status", oldStatus, "new_status", status)
 	// Notify the card's owning client. The card itself doesn't carry
 	// owner_client_id; resolve via the account.
 	if a, err := s.Store.GetAccountByID(ctx, updated.AccountID); err == nil {
 		s.notifyCardStatusChanged(ctx, updated, oldStatus, a.OwnerClientID)
+	} else {
+		s.log().WarnContext(ctx, "card status notify skipped: account lookup failed",
+			"err", err, "card_id", id, "account_id", updated.AccountID)
 	}
 	return updated, nil
 }
@@ -263,6 +293,7 @@ func (s *Service) UpdateCardLimit(ctx context.Context, id, newLimit string) (*do
 		return nil, err
 	}
 	if target.Status == domain.CardDeactivated {
+		s.log().WarnContext(ctx, "update card limit rejected: card deactivated", "card_id", id)
 		return nil, apperr.FailedPrecondition("deaktivirana kartica se ne može menjati")
 	}
 	if p.UserKind == auth.KindClient {
@@ -271,6 +302,8 @@ func (s *Service) UpdateCardLimit(ctx context.Context, id, newLimit string) (*do
 			return nil, err
 		}
 		if a.OwnerClientID != p.UserID {
+			s.log().WarnContext(ctx, "update card limit denied: card not owned by caller",
+				"card_id", id, "user_id", p.UserID)
 			return nil, apperr.PermissionDenied("nedovoljne permisije")
 		}
 	} else if err := s.requirePermission(ctx, permissions.CardWrite); err != nil {
@@ -279,16 +312,26 @@ func (s *Service) UpdateCardLimit(ctx context.Context, id, newLimit string) (*do
 
 	limit := strings.TrimSpace(newLimit)
 	if limit == "" {
+		s.log().WarnContext(ctx, "update card limit validation failed: missing limit", "card_id", id)
 		return nil, apperr.Validation("limit kartice je obavezan i mora biti veći od 0")
 	}
 	rat, err := money.Parse(limit)
 	if err != nil {
+		s.log().WarnContext(ctx, "update card limit validation failed: bad limit",
+			"err", err, "card_id", id, "card_limit", limit)
 		return nil, apperr.Validation("limit kartice nije validan iznos")
 	}
 	if !money.IsPositive(rat) {
+		s.log().WarnContext(ctx, "update card limit validation failed: non-positive limit",
+			"card_id", id, "card_limit", limit)
 		return nil, apperr.Validation("limit kartice mora biti veći od 0")
 	}
-	return s.Store.UpdateCardLimit(ctx, id, limit)
+	updated, err := s.Store.UpdateCardLimit(ctx, id, limit)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "card limit updated", "card_id", id, "card_limit", limit)
+	return updated, nil
 }
 
 // generateCardCredentials returns a Luhn-clean number for brand and a

--- a/services/bank/internal/service/companies.go
+++ b/services/bank/internal/service/companies.go
@@ -36,9 +36,11 @@ func (s *Service) CreateCompany(ctx context.Context, in CreateCompanyInput) (*do
 		return nil, err
 	}
 	if err := validateCompany(in); err != nil {
+		s.log().WarnContext(ctx, "create company validation failed",
+			"err", err, "owner_client_id", in.OwnerClientID, "registry_id", in.RegistryID)
 		return nil, err
 	}
-	return s.Store.CreateCompany(ctx, &domain.Company{
+	created, err := s.Store.CreateCompany(ctx, &domain.Company{
 		Name:          strings.TrimSpace(in.Name),
 		RegistryID:    strings.TrimSpace(in.RegistryID),
 		TaxID:         strings.TrimSpace(in.TaxID),
@@ -46,6 +48,12 @@ func (s *Service) CreateCompany(ctx context.Context, in CreateCompanyInput) (*do
 		Address:       strings.TrimSpace(in.Address),
 		OwnerClientID: strings.TrimSpace(in.OwnerClientID),
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "company created",
+		"company_id", created.ID, "owner_client_id", created.OwnerClientID, "registry_id", created.RegistryID)
+	return created, nil
 }
 
 func (s *Service) GetCompany(ctx context.Context, id string) (*domain.Company, error) {
@@ -96,6 +104,7 @@ func (s *Service) UpdateCompany(ctx context.Context, in UpdateCompanyInput) (*do
 	}
 	if v := strings.TrimSpace(in.ActivityCode); v != "" {
 		if !activityRe.MatchString(v) {
+			s.log().WarnContext(ctx, "update company validation failed: bad activity code", "company_id", in.ID)
 			return nil, apperr.Validation("activity code must match xx.xx")
 		}
 		target.ActivityCode = v
@@ -106,7 +115,12 @@ func (s *Service) UpdateCompany(ctx context.Context, in UpdateCompanyInput) (*do
 	if v := strings.TrimSpace(in.OwnerClientID); v != "" {
 		target.OwnerClientID = v
 	}
-	return s.Store.UpdateCompany(ctx, target)
+	updated, err := s.Store.UpdateCompany(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "company updated", "company_id", updated.ID)
+	return updated, nil
 }
 
 func validateCompany(in CreateCompanyInput) error {

--- a/services/bank/internal/service/dividend_settle.go
+++ b/services/bank/internal/service/dividend_settle.go
@@ -59,10 +59,19 @@ func (s *Service) SettleDividend(ctx context.Context, in SettleDividendInput) (*
 
 	to, err := s.Store.GetAccountByID(ctx, in.AccountID)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "settle dividend: account not found",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		} else {
+			s.log().ErrorContext(ctx, "settle dividend: account lookup failed",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		}
 		return nil, err
 	}
 	house, err := s.Store.GetSystemAccount(ctx, in.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle dividend: house account lookup failed",
+			"err", err, "currency", in.Currency, "op_id", in.OpID)
 		return nil, err
 	}
 
@@ -93,7 +102,14 @@ func (s *Service) SettleDividend(ctx context.Context, in SettleDividendInput) (*
 		purpose = "Isplata dividende"
 	}
 
-	return s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
+	res, err := s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
 		return s.executeMoneyMove(ctx, tx, house, to, amt, domain.TxKindDividend, in.OpID, initiator, paymentMeta{Purpose: purpose}, 0)
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "dividend settled",
+		"op_id", in.OpID, "account_id", in.AccountID, "amount", in.Amount,
+		"currency", in.Currency, "legs", len(res.Transactions))
+	return res, nil
 }

--- a/services/bank/internal/service/exchange_quote.go
+++ b/services/bank/internal/service/exchange_quote.go
@@ -94,9 +94,13 @@ func (s *Service) commissionRateFor(p auth.Principal) *big.Rat {
 // principal.
 func (s *Service) commissionRate() *big.Rat {
 	if s.Cfg.FXCommission != "" {
-		if r, err := money.Parse(s.Cfg.FXCommission); err == nil {
+		r, err := money.Parse(s.Cfg.FXCommission)
+		if err == nil {
 			return r
 		}
+		// Misconfigured FX_COMMISSION silently falling back to the
+		// default would be invisible otherwise.
+		s.log().Warn("fx commission config unparseable, using default", "err", err, "fx_commission", s.Cfg.FXCommission)
 	}
 	return money.MustParse("0.005")
 }
@@ -112,16 +116,19 @@ func (s *Service) commissionRate() *big.Rat {
 // RSD → Y at ASK_Y (primer 2). The BID column is unused by this path.
 func (s *Service) rateAndConvert(ctx context.Context, from, to domain.Currency, amt *big.Rat) (composite, toAmount *big.Rat, err error) {
 	if s.Rates == nil {
+		s.log().ErrorContext(ctx, "exchange rate provider not configured", "from_currency", from, "to_currency", to)
 		return nil, nil, apperr.Internal("exchange rate provider not configured", nil)
 	}
 	switch {
 	case from == domain.CurrencyRSD:
 		_, ask, err := s.Rates.Quote(ctx, to, domain.CurrencyRSD)
 		if err != nil {
+			s.log().ErrorContext(ctx, "exchange rate quote failed", "err", err, "currency", to)
 			return nil, nil, err
 		}
 		askR, perr := money.Parse(ask)
 		if perr != nil {
+			s.log().ErrorContext(ctx, "parse exchange rate failed", "err", perr, "currency", to, "rate", ask)
 			return nil, nil, apperr.Internal("parse rate", perr)
 		}
 		conv, derr := money.Div(amt, askR)
@@ -136,10 +143,12 @@ func (s *Service) rateAndConvert(ctx context.Context, from, to domain.Currency, 
 	case to == domain.CurrencyRSD:
 		_, ask, err := s.Rates.Quote(ctx, from, domain.CurrencyRSD)
 		if err != nil {
+			s.log().ErrorContext(ctx, "exchange rate quote failed", "err", err, "currency", from)
 			return nil, nil, err
 		}
 		askR, perr := money.Parse(ask)
 		if perr != nil {
+			s.log().ErrorContext(ctx, "parse exchange rate failed", "err", perr, "currency", from, "rate", ask)
 			return nil, nil, apperr.Internal("parse rate", perr)
 		}
 		conv := money.Mul(amt, askR)
@@ -147,18 +156,22 @@ func (s *Service) rateAndConvert(ctx context.Context, from, to domain.Currency, 
 	default:
 		_, askFrom, err := s.Rates.Quote(ctx, from, domain.CurrencyRSD)
 		if err != nil {
+			s.log().ErrorContext(ctx, "exchange rate quote failed", "err", err, "currency", from)
 			return nil, nil, err
 		}
 		_, askTo, err := s.Rates.Quote(ctx, to, domain.CurrencyRSD)
 		if err != nil {
+			s.log().ErrorContext(ctx, "exchange rate quote failed", "err", err, "currency", to)
 			return nil, nil, err
 		}
 		askFromR, perr := money.Parse(askFrom)
 		if perr != nil {
+			s.log().ErrorContext(ctx, "parse exchange rate failed", "err", perr, "currency", from, "rate", askFrom)
 			return nil, nil, apperr.Internal("parse from rate", perr)
 		}
 		askToR, perr := money.Parse(askTo)
 		if perr != nil {
+			s.log().ErrorContext(ctx, "parse exchange rate failed", "err", perr, "currency", to, "rate", askTo)
 			return nil, nil, apperr.Internal("parse to rate", perr)
 		}
 		rsdAmt := money.Mul(amt, askFromR)

--- a/services/bank/internal/service/forex_forward.go
+++ b/services/bank/internal/service/forex_forward.go
@@ -101,10 +101,14 @@ func (s *Service) resolveSpreadFactor(ctx context.Context, base, quote domain.Cu
 		if apperrIs(err, apperr.KindNotFound) {
 			return money.MustParse(defaultForexForwardSpread), defaultForexForwardSpread, nil
 		}
+		s.log().ErrorContext(ctx, "forex forward: spread lookup failed",
+			"err", err, "base_currency", base, "quote_currency", quote)
 		return nil, "", err
 	}
 	r, perr := money.Parse(sp.SpreadFactor)
 	if perr != nil {
+		s.log().ErrorContext(ctx, "forex forward: stored spread factor unparseable",
+			"err", perr, "base_currency", base, "quote_currency", quote, "spread_factor", sp.SpreadFactor)
 		return nil, "", apperr.Internal("parse spread factor", perr)
 	}
 	return r, sp.SpreadFactor, nil
@@ -130,6 +134,8 @@ func (s *Service) quoteForward(ctx context.Context, base, quote domain.Currency,
 		return nil, nil, apperr.Validation(err.Error())
 	}
 	if s.Rates == nil {
+		s.log().ErrorContext(ctx, "forex forward: exchange rate provider not configured",
+			"base_currency", base, "quote_currency", quote)
 		return nil, nil, apperr.Internal("exchange rate provider not configured", nil)
 	}
 
@@ -138,13 +144,19 @@ func (s *Service) quoteForward(ctx context.Context, base, quote domain.Currency,
 	// Spot ASK for base→RSD per spec p.26 (always sell-side).
 	_, ask, err := s.Rates.Quote(ctx, base, quote)
 	if err != nil {
+		s.log().ErrorContext(ctx, "forex forward: spot rate quote failed",
+			"err", err, "base_currency", base, "quote_currency", quote)
 		return nil, nil, err
 	}
 	spotAsk, perr := money.Parse(ask)
 	if perr != nil {
+		s.log().ErrorContext(ctx, "forex forward: parse spot ask failed",
+			"err", perr, "base_currency", base, "quote_currency", quote, "rate", ask)
 		return nil, nil, apperr.Internal("parse spot ask", perr)
 	}
 	if !money.IsPositive(spotAsk) {
+		s.log().ErrorContext(ctx, "forex forward: spot ask non-positive",
+			"base_currency", base, "quote_currency", quote, "rate", ask)
 		return nil, nil, apperr.Internal("spot ask non-positive", nil)
 	}
 
@@ -295,10 +307,27 @@ func (s *Service) CreateForexForward(ctx context.Context, in CreateForexForwardI
 		return nil
 	})
 	if err != nil {
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "create forex forward rejected, releasing reservation",
+				"err", err, "client_id", p.UserID, "op_id", opID,
+				"base_currency", in.BaseCurrency, "notional", in.Notional)
+		} else {
+			s.log().ErrorContext(ctx, "create forex forward failed, releasing reservation",
+				"err", err, "client_id", p.UserID, "op_id", opID,
+				"base_currency", in.BaseCurrency, "notional", in.Notional)
+		}
 		// Roll back the reservation we made before the tx.
-		_, _ = s.ReleaseFunds(reserveCtx, opID)
+		if _, rerr := s.ReleaseFunds(reserveCtx, opID); rerr != nil {
+			s.log().ErrorContext(ctx, "create forex forward: release reservation failed",
+				"err", rerr, "client_id", p.UserID, "op_id", opID)
+		}
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "forex forward created",
+		"forward_id", out.ID, "client_id", p.UserID, "op_id", opID,
+		"base_currency", out.BaseCurrency, "notional", out.Notional,
+		"forward_rate", out.ForwardRate, "settlement_date", out.SettlementDate,
+		"commission", out.Commission)
 	return out, nil
 }
 
@@ -333,9 +362,12 @@ func (s *Service) CancelForexForward(ctx context.Context, id string) (*domain.Fo
 	}
 	// Release the obligation reservation (best-effort, idempotent).
 	if _, rerr := s.ReleaseFunds(s.internalCtx(ctx), f.ReservationID); rerr != nil {
-		s.Log.WarnContext(ctx, "forex forward cancel: release reservation failed",
-			"id", f.ID, "reservation_id", f.ReservationID, "err", rerr.Error())
+		s.log().WarnContext(ctx, "forex forward cancel: release reservation failed",
+			"err", rerr, "forward_id", f.ID, "reservation_id", f.ReservationID)
 	}
+	s.log().InfoContext(ctx, "forex forward cancelled",
+		"forward_id", f.ID, "client_id", p.UserID, "reservation_id", f.ReservationID,
+		"base_currency", f.BaseCurrency, "notional", f.Notional)
 	return f, nil
 }
 
@@ -363,6 +395,7 @@ func (s *Service) RunForexForwardSettlement(ctx context.Context) (*ForexForwardS
 	now := s.now()
 	due, err := s.Store.ListDueForexForwards(ctx, now)
 	if err != nil {
+		s.log().ErrorContext(ctx, "forex forward settlement: list due contracts failed", "err", err)
 		return nil, err
 	}
 
@@ -374,10 +407,16 @@ func (s *Service) RunForexForwardSettlement(ctx context.Context) (*ForexForwardS
 		switch execErr {
 		case nil:
 			if merr := s.Store.MarkForexForwardSettled(ctx, f.ID, at); merr != nil {
-				s.Log.WarnContext(ctx, "forex forward mark-settled failed", "id", f.ID, "err", merr.Error())
+				// Funds moved but the row still reads 'active' — the next
+				// sweep retries idempotently, but flag the inconsistency.
+				s.log().ErrorContext(ctx, "forex forward settled but mark-settled failed",
+					"err", merr, "forward_id", f.ID, "client_id", f.ClientID, "reservation_id", f.ReservationID)
 				continue
 			}
 			res.Settled++
+			s.log().InfoContext(ctx, "forex forward settled",
+				"forward_id", f.ID, "client_id", f.ClientID, "reservation_id", f.ReservationID,
+				"base_currency", f.BaseCurrency, "notional", f.Notional, "forward_rate", f.ForwardRate)
 			s.notifyForexForwardSettled(ctx, f)
 		default:
 			// Settlement could not complete (e.g. the reserved funds were
@@ -388,14 +427,20 @@ func (s *Service) RunForexForwardSettlement(ctx context.Context) (*ForexForwardS
 				reason = "rezervisana sredstva više nisu dostupna"
 			}
 			if merr := s.Store.MarkForexForwardFailed(ctx, f.ID, reason, at); merr != nil {
-				s.Log.WarnContext(ctx, "forex forward mark-failed failed", "id", f.ID, "err", merr.Error())
+				s.log().ErrorContext(ctx, "forex forward mark-failed failed",
+					"err", merr, "forward_id", f.ID, "client_id", f.ClientID)
 				continue
 			}
-			_, _ = s.ReleaseFunds(s.internalCtx(ctx), f.ReservationID)
+			if _, rerr := s.ReleaseFunds(s.internalCtx(ctx), f.ReservationID); rerr != nil {
+				s.log().ErrorContext(ctx, "forex forward settlement: release reservation failed",
+					"err", rerr, "forward_id", f.ID, "reservation_id", f.ReservationID)
+			}
 			res.Failed++
 			s.notifyForexForwardFailed(ctx, f, reason)
-			s.Log.WarnContext(ctx, "forex forward settlement failed",
-				"id", f.ID, "client_id", f.ClientID, "err", execErr.Error())
+			s.log().WarnContext(ctx, "forex forward settlement failed",
+				"err", execErr, "forward_id", f.ID, "client_id", f.ClientID,
+				"reservation_id", f.ReservationID, "base_currency", f.BaseCurrency,
+				"notional", f.Notional, "reason", reason)
 		}
 	}
 	return res, nil
@@ -484,12 +529,21 @@ func (s *Service) SetForexForwardSpread(ctx context.Context, base, quote domain.
 	if sf.Sign() < 0 {
 		return nil, apperr.Validation("spread faktor ne sme biti negativan")
 	}
-	return s.Store.UpsertForexForwardSpread(ctx, &domain.ForexForwardSpread{
+	out, err := s.Store.UpsertForexForwardSpread(ctx, &domain.ForexForwardSpread{
 		BaseCurrency:  base,
 		QuoteCurrency: quote,
 		SpreadFactor:  money.FormatRate(sf),
 		UpdatedBy:     p.UserID,
 	})
+	if err != nil {
+		s.log().ErrorContext(ctx, "set forex forward spread failed",
+			"err", err, "base_currency", base, "quote_currency", quote, "user_id", p.UserID)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "forex forward spread updated",
+		"base_currency", base, "quote_currency", quote,
+		"spread_factor", out.SpreadFactor, "user_id", p.UserID)
+	return out, nil
 }
 
 // =====================================================================

--- a/services/bank/internal/service/interbank_2pc.go
+++ b/services/bank/internal/service/interbank_2pc.go
@@ -102,12 +102,30 @@ func (s *Service) PreparePayment(ctx context.Context, in PreparePaymentInput) (*
 		// the partner can be auto-blocked. Best-effort — never mask the
 		// original error.
 		s.onPrepareFailure(ctx, in, err)
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "interbank prepare rejected",
+				"err", err, "transaction_id", in.TransactionID,
+				"sender_routing_number", in.SenderRoutingNumber, "direction", in.Direction,
+				"local_account", in.LocalAccountNumber, "remote_account", in.RemoteAccountNumber,
+				"amount", in.Amount, "currency", in.Currency)
+		} else {
+			s.log().ErrorContext(ctx, "interbank prepare failed",
+				"err", err, "transaction_id", in.TransactionID,
+				"sender_routing_number", in.SenderRoutingNumber, "direction", in.Direction,
+				"local_account", in.LocalAccountNumber, "remote_account", in.RemoteAccountNumber,
+				"amount", in.Amount, "currency", in.Currency)
+		}
 		return nil, err
 	}
 	// A clean prepare clears any prior failure streak.
 	if rerr := s.Store.ResetPartnerFailures(ctx, in.SenderRoutingNumber); rerr != nil {
-		s.Log.Warn("interbank: reset partner failures", "sender_routing_number", in.SenderRoutingNumber, "error", rerr)
+		s.log().WarnContext(ctx, "interbank: reset partner failures", "err", rerr, "sender_routing_number", in.SenderRoutingNumber)
 	}
+	s.log().InfoContext(ctx, "interbank tx prepared",
+		"transaction_id", res.TransactionID, "status", res.Status, "reservation_id", res.ReservationID,
+		"sender_routing_number", in.SenderRoutingNumber, "direction", in.Direction,
+		"local_account", in.LocalAccountNumber, "remote_account", in.RemoteAccountNumber,
+		"amount", in.Amount, "currency", in.Currency)
 	return res, nil
 }
 
@@ -202,12 +220,12 @@ func (s *Service) onPrepareFailure(ctx context.Context, in PreparePaymentInput, 
 	}); ierr != nil {
 		// A conflict means a row already exists (e.g. a partial prepare
 		// that did persist); not worth surfacing.
-		s.Log.Warn("interbank: record failed attempt", "sender_routing_number", in.SenderRoutingNumber, "transaction_id", in.TransactionID, "error", ierr)
+		s.log().WarnContext(ctx, "interbank: record failed attempt", "err", ierr, "sender_routing_number", in.SenderRoutingNumber, "transaction_id", in.TransactionID)
 	}
 
 	n, ferr := s.Store.RecordPartnerFailure(ctx, in.SenderRoutingNumber)
 	if ferr != nil {
-		s.Log.Warn("interbank: record partner failure", "sender_routing_number", in.SenderRoutingNumber, "error", ferr)
+		s.log().WarnContext(ctx, "interbank: record partner failure", "err", ferr, "sender_routing_number", in.SenderRoutingNumber)
 		return
 	}
 	if shouldAutoBlock(n) {
@@ -234,10 +252,10 @@ func isCountablePrepareFailure(err error) bool {
 func (s *Service) autoBlockPartner(ctx context.Context, senderRouting, failures int) {
 	reason := fmt.Sprintf("automatski blokirana posle %d uzastopnih neuspeha", failures)
 	if _, err := s.Store.BlockBank(ctx, senderRouting, reason, domain.BlacklistAutoBlockBy); err != nil {
-		s.Log.Warn("interbank: auto-block partner", "sender_routing_number", senderRouting, "error", err)
+		s.log().ErrorContext(ctx, "interbank: auto-block partner failed", "err", err, "sender_routing_number", senderRouting)
 		return
 	}
-	s.Log.Warn("interbank: partner auto-blacklisted",
+	s.log().WarnContext(ctx, "interbank: partner auto-blacklisted",
 		"sender_routing_number", senderRouting, "consecutive_failures", failures)
 	s.notifyInterbankAutoBlock(ctx, senderRouting, failures)
 }
@@ -256,7 +274,7 @@ func (s *Service) notifyInterbankAutoBlock(ctx context.Context, senderRouting, f
 		senderRouting, failures,
 	)
 	if err := s.InApp.Notify(ctx, domain.InterbankSupervisorAudience, "employee", "interbank", title, body); err != nil {
-		s.Log.Warn("interbank: auto-block notify", "error", err)
+		s.log().WarnContext(ctx, "interbank: auto-block notify failed", "err", err, "sender_routing_number", senderRouting)
 	}
 }
 
@@ -305,9 +323,17 @@ func (s *Service) prepareOutbound(ctx context.Context, in PreparePaymentInput, a
 		_, ierr := s.Store.InsertInterbankTx(ctx, tx, row)
 		return ierr
 	}); err != nil {
+		s.log().ErrorContext(ctx, "interbank prepare outbound: record prepared row failed, releasing reservation",
+			"err", err, "transaction_id", in.TransactionID, "sender_routing_number", in.SenderRoutingNumber,
+			"reservation_id", res.ReservationID, "op_id", opID,
+			"local_account", in.LocalAccountNumber, "amount", in.Amount, "currency", in.Currency)
 		// Release the reservation if recording the prepared row failed —
 		// avoids leaking a held debit.
-		_, _ = s.ReleaseFunds(ctx, opID)
+		if _, rerr := s.ReleaseFunds(ctx, opID); rerr != nil {
+			s.log().ErrorContext(ctx, "interbank prepare outbound: release reservation failed",
+				"err", rerr, "transaction_id", in.TransactionID, "sender_routing_number", in.SenderRoutingNumber,
+				"reservation_id", res.ReservationID, "op_id", opID)
+		}
 		return nil, err
 	}
 	_ = amt // already consumed by ReserveFunds via in.Amount
@@ -379,16 +405,27 @@ func (s *Service) CommitPayment(ctx context.Context, senderRouting int, txID str
 
 	row, err := s.Store.GetInterbankTx(ctx, nil, senderRouting, txID, false)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "interbank commit: tx not found",
+				"err", err, "transaction_id", txID, "sender_routing_number", senderRouting)
+		} else {
+			s.log().ErrorContext(ctx, "interbank commit: tx lookup failed",
+				"err", err, "transaction_id", txID, "sender_routing_number", senderRouting)
+		}
 		return nil, err
 	}
 	switch row.Status {
 	case domain.InterbankTxCommitted:
 		return &CommitPaymentResult{TransactionID: txID, Status: row.Status, OpID: row.OpID}, nil
 	case domain.InterbankTxRolledBack:
+		s.log().WarnContext(ctx, "interbank commit rejected: transaction is rolled back",
+			"transaction_id", txID, "sender_routing_number", senderRouting, "direction", row.Direction)
 		return nil, apperr.FailedPrecondition("transaction is rolled back")
 	case domain.InterbankTxPrepared:
 		// fall through
 	default:
+		s.log().ErrorContext(ctx, "interbank commit: unknown tx status",
+			"transaction_id", txID, "sender_routing_number", senderRouting, "status", row.Status)
 		return nil, apperr.Internal("unknown interbank tx status", nil)
 	}
 
@@ -400,6 +437,8 @@ func (s *Service) CommitPayment(ctx context.Context, senderRouting int, txID str
 	case domain.InterbankInbound:
 		return s.commitInbound(ctx, row, opID)
 	default:
+		s.log().ErrorContext(ctx, "interbank commit: unknown direction",
+			"transaction_id", txID, "sender_routing_number", senderRouting, "direction", row.Direction)
 		return nil, apperr.Internal("unknown direction", nil)
 	}
 }
@@ -410,6 +449,9 @@ func (s *Service) commitOutbound(ctx context.Context, row *domain.InterbankProto
 	// (the partner credits their user separately on their side).
 	system, err := s.Store.GetSystemAccount(ctx, row.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "interbank commit outbound: bank system account missing",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"currency", row.Currency)
 		return nil, apperr.FailedPrecondition("bank system account missing for currency")
 	}
 	if _, err := s.CommitReservedFunds(ctx, CommitReservedFundsInput{
@@ -420,6 +462,11 @@ func (s *Service) commitOutbound(ctx context.Context, row *domain.InterbankProto
 		IsActuary:     true, // internal — no commission
 		Purpose:       interbankPurpose(row),
 	}); err != nil {
+		s.log().ErrorContext(ctx, "interbank commit outbound: commit reserved funds failed",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"op_id", opID, "reservation_id", row.ReservationID, "direction", row.Direction,
+			"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+			"amount", row.Amount, "currency", row.Currency)
 		return nil, err
 	}
 	if err := s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
@@ -427,8 +474,19 @@ func (s *Service) commitOutbound(ctx context.Context, row *domain.InterbankProto
 			domain.InterbankTxCommitted, opID, "")
 		return merr
 	}); err != nil {
+		// Money has moved but the row still reads 'prepared' — flag loudly
+		// so a stuck-looking 2PC can be traced to this exact spot.
+		s.log().ErrorContext(ctx, "interbank commit outbound: funds committed but status update failed",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"op_id", opID, "reservation_id", row.ReservationID,
+			"amount", row.Amount, "currency", row.Currency)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "interbank tx committed",
+		"transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+		"direction", row.Direction, "op_id", opID, "reservation_id", row.ReservationID,
+		"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+		"amount", row.Amount, "currency", row.Currency)
 	return &CommitPaymentResult{TransactionID: row.TransactionID, Status: domain.InterbankTxCommitted, OpID: opID}, nil
 }
 
@@ -441,24 +499,50 @@ func (s *Service) commitInbound(ctx context.Context, row *domain.InterbankProtoc
 				domain.InterbankTxCommitted, opID, "")
 			return merr
 		}); err != nil {
+			// Ledger legs exist but the row still reads 'prepared' —
+			// inconsistent state worth a loud record.
+			s.log().ErrorContext(ctx, "interbank commit inbound: legs exist but status update failed",
+				"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+				"op_id", opID, "amount", row.Amount, "currency", row.Currency)
 			return nil, err
 		}
+		s.log().InfoContext(ctx, "interbank tx committed",
+			"transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"direction", row.Direction, "op_id", opID,
+			"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+			"amount", row.Amount, "currency", row.Currency)
 		return &CommitPaymentResult{TransactionID: row.TransactionID, Status: domain.InterbankTxCommitted, OpID: opID}, nil
 	}
 
 	dst, err := s.Store.GetAccountByNumber(ctx, row.LocalAccountNumber)
 	if err != nil {
+		// Prepare already validated this account; vanishing at commit
+		// time is an inconsistency, not a client mistake.
+		s.log().ErrorContext(ctx, "interbank commit inbound: destination account lookup failed",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"local_account", row.LocalAccountNumber)
 		return nil, apperr.Validation("destination account not found")
 	}
 	if dst.Status != domain.AccountActive {
+		s.log().WarnContext(ctx, "interbank commit inbound: destination account not active",
+			"transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"local_account", row.LocalAccountNumber, "account_status", dst.Status)
 		return nil, apperr.FailedPrecondition("destination account is not active")
 	}
 	system, err := s.Store.GetSystemAccount(ctx, row.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "interbank commit inbound: bank system account missing",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"currency", row.Currency)
 		return nil, apperr.FailedPrecondition("bank system account missing for currency")
 	}
 	amt, err := parsePositive(row.Amount)
 	if err != nil {
+		// The stored amount was validated at prepare time; failing to
+		// parse now means the row is corrupt.
+		s.log().ErrorContext(ctx, "interbank commit inbound: stored amount unparseable",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"amount", row.Amount, "currency", row.Currency)
 		return nil, err
 	}
 
@@ -477,8 +561,18 @@ func (s *Service) commitInbound(ctx context.Context, row *domain.InterbankProtoc
 			domain.InterbankTxCommitted, opID, "")
 		return merr
 	}); err != nil {
+		s.log().ErrorContext(ctx, "interbank commit inbound failed",
+			"err", err, "transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+			"op_id", opID, "direction", row.Direction,
+			"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+			"amount", row.Amount, "currency", row.Currency)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "interbank tx committed",
+		"transaction_id", row.TransactionID, "sender_routing_number", row.SenderRoutingNumber,
+		"direction", row.Direction, "op_id", opID,
+		"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+		"amount", row.Amount, "currency", row.Currency)
 	return &CommitPaymentResult{TransactionID: row.TransactionID, Status: domain.InterbankTxCommitted, OpID: opID}, nil
 }
 
@@ -501,16 +595,27 @@ func (s *Service) RollbackPayment(ctx context.Context, senderRouting int, txID, 
 
 	row, err := s.Store.GetInterbankTx(ctx, nil, senderRouting, txID, false)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "interbank rollback: tx not found",
+				"err", err, "transaction_id", txID, "sender_routing_number", senderRouting)
+		} else {
+			s.log().ErrorContext(ctx, "interbank rollback: tx lookup failed",
+				"err", err, "transaction_id", txID, "sender_routing_number", senderRouting)
+		}
 		return nil, err
 	}
 	switch row.Status {
 	case domain.InterbankTxRolledBack:
 		return &RollbackPaymentResult{TransactionID: txID, Status: row.Status}, nil
 	case domain.InterbankTxCommitted:
+		s.log().WarnContext(ctx, "interbank rollback rejected: transaction is already committed",
+			"transaction_id", txID, "sender_routing_number", senderRouting, "direction", row.Direction)
 		return nil, apperr.FailedPrecondition("transaction is already committed")
 	case domain.InterbankTxPrepared:
 		// fall through
 	default:
+		s.log().ErrorContext(ctx, "interbank rollback: unknown tx status",
+			"transaction_id", txID, "sender_routing_number", senderRouting, "status", row.Status)
 		return nil, apperr.Internal("unknown interbank tx status", nil)
 	}
 
@@ -518,6 +623,10 @@ func (s *Service) RollbackPayment(ctx context.Context, senderRouting int, txID, 
 	if row.Direction == domain.InterbankOutbound {
 		opID := deriveOpID(senderRouting, txID)
 		if _, err := s.ReleaseFunds(ctx, opID); err != nil && !apperrIs(err, apperr.KindNotFound) {
+			s.log().ErrorContext(ctx, "interbank rollback: release reservation failed",
+				"err", err, "transaction_id", txID, "sender_routing_number", senderRouting,
+				"op_id", opID, "reservation_id", row.ReservationID,
+				"amount", row.Amount, "currency", row.Currency)
 			return nil, err
 		}
 	}
@@ -526,8 +635,18 @@ func (s *Service) RollbackPayment(ctx context.Context, senderRouting int, txID, 
 			domain.InterbankTxRolledBack, "", reason)
 		return merr
 	}); err != nil {
+		// Reservation (if any) is released but the row still reads
+		// 'prepared' — inconsistent state worth a loud record.
+		s.log().ErrorContext(ctx, "interbank rollback: reservation released but status update failed",
+			"err", err, "transaction_id", txID, "sender_routing_number", senderRouting,
+			"direction", row.Direction, "amount", row.Amount, "currency", row.Currency)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "interbank tx rolled back",
+		"transaction_id", txID, "sender_routing_number", senderRouting,
+		"direction", row.Direction, "reservation_id", row.ReservationID,
+		"local_account", row.LocalAccountNumber, "remote_account", row.RemoteAccountNumber,
+		"amount", row.Amount, "currency", row.Currency, "reason", reason)
 	return &RollbackPaymentResult{TransactionID: txID, Status: domain.InterbankTxRolledBack}, nil
 }
 
@@ -559,9 +678,16 @@ func (s *Service) RecordInboundMessage(ctx context.Context, in RecordInboundMess
 		ResponseStatus:      in.ResponseStatus,
 		ResponseBody:        in.ResponseBody,
 	}
-	return s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+	if err := s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 		return s.Store.UpsertInterbankMessage(ctx, tx, row)
-	})
+	}); err != nil {
+		s.log().ErrorContext(ctx, "interbank record inbound message failed",
+			"err", err, "sender_routing_number", in.SenderRoutingNumber,
+			"idempotence_key", in.IdempotenceKey, "message_type", in.MessageType,
+			"transaction_id", in.TransactionID)
+		return err
+	}
+	return nil
 }
 
 // GetInboundMessage returns the cached response for a (sender, key) or
@@ -575,6 +701,8 @@ func (s *Service) GetInboundMessage(ctx context.Context, senderRouting int, key 
 		if apperrIs(err, apperr.KindNotFound) {
 			return nil, nil
 		}
+		s.log().ErrorContext(ctx, "interbank get inbound message failed",
+			"err", err, "sender_routing_number", senderRouting, "idempotence_key", key)
 		return nil, err
 	}
 	return out, nil

--- a/services/bank/internal/service/interbank_supervisor.go
+++ b/services/bank/internal/service/interbank_supervisor.go
@@ -122,7 +122,15 @@ func (s *Service) BlockInterbankPartner(ctx context.Context, senderRouting int, 
 	if p, ok := auth.PrincipalFrom(ctx); ok {
 		by = p.UserID
 	}
-	return s.Store.BlockBank(ctx, senderRouting, reason, by)
+	out, err := s.Store.BlockBank(ctx, senderRouting, reason, by)
+	if err != nil {
+		s.log().ErrorContext(ctx, "interbank block partner failed",
+			"err", err, "sender_routing_number", senderRouting, "blocked_by", by)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "interbank partner blocked",
+		"sender_routing_number", senderRouting, "blocked_by", by, "reason", reason)
+	return out, nil
 }
 
 // UnblockInterbankPartner lifts an active blacklist entry. The
@@ -137,11 +145,19 @@ func (s *Service) UnblockInterbankPartner(ctx context.Context, senderRouting int
 	}
 	out, err := s.Store.UnblockBank(ctx, senderRouting)
 	if err != nil {
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "interbank unblock partner rejected",
+				"err", err, "sender_routing_number", senderRouting)
+		} else {
+			s.log().ErrorContext(ctx, "interbank unblock partner failed",
+				"err", err, "sender_routing_number", senderRouting)
+		}
 		return nil, err
 	}
 	if rerr := s.Store.ResetPartnerFailures(ctx, senderRouting); rerr != nil {
-		s.Log.Warn("interbank: reset failures on unblock", "sender_routing_number", senderRouting, "error", rerr)
+		s.log().WarnContext(ctx, "interbank: reset failures on unblock", "err", rerr, "sender_routing_number", senderRouting)
 	}
+	s.log().InfoContext(ctx, "interbank partner unblocked", "sender_routing_number", senderRouting)
 	return out, nil
 }
 

--- a/services/bank/internal/service/loans.go
+++ b/services/bank/internal/service/loans.go
@@ -67,7 +67,7 @@ func (s *Service) SubmitLoanRequest(ctx context.Context, in SubmitLoanRequestInp
 		return nil, apperr.FailedPrecondition("račun nije aktivan")
 	}
 
-	return s.Store.CreateLoanRequest(ctx, &domain.LoanRequest{
+	created, err := s.Store.CreateLoanRequest(ctx, &domain.LoanRequest{
 		ClientID:                 p.UserID,
 		AccountID:                in.AccountID,
 		LoanType:                 in.LoanType,
@@ -81,6 +81,17 @@ func (s *Service) SubmitLoanRequest(ctx context.Context, in SubmitLoanRequestInp
 		InstallmentsTotal:        in.InstallmentsTotal,
 		ContactPhone:             strings.TrimSpace(in.ContactPhone),
 	})
+	if err != nil {
+		s.log().ErrorContext(ctx, "create loan request failed",
+			"err", err, "client_id", p.UserID, "account_id", in.AccountID,
+			"loan_type", in.LoanType, "amount", in.Amount, "currency", in.Currency)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "loan request submitted",
+		"request_id", created.ID, "client_id", p.UserID, "account_id", in.AccountID,
+		"loan_type", in.LoanType, "amount", created.Amount, "currency", created.Currency,
+		"installments_total", created.InstallmentsTotal)
+	return created, nil
 }
 
 // DecideLoanRequest is the employee's "Odobri" / "Odbij" path. On
@@ -99,6 +110,7 @@ func (s *Service) DecideLoanRequest(ctx context.Context, requestID string, appro
 	}
 
 	var decided *domain.LoanRequest
+	var materialized *domain.Loan
 	err = s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 		req, err := s.Store.GetLoanRequestByID(ctx, requestID)
 		if err != nil {
@@ -118,11 +130,28 @@ func (s *Service) DecideLoanRequest(ctx context.Context, requestID string, appro
 		}
 		decided = out
 
-		_, err = s.materializeLoan(ctx, tx, req)
+		materialized, err = s.materializeLoan(ctx, tx, req)
 		return err
 	})
 	if err != nil {
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "decide loan request rejected",
+				"err", err, "request_id", requestID, "approve", approve, "employee_id", p.UserID)
+		} else {
+			s.log().ErrorContext(ctx, "decide loan request failed",
+				"err", err, "request_id", requestID, "approve", approve, "employee_id", p.UserID)
+		}
 		return nil, err
+	}
+	if materialized != nil {
+		s.log().InfoContext(ctx, "loan approved",
+			"request_id", requestID, "loan_id", materialized.ID, "loan_number", materialized.LoanNumber,
+			"client_id", materialized.ClientID, "account_id", materialized.AccountID,
+			"principal", materialized.Principal, "currency", materialized.Currency,
+			"installments_total", materialized.InstallmentsTotal, "employee_id", p.UserID)
+	} else {
+		s.log().InfoContext(ctx, "loan request rejected",
+			"request_id", requestID, "client_id", decided.ClientID, "employee_id", p.UserID)
 	}
 	s.notifyLoanDecision(ctx, decided)
 	return decided, nil
@@ -134,6 +163,8 @@ func (s *Service) DecideLoanRequest(ctx context.Context, requestID string, appro
 func (s *Service) materializeLoan(ctx context.Context, tx pgx.Tx, req *domain.LoanRequest) (*domain.Loan, error) {
 	principal, err := money.Parse(req.Amount)
 	if err != nil {
+		s.log().ErrorContext(ctx, "materialize loan: stored amount unparseable",
+			"err", err, "request_id", req.ID, "amount", req.Amount, "currency", req.Currency)
 		return nil, apperr.Internal("parse amount", err)
 	}
 
@@ -144,10 +175,14 @@ func (s *Service) materializeLoan(ctx context.Context, tx pgx.Tx, req *domain.Lo
 	if req.Currency != domain.CurrencyRSD {
 		_, ask, err := s.Rates.Quote(ctx, req.Currency, domain.CurrencyRSD)
 		if err != nil {
+			s.log().ErrorContext(ctx, "materialize loan: rate lookup failed",
+				"err", err, "request_id", req.ID, "currency", req.Currency)
 			return nil, apperr.Internal("rate lookup", err)
 		}
 		askR, perr := money.Parse(ask)
 		if perr != nil {
+			s.log().ErrorContext(ctx, "materialize loan: parse rate failed",
+				"err", perr, "request_id", req.ID, "currency", req.Currency, "rate", ask)
 			return nil, apperr.Internal("parse rate", perr)
 		}
 		amountRSD = money.Mul(principal, askR)
@@ -321,10 +356,11 @@ func (s *Service) RunInstallmentJob(ctx context.Context, dueOn time.Time) (*Inst
 func (s *Service) RunInstallmentJobAuto(ctx context.Context) error {
 	res, err := s.runInstallmentJob(ctx, s.now())
 	if err != nil {
+		s.log().ErrorContext(ctx, "installment job failed", "err", err)
 		return err
 	}
 	if res.Processed > 0 {
-		s.Log.Info("installment job ran",
+		s.log().InfoContext(ctx, "installment job ran",
 			"processed", res.Processed,
 			"paid", res.Paid, "missed", res.Missed,
 			"penalised", res.Penalised, "overdue", res.Overdue)
@@ -339,30 +375,44 @@ func (s *Service) RunInstallmentJobAuto(ctx context.Context) error {
 func (s *Service) runInstallmentJob(ctx context.Context, dueOn time.Time) (*InstallmentJobResult, error) {
 	due, err := s.Store.ListInstallmentsDueOn(ctx, dueOn)
 	if err != nil {
+		s.log().ErrorContext(ctx, "installment job: list due installments failed", "err", err)
 		return nil, err
 	}
 	res := &InstallmentJobResult{Processed: len(due)}
 	for _, inst := range due {
 		outcome, err := s.collectOneInstallment(ctx, inst)
 		if err != nil {
-			s.Log.Warn("installment job: unexpected error",
-				"installment_id", inst.ID, "loan_id", inst.LoanID, "error", err)
+			s.log().ErrorContext(ctx, "installment job: collect installment failed",
+				"err", err, "installment_id", inst.ID, "loan_id", inst.LoanID,
+				"amount", inst.Amount, "currency", inst.Currency)
 			res.Overdue++
 			continue
 		}
 		switch outcome {
 		case installmentPaid:
 			res.Paid++
+			s.log().InfoContext(ctx, "installment charged",
+				"installment_id", inst.ID, "loan_id", inst.LoanID,
+				"sequence_number", inst.SequenceNumber, "amount", inst.Amount, "currency", inst.Currency)
 		case installmentMissed:
 			res.Missed++
 			res.Overdue++
+			s.log().WarnContext(ctx, "installment missed: insufficient funds",
+				"installment_id", inst.ID, "loan_id", inst.LoanID,
+				"sequence_number", inst.SequenceNumber, "amount", inst.Amount, "currency", inst.Currency)
 			s.notifyMiss(ctx, inst)
 		case installmentPenalised:
 			res.Penalised++
 			res.Overdue++
+			s.log().WarnContext(ctx, "installment retry failed: late penalty applied",
+				"installment_id", inst.ID, "loan_id", inst.LoanID,
+				"sequence_number", inst.SequenceNumber, "amount", inst.Amount, "currency", inst.Currency)
 			s.notifyMiss(ctx, inst)
 		case installmentRetryFailed:
 			res.Overdue++
+			s.log().WarnContext(ctx, "installment retry failed: still overdue",
+				"installment_id", inst.ID, "loan_id", inst.LoanID,
+				"sequence_number", inst.SequenceNumber, "amount", inst.Amount, "currency", inst.Currency)
 			s.notifyMiss(ctx, inst)
 		}
 	}
@@ -404,7 +454,12 @@ func (s *Service) collectOneInstallment(ctx context.Context, inst *domain.LoanIn
 			return err
 		}
 
-		amt, _ := money.Parse(inst.Amount)
+		amt, perr := money.Parse(inst.Amount)
+		if perr != nil {
+			// Stored by us at schedule time — unparseable means corrupt data.
+			s.log().ErrorContext(ctx, "collect installment: stored amount unparseable",
+				"err", perr, "installment_id", inst.ID, "loan_id", inst.LoanID, "amount", inst.Amount)
+		}
 		neg := money.FormatAmount(money.Sub(money.MustParse("0"), amt))
 		if err := s.Store.AdjustBalance(ctx, tx, loan.AccountID, neg); err != nil {
 			if !errors.Is(err, store.ErrInsufficientFunds) {
@@ -446,9 +501,14 @@ func (s *Service) collectOneInstallment(ctx context.Context, inst *domain.LoanIn
 
 		// remaining_principal -= principal-part of this installment.
 		// principal-part = amount − (remaining × monthlyRate-at-due).
-		remaining, _ := money.Parse(loan.RemainingPrincipal)
-		annualPct, _ := money.Parse(inst.InterestRateAtDue)
-		monthlyRate, _ := money.Div(annualPct, money.MustParse("1200"))
+		remaining, rerr := money.Parse(loan.RemainingPrincipal)
+		annualPct, aerr := money.Parse(inst.InterestRateAtDue)
+		if rerr != nil || aerr != nil {
+			s.log().ErrorContext(ctx, "collect installment: stored loan figures unparseable",
+				"err", errors.Join(rerr, aerr), "installment_id", inst.ID, "loan_id", inst.LoanID,
+				"remaining_principal", loan.RemainingPrincipal, "interest_rate_at_due", inst.InterestRateAtDue)
+		}
+		monthlyRate, _ := money.Div(annualPct, money.MustParse("1200")) // divisor is a non-zero constant
 		interestPart := money.Mul(remaining, monthlyRate)
 		principalPart := money.Sub(amt, interestPart)
 		newRemaining := money.Sub(remaining, principalPart)
@@ -562,7 +622,7 @@ func (s *Service) applyLatePenalty(ctx context.Context, tx pgx.Tx, loan *domain.
 func (s *Service) notifyMiss(ctx context.Context, inst *domain.LoanInstallment) {
 	loan, err := s.Store.GetLoanByID(ctx, inst.LoanID)
 	if err != nil {
-		s.Log.Warn("notify miss: get loan failed", "loan_id", inst.LoanID, "error", err)
+		s.log().WarnContext(ctx, "notify miss: get loan failed", "err", err, "loan_id", inst.LoanID)
 		return
 	}
 	s.notifyInstallmentMissed(ctx, loan, inst)
@@ -594,10 +654,11 @@ func (s *Service) RunVariableRateJob(ctx context.Context) (*VariableRateJobResul
 func (s *Service) RunVariableRateJobAuto(ctx context.Context) error {
 	res, err := s.runVariableRateJob(ctx)
 	if err != nil {
+		s.log().ErrorContext(ctx, "variable-rate job failed", "err", err)
 		return err
 	}
 	if res.Processed > 0 {
-		s.Log.Info("variable-rate job ran",
+		s.log().InfoContext(ctx, "variable-rate job ran",
 			"processed", res.Processed,
 			"updated", res.Updated,
 			"failed", res.Failed)
@@ -611,12 +672,13 @@ func (s *Service) RunVariableRateJobAuto(ctx context.Context) error {
 func (s *Service) runVariableRateJob(ctx context.Context) (*VariableRateJobResult, error) {
 	loansList, err := s.Store.ListActiveVariableLoans(ctx)
 	if err != nil {
+		s.log().ErrorContext(ctx, "variable-rate job: list active variable loans failed", "err", err)
 		return nil, err
 	}
 	res := &VariableRateJobResult{Processed: len(loansList)}
 	for _, l := range loansList {
 		if err := s.refreshOneVariableLoan(ctx, l); err != nil {
-			s.Log.Warn("variable-rate refresh failed", "loan_id", l.ID, "error", err)
+			s.log().WarnContext(ctx, "variable-rate refresh failed", "err", err, "loan_id", l.ID, "loan_number", l.LoanNumber)
 			res.Failed++
 			continue
 		}
@@ -629,8 +691,13 @@ func (s *Service) runVariableRateJob(ctx context.Context) (*VariableRateJobResul
 // over its remaining installments at the new rate.
 func (s *Service) refreshOneVariableLoan(ctx context.Context, l *domain.Loan) error {
 	offset := randomPomeraj()
-	base, _ := money.Parse(l.BaseRate)
-	margin, _ := money.Parse(l.Margin)
+	base, berr := money.Parse(l.BaseRate)
+	margin, merr := money.Parse(l.Margin)
+	if berr != nil || merr != nil {
+		s.log().ErrorContext(ctx, "variable-rate refresh: stored loan rates unparseable",
+			"err", errors.Join(berr, merr), "loan_id", l.ID, "loan_number", l.LoanNumber,
+			"base_rate", l.BaseRate, "margin", l.Margin)
+	}
 	monthly := loans.MonthlyRate(base, offset, margin)
 	paid, err := s.countPaidInstallments(ctx, l.ID)
 	if err != nil {
@@ -640,7 +707,12 @@ func (s *Service) refreshOneVariableLoan(ctx context.Context, l *domain.Loan) er
 	if nRemaining <= 0 {
 		return nil
 	}
-	remaining, _ := money.Parse(l.RemainingPrincipal)
+	remaining, rerr := money.Parse(l.RemainingPrincipal)
+	if rerr != nil {
+		s.log().ErrorContext(ctx, "variable-rate refresh: stored remaining principal unparseable",
+			"err", rerr, "loan_id", l.ID, "loan_number", l.LoanNumber,
+			"remaining_principal", l.RemainingPrincipal)
+	}
 	annuity := loans.Annuity(remaining, monthly, nRemaining)
 	newAmount := money.FormatAmount(annuity)
 	return s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
@@ -675,6 +747,9 @@ func (s *Service) generateLoanNumber() string {
 	// we use 10 digits for headroom.
 	v, err := rand.Int(rand.Reader, big.NewInt(1_000_000_0000))
 	if err != nil {
+		// Extremely unlikely; the timestamp fallback keeps the loan
+		// creation alive but is worth a record.
+		s.log().Warn("generate loan number: crypto rand failed, using timestamp fallback", "err", err)
 		return s.now().Format("20060102150405")
 	}
 	return fmt.Sprintf("%010d", v.Int64())

--- a/services/bank/internal/service/maintenance.go
+++ b/services/bank/internal/service/maintenance.go
@@ -45,9 +45,10 @@ func (s *Service) RunMaintenanceFeeJob(ctx context.Context, now time.Time) (*Mai
 func (s *Service) RunMaintenanceFeeJobAuto(ctx context.Context) error {
 	res, err := s.runMaintenanceFeeJob(ctx, s.now())
 	if err != nil {
+		s.log().ErrorContext(ctx, "maintenance fee job failed", "err", err)
 		return err
 	}
-	s.Log.Info("maintenance fee job ran",
+	s.log().InfoContext(ctx, "maintenance fee job ran",
 		"processed", res.Processed, "charged", res.Charged, "skipped", res.Skipped)
 	return nil
 }
@@ -62,17 +63,20 @@ func (s *Service) runMaintenanceFeeJob(ctx context.Context, now time.Time) (*Mai
 	cutoff := now.Add(-monthlyDebitCutoff)
 	due, err := s.Store.ListAccountsDueForMaintenance(ctx, cutoff)
 	if err != nil {
+		s.log().ErrorContext(ctx, "maintenance fee job: list due accounts failed", "err", err)
 		return nil, err
 	}
 	res := &MaintenanceFeeJobResult{Processed: len(due)}
 	for _, a := range due {
 		if err := s.chargeMaintenance(ctx, a); err != nil {
 			res.Skipped++
-			s.Log.Warn("maintenance fee skipped",
-				"account_id", a.ID, "currency", a.Currency, "fee", a.MaintenanceFee, "error", err)
+			s.log().WarnContext(ctx, "maintenance fee skipped",
+				"err", err, "account_id", a.ID, "currency", a.Currency, "fee", a.MaintenanceFee)
 			continue
 		}
 		res.Charged++
+		s.log().InfoContext(ctx, "maintenance fee charged",
+			"account_id", a.ID, "fee", a.MaintenanceFee, "currency", a.Currency)
 	}
 	return res, nil
 }

--- a/services/bank/internal/service/notifications.go
+++ b/services/bank/internal/service/notifications.go
@@ -23,22 +23,22 @@ func (s *Service) notify(ctx context.Context, clientID, eventKind, subject, body
 	// user_id and the kind is always "client".
 	if s.InApp != nil {
 		if err := s.InApp.Notify(ctx, clientID, "client", eventKind, subject, body); err != nil {
-			s.Log.Warn("notify: in-app create failed", "client_id", clientID, "error", err)
+			s.log().WarnContext(ctx, "notify: in-app create failed", "err", err, "client_id", clientID, "kind", eventKind)
 		}
 	}
 
 	// Email leg.
 	if s.Notifier == nil || s.UserResolver == nil {
-		s.Log.Info("notification email skipped (no notifier wired)", "client_id", clientID, "subject", subject)
+		s.log().InfoContext(ctx, "notification email skipped (no notifier wired)", "client_id", clientID, "subject", subject)
 		return
 	}
 	to, err := s.UserResolver.ClientEmail(ctx, clientID)
 	if err != nil || to == "" {
-		s.Log.Warn("notify: client email lookup failed", "client_id", clientID, "error", err)
+		s.log().WarnContext(ctx, "notify: client email lookup failed", "err", err, "client_id", clientID)
 		return
 	}
 	if err := s.Notifier.Send(ctx, to, subject, body, false); err != nil {
-		s.Log.Warn("notify: send failed", "to", to, "subject", subject, "error", err)
+		s.log().WarnContext(ctx, "notify: send failed", "err", err, "to", to, "subject", subject)
 	}
 }
 

--- a/services/bank/internal/service/payments.go
+++ b/services/bank/internal/service/payments.go
@@ -12,6 +12,7 @@ import (
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
+	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/store"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
@@ -42,7 +43,7 @@ func (s *Service) CreatePayment(ctx context.Context, in CreatePaymentInput) (res
 		}
 		bizmetric.PaymentCompleted(ctx, "payment", c, paymentStatus(err))
 		if err != nil {
-			s.Log.WarnContext(ctx, "CreatePayment failed",
+			s.log().WarnContext(ctx, "CreatePayment failed",
 				"from_account", in.FromAccountID,
 				"to_account_no", in.ToAccountNumber,
 				"amount", in.Amount,
@@ -94,12 +95,20 @@ func (s *Service) CreatePayment(ctx context.Context, in CreatePaymentInput) (res
 	}
 
 	if in.SaveRecipient && p.UserKind == auth.KindClient {
-		_, _ = s.Store.UpsertPaymentRecipient(ctx, &domain.PaymentRecipient{
+		if _, rerr := s.Store.UpsertPaymentRecipient(ctx, &domain.PaymentRecipient{
 			ClientID:      p.UserID,
 			Name:          strings.TrimSpace(in.RecipientName),
 			AccountNumber: to.Number,
-		})
+		}); rerr != nil {
+			// Best-effort convenience write — never fails the payment.
+			s.log().WarnContext(ctx, "save payment recipient failed",
+				"err", rerr, "client_id", p.UserID, "account_number", to.Number)
+		}
 	}
+
+	s.log().InfoContext(ctx, "payment executed",
+		"op_id", op, "from_account", from.Number, "to_account", to.Number,
+		"amount", money.FormatAmount(amt), "currency", from.Currency, "legs", len(result.Transactions))
 
 	// Spec E2E "Klijent dobija email potvrdu" — sender side only.
 	s.notifyPaymentSucceeded(ctx, from.OwnerClientID, from.Number, to.Number, money.FormatAmount(amt), from.Currency)
@@ -129,7 +138,7 @@ func (s *Service) CreateTransfer(ctx context.Context, in CreateTransferInput) (r
 		}
 		bizmetric.PaymentCompleted(ctx, k, c, paymentStatus(err))
 		if err != nil {
-			s.Log.WarnContext(ctx, "CreateTransfer failed",
+			s.log().WarnContext(ctx, "CreateTransfer failed",
 				"from", in.FromAccountID, "to", in.ToAccountID,
 				"amount", in.Amount, "currency", c, "err", err.Error())
 		}
@@ -193,6 +202,9 @@ func (s *Service) CreateTransfer(ctx context.Context, in CreateTransferInput) (r
 	if err != nil {
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "transfer completed",
+		"op_id", op, "from_account", from.Number, "to_account", to.Number,
+		"amount", in.Amount, "currency", currency, "kind", kindLabel)
 	return result, nil
 }
 
@@ -234,10 +246,16 @@ type paymentMeta struct {
 // All other callers pass 0.
 func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *domain.Account, fromAmt *big.Rat, kind domain.TransactionKind, opID string, initiator auth.Principal, meta paymentMeta, legOffset int) ([]*domain.Transaction, error) {
 	if from.Status != domain.AccountActive || to.Status != domain.AccountActive {
+		s.log().WarnContext(ctx, "money move rejected: account not active",
+			"op_id", opID, "kind", kind, "from_account", from.Number, "to_account", to.Number,
+			"from_status", from.Status, "to_status", to.Status)
 		return nil, apperr.FailedPrecondition("jedan od računa nije aktivan")
 	}
 
 	if err := s.Store.CheckLimits(ctx, tx, from.ID, money.FormatAmount(fromAmt)); err != nil {
+		s.log().WarnContext(ctx, "money move rejected: limit check failed",
+			"err", err, "op_id", opID, "kind", kind, "from_account", from.Number,
+			"amount", money.FormatAmount(fromAmt), "currency", from.Currency)
 		return nil, err
 	}
 
@@ -246,9 +264,13 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 		fromStr := money.FormatAmount(fromAmt)
 		negFrom := money.FormatAmount(money.Sub(money.MustParse("0"), fromAmt))
 		if err := s.Store.AdjustBalance(ctx, tx, from.ID, negFrom); err != nil {
+			s.logMoneyMoveDebitErr(ctx, err, opID, kind, from.Number, fromStr, from.Currency)
 			return nil, err
 		}
 		if err := s.Store.AdjustBalance(ctx, tx, to.ID, fromStr); err != nil {
+			s.log().ErrorContext(ctx, "money move: credit destination failed",
+				"err", err, "op_id", opID, "kind", kind, "to_account", to.Number,
+				"amount", fromStr, "currency", to.Currency)
 			return nil, err
 		}
 		leg, err := s.Store.InsertTransaction(ctx, tx, &domain.Transaction{
@@ -261,6 +283,10 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 			Status:            domain.TxStatusRealized,
 		})
 		if err != nil {
+			s.log().ErrorContext(ctx, "money move: insert ledger leg failed",
+				"err", err, "op_id", opID, "kind", kind, "leg_index", legOffset+1,
+				"from_account", from.Number, "to_account", to.Number,
+				"amount", fromStr, "currency", from.Currency)
 			return nil, err
 		}
 		return []*domain.Transaction{leg}, nil
@@ -269,20 +295,31 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 	// Cross-currency — menjačnica via bank house accounts.
 	bankFrom, err := s.Store.GetSystemAccount(ctx, from.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "money move: source house account lookup failed",
+			"err", err, "op_id", opID, "kind", kind, "currency", from.Currency)
 		return nil, err
 	}
 	bankTo, err := s.Store.GetSystemAccount(ctx, to.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "money move: destination house account lookup failed",
+			"err", err, "op_id", opID, "kind", kind, "currency", to.Currency)
 		return nil, err
 	}
 
 	composite, toBefore, err := s.rateAndConvert(ctx, from.Currency, to.Currency, fromAmt)
 	if err != nil {
+		s.log().ErrorContext(ctx, "money move: fx conversion failed",
+			"err", err, "op_id", opID, "kind", kind,
+			"from_currency", from.Currency, "to_currency", to.Currency,
+			"amount", money.FormatAmount(fromAmt))
 		return nil, err
 	}
 	commission := money.Mul(toBefore, s.commissionRateFor(initiator))
 	toAmt := money.Sub(toBefore, commission)
 	if !money.IsPositive(toAmt) {
+		s.log().WarnContext(ctx, "money move rejected: amount too small after commission",
+			"op_id", opID, "kind", kind, "from_currency", from.Currency, "to_currency", to.Currency,
+			"amount", money.FormatAmount(fromAmt))
 		return nil, apperr.Validation("amount too small after commission")
 	}
 
@@ -293,18 +330,26 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 
 	// Debit source, credit bank's source-currency house.
 	if err := s.Store.AdjustBalance(ctx, tx, from.ID, negFrom); err != nil {
+		s.logMoneyMoveDebitErr(ctx, err, opID, kind, from.Number, fromStr, from.Currency)
 		return nil, err
 	}
 	if err := s.Store.AdjustBalance(ctx, tx, bankFrom.ID, fromStr); err != nil {
+		s.log().ErrorContext(ctx, "money move: credit source house failed",
+			"err", err, "op_id", opID, "kind", kind, "amount", fromStr, "currency", from.Currency)
 		return nil, err
 	}
 	// Debit bank's to-currency house, credit destination (commission
 	// is the spread the bank keeps; bankTo loses toAmt only — not
 	// toBefore — so the difference accrues to the bank's books).
 	if err := s.Store.AdjustBalance(ctx, tx, bankTo.ID, negTo); err != nil {
+		s.log().ErrorContext(ctx, "money move: debit destination house failed",
+			"err", err, "op_id", opID, "kind", kind, "amount", toStr, "currency", to.Currency)
 		return nil, err
 	}
 	if err := s.Store.AdjustBalance(ctx, tx, to.ID, toStr); err != nil {
+		s.log().ErrorContext(ctx, "money move: credit destination failed",
+			"err", err, "op_id", opID, "kind", kind, "to_account", to.Number,
+			"amount", toStr, "currency", to.Currency)
 		return nil, err
 	}
 
@@ -318,6 +363,9 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 		Status:            domain.TxStatusRealized,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "money move: insert ledger leg failed",
+			"err", err, "op_id", opID, "kind", kind, "leg_index", legOffset+1,
+			"from_account", from.Number, "amount", fromStr, "currency", from.Currency)
 		return nil, err
 	}
 	leg2, err := s.Store.InsertTransaction(ctx, tx, &domain.Transaction{
@@ -333,9 +381,27 @@ func (s *Service) executeMoneyMove(ctx context.Context, tx pgx.Tx, from, to *dom
 		Status:            domain.TxStatusRealized,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "money move: insert ledger leg failed",
+			"err", err, "op_id", opID, "kind", kind, "leg_index", legOffset+2,
+			"to_account", to.Number, "amount", toStr, "currency", to.Currency)
 		return nil, err
 	}
 	return []*domain.Transaction{leg1, leg2}, nil
+}
+
+// logMoneyMoveDebitErr classifies a source-debit failure: insufficient
+// funds is an expected client-class outcome (Warn); anything else is a
+// db-level Error.
+func (s *Service) logMoneyMoveDebitErr(ctx context.Context, err error, opID string, kind domain.TransactionKind, fromNumber, amount string, currency domain.Currency) {
+	if errors.Is(err, store.ErrInsufficientFunds) {
+		s.log().WarnContext(ctx, "money move rejected: insufficient funds",
+			"err", err, "op_id", opID, "kind", kind, "from_account", fromNumber,
+			"amount", amount, "currency", currency)
+		return
+	}
+	s.log().ErrorContext(ctx, "money move: debit source failed",
+		"err", err, "op_id", opID, "kind", kind, "from_account", fromNumber,
+		"amount", amount, "currency", currency)
 }
 
 // resolvePaymentEndpoints loads source + destination accounts, runs

--- a/services/bank/internal/service/recipients.go
+++ b/services/bank/internal/service/recipients.go
@@ -27,6 +27,8 @@ func (s *Service) CreatePaymentRecipient(ctx context.Context, name, accountNumbe
 		return nil, apperr.Validation("naziv primaoca je obavezan")
 	}
 	if _, err := account.Validate(accountNumber); err != nil {
+		s.log().WarnContext(ctx, "create payment recipient validation failed",
+			"err", err, "account_number", accountNumber, "client_id", p.UserID)
 		return nil, apperr.Validation("broj računa nije ispravan: " + err.Error())
 	}
 	return s.Store.UpsertPaymentRecipient(ctx, &domain.PaymentRecipient{
@@ -56,6 +58,8 @@ func (s *Service) UpdatePaymentRecipient(ctx context.Context, id, name, accountN
 		return nil, apperr.PermissionDenied("samo klijent može da menja primaoce")
 	}
 	if _, err := account.Validate(strings.TrimSpace(accountNumber)); err != nil {
+		s.log().WarnContext(ctx, "update payment recipient validation failed",
+			"err", err, "recipient_id", id, "account_number", strings.TrimSpace(accountNumber), "client_id", p.UserID)
 		return nil, apperr.Validation("broj računa nije ispravan: " + err.Error())
 	}
 	return s.Store.UpdatePaymentRecipient(ctx, &domain.PaymentRecipient{

--- a/services/bank/internal/service/reservations.go
+++ b/services/bank/internal/service/reservations.go
@@ -89,12 +89,24 @@ func (s *Service) ReserveFunds(ctx context.Context, in ReserveFundsInput) (*Rese
 
 	acc, err := s.Store.GetAccountByID(ctx, in.AccountID)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "reserve funds: account not found",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind)
+		} else {
+			s.log().ErrorContext(ctx, "reserve funds: account lookup failed",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind)
+		}
 		return nil, err
 	}
 	if acc.Currency != in.Currency {
+		s.log().WarnContext(ctx, "reserve funds rejected: currency mismatch",
+			"account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind,
+			"account_currency", acc.Currency, "currency", in.Currency)
 		return nil, apperr.Validation("reservation currency must match account")
 	}
 	if acc.Status != domain.AccountActive {
+		s.log().WarnContext(ctx, "reserve funds rejected: account not active",
+			"account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind, "account_status", acc.Status)
 		return nil, apperr.FailedPrecondition("account not active")
 	}
 
@@ -129,9 +141,25 @@ func (s *Service) ReserveFunds(ctx context.Context, in ReserveFundsInput) (*Rese
 			if lerr == nil && winner != nil {
 				return &ReserveFundsResult{ReservationID: winner.ID, OpID: winner.OpID}, nil
 			}
+			if lerr != nil {
+				s.log().ErrorContext(ctx, "reserve funds: re-read of racing reservation failed",
+					"err", lerr, "account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind)
+			}
+		}
+		if errors.Is(err, store.ErrInsufficientFunds) {
+			s.log().WarnContext(ctx, "reserve funds rejected: insufficient funds",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind,
+				"amount", in.Amount, "currency", in.Currency)
+		} else {
+			s.log().ErrorContext(ctx, "reserve funds failed",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID, "op_kind", in.OpKind,
+				"amount", in.Amount, "currency", in.Currency)
 		}
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "funds reserved",
+		"reservation_id", inserted.ID, "op_id", inserted.OpID, "op_kind", in.OpKind,
+		"account_id", in.AccountID, "amount", in.Amount, "currency", in.Currency)
 	return &ReserveFundsResult{ReservationID: inserted.ID, OpID: inserted.OpID}, nil
 }
 
@@ -180,7 +208,11 @@ func (s *Service) ReleaseFunds(ctx context.Context, opID string) (*ReleaseFundsR
 		return nil
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "release funds failed", "err", err, "op_id", opID)
 		return nil, err
+	}
+	if released {
+		s.log().InfoContext(ctx, "reservation released", "op_id", opID)
 	}
 	return &ReleaseFundsResult{Released: released}, nil
 }
@@ -383,8 +415,20 @@ func (s *Service) CommitReservedFunds(ctx context.Context, in CommitReservedFund
 		return s.Store.MarkReservationState(ctx, tx, in.OpID, domain.ReservationCommitted)
 	})
 	if err != nil {
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "commit reserved funds rejected",
+				"err", err, "op_id", in.OpID, "dest_account_id", in.DestAccountID,
+				"dest_amount", in.DestAmount, "dest_currency", in.DestCurrency)
+		} else {
+			s.log().ErrorContext(ctx, "commit reserved funds failed",
+				"err", err, "op_id", in.OpID, "dest_account_id", in.DestAccountID,
+				"dest_amount", in.DestAmount, "dest_currency", in.DestCurrency)
+		}
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "reserved funds committed",
+		"op_id", in.OpID, "dest_account_id", in.DestAccountID,
+		"dest_amount", in.DestAmount, "dest_currency", in.DestCurrency, "legs", len(legs))
 	return &domain.PaymentResult{OpID: in.OpID, Status: domain.TxStatusRealized, Transactions: legs}, nil
 }
 
@@ -425,6 +469,13 @@ func (s *Service) TransferBetweenClients(ctx context.Context, in TransferBetween
 
 	from, err := s.Store.GetAccountByID(ctx, in.FromAccountID)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "transfer between clients: source account not found",
+				"err", err, "from_account_id", in.FromAccountID, "op_id", in.OpID, "op_kind", in.OpKind)
+		} else {
+			s.log().ErrorContext(ctx, "transfer between clients: source account lookup failed",
+				"err", err, "from_account_id", in.FromAccountID, "op_id", in.OpID, "op_kind", in.OpKind)
+		}
 		return nil, err
 	}
 	// Reserve in source currency; commit produces dest currency amount
@@ -442,8 +493,13 @@ func (s *Service) TransferBetweenClients(ctx context.Context, in TransferBetween
 
 	to, err := s.Store.GetAccountByID(ctx, in.ToAccountID)
 	if err != nil {
+		s.log().WarnContext(ctx, "transfer between clients: destination account lookup failed, releasing reservation",
+			"err", err, "to_account_id", in.ToAccountID, "op_id", in.OpID, "op_kind", in.OpKind)
 		// Best-effort release so we don't leak a held reservation.
-		_, _ = s.ReleaseFunds(ctx, in.OpID)
+		if _, rerr := s.ReleaseFunds(ctx, in.OpID); rerr != nil {
+			s.log().ErrorContext(ctx, "transfer between clients: release reservation failed",
+				"err", rerr, "op_id", in.OpID, "from_account_id", in.FromAccountID)
+		}
 		return nil, err
 	}
 
@@ -469,13 +525,24 @@ func (s *Service) TransferBetweenClients(ctx context.Context, in TransferBetween
 	}
 	_, toBefore, err := s.rateAndConvert(ctx, from.Currency, to.Currency, amt)
 	if err != nil {
-		_, _ = s.ReleaseFunds(ctx, in.OpID)
+		s.log().ErrorContext(ctx, "transfer between clients: fx conversion failed, releasing reservation",
+			"err", err, "op_id", in.OpID, "from_currency", from.Currency, "to_currency", to.Currency,
+			"amount", in.Amount)
+		if _, rerr := s.ReleaseFunds(ctx, in.OpID); rerr != nil {
+			s.log().ErrorContext(ctx, "transfer between clients: release reservation failed",
+				"err", rerr, "op_id", in.OpID, "from_account_id", in.FromAccountID)
+		}
 		return nil, err
 	}
 	commission := money.Mul(toBefore, s.commissionRateFor(initiator))
 	toAmt := money.Sub(toBefore, commission)
 	if !money.IsPositive(toAmt) {
-		_, _ = s.ReleaseFunds(ctx, in.OpID)
+		s.log().WarnContext(ctx, "transfer between clients rejected: amount too small after commission, releasing reservation",
+			"op_id", in.OpID, "amount", in.Amount, "from_currency", from.Currency, "to_currency", to.Currency)
+		if _, rerr := s.ReleaseFunds(ctx, in.OpID); rerr != nil {
+			s.log().ErrorContext(ctx, "transfer between clients: release reservation failed",
+				"err", rerr, "op_id", in.OpID, "from_account_id", in.FromAccountID)
+		}
 		return nil, apperr.Validation("amount too small after commission")
 	}
 	return s.CommitReservedFunds(ctx, CommitReservedFundsInput{
@@ -510,4 +577,20 @@ func apperrIs(err error, kind apperr.Kind) bool {
 		return false
 	}
 	return ae.Kind == kind
+}
+
+// clientClassErr reports whether err is an expected client-class apperr
+// (validation, not-found, conflict, precondition, auth) — logged at Warn
+// — as opposed to an unexpected internal failure logged at Error.
+func clientClassErr(err error) bool {
+	var ae *apperr.Error
+	if !errors.As(err, &ae) {
+		return false
+	}
+	switch ae.Kind {
+	case apperr.KindNotFound, apperr.KindConflict, apperr.KindValidation,
+		apperr.KindUnauthenticated, apperr.KindPermissionDenied, apperr.KindFailedPrecondition:
+		return true
+	}
+	return false
 }

--- a/services/bank/internal/service/scheduled_payments.go
+++ b/services/bank/internal/service/scheduled_payments.go
@@ -83,8 +83,16 @@ func (s *Service) SchedulePayment(ctx context.Context, in SchedulePaymentInput) 
 	}
 	out, err := s.Store.InsertScheduledPayment(ctx, sp)
 	if err != nil {
+		s.log().ErrorContext(ctx, "schedule payment failed",
+			"err", err, "client_id", sp.ClientID, "from_account", from.Number,
+			"to_account", to.Number, "amount", sp.Amount, "currency", sp.Currency,
+			"scheduled_date", sp.ScheduledDate)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "payment scheduled",
+		"scheduled_payment_id", out.ID, "client_id", out.ClientID,
+		"from_account", from.Number, "to_account", out.ToAccountNumber,
+		"amount", out.Amount, "currency", out.Currency, "scheduled_date", out.ScheduledDate)
 	return out, nil
 }
 
@@ -115,7 +123,16 @@ func (s *Service) CancelScheduledPayment(ctx context.Context, id string) (*domai
 	if id == "" {
 		return nil, apperr.Validation("id is required")
 	}
-	return s.Store.CancelScheduledPayment(ctx, id, p.UserID)
+	out, err := s.Store.CancelScheduledPayment(ctx, id, p.UserID)
+	if err != nil {
+		s.log().WarnContext(ctx, "cancel scheduled payment failed",
+			"err", err, "scheduled_payment_id", id, "client_id", p.UserID)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "scheduled payment cancelled",
+		"scheduled_payment_id", out.ID, "client_id", p.UserID,
+		"amount", out.Amount, "currency", out.Currency)
+	return out, nil
 }
 
 // ScheduledPaymentRunResult tallies one due-sweep pass.
@@ -140,6 +157,7 @@ func (s *Service) RunDueScheduledPayments(ctx context.Context) (*ScheduledPaymen
 	now := s.now()
 	due, err := s.Store.ListDueScheduledPayments(ctx, now)
 	if err != nil {
+		s.log().ErrorContext(ctx, "scheduled payment sweep: list due payments failed", "err", err)
 		return nil, err
 	}
 
@@ -151,24 +169,36 @@ func (s *Service) RunDueScheduledPayments(ctx context.Context) (*ScheduledPaymen
 		switch {
 		case execErr == nil:
 			if err := s.Store.MarkScheduledPaymentCompleted(ctx, sp.ID, at); err != nil {
-				s.Log.WarnContext(ctx, "scheduled payment mark-completed failed", "id", sp.ID, "err", err.Error())
+				// Money moved but the row still reads 'scheduled' — the
+				// next sweep would re-execute it; flag loudly.
+				s.log().ErrorContext(ctx, "scheduled payment executed but mark-completed failed",
+					"err", err, "scheduled_payment_id", sp.ID, "client_id", sp.ClientID,
+					"amount", sp.Amount, "currency", sp.Currency)
 				continue
 			}
 			res.Succeeded++
+			s.log().InfoContext(ctx, "scheduled payment executed",
+				"scheduled_payment_id", sp.ID, "client_id", sp.ClientID,
+				"to_account", sp.ToAccountNumber, "amount", sp.Amount, "currency", sp.Currency)
 			s.notifyScheduledPaymentSucceeded(ctx, sp)
 		case isInsufficientFunds(execErr):
 			reason := "nedovoljno sredstava na računu"
 			if err := s.Store.MarkScheduledPaymentFailed(ctx, sp.ID, reason, at); err != nil {
-				s.Log.WarnContext(ctx, "scheduled payment mark-failed failed", "id", sp.ID, "err", err.Error())
+				s.log().ErrorContext(ctx, "scheduled payment mark-failed failed",
+					"err", err, "scheduled_payment_id", sp.ID, "client_id", sp.ClientID)
 				continue
 			}
 			res.Failed++
+			s.log().WarnContext(ctx, "scheduled payment failed: insufficient funds",
+				"scheduled_payment_id", sp.ID, "client_id", sp.ClientID,
+				"to_account", sp.ToAccountNumber, "amount", sp.Amount, "currency", sp.Currency)
 			s.notifyScheduledPaymentFailed(ctx, sp, reason)
 		default:
 			// Transient/other error — leave 'scheduled' for the next
 			// sweep, don't notify (avoids spamming on a flaky run).
-			s.Log.WarnContext(ctx, "scheduled payment execution deferred",
-				"id", sp.ID, "client_id", sp.ClientID, "err", execErr.Error())
+			s.log().WarnContext(ctx, "scheduled payment execution deferred",
+				"err", execErr, "scheduled_payment_id", sp.ID, "client_id", sp.ClientID,
+				"to_account", sp.ToAccountNumber, "amount", sp.Amount, "currency", sp.Currency)
 		}
 	}
 	return res, nil

--- a/services/bank/internal/service/service.go
+++ b/services/bank/internal/service/service.go
@@ -94,6 +94,15 @@ func New(st *store.Store, cfg Config, log *slog.Logger) *Service {
 	return &Service{Store: st, Cfg: cfg, Log: log}
 }
 
+// log returns the wired logger, falling back to slog.Default() so
+// logging is nil-safe in unit tests that construct Service bare.
+func (s *Service) log() *slog.Logger {
+	if s.Log != nil {
+		return s.Log
+	}
+	return slog.Default()
+}
+
 func (s *Service) requirePermission(ctx context.Context, perm string) error {
 	p, ok := auth.PrincipalFrom(ctx)
 	if !ok {

--- a/services/bank/internal/service/spent_reset.go
+++ b/services/bank/internal/service/spent_reset.go
@@ -33,10 +33,11 @@ func (s *Service) RunSpentResetJob(ctx context.Context) (*SpentResetJobResult, e
 func (s *Service) RunSpentResetJobAuto(ctx context.Context) error {
 	res, err := s.runSpentResetJob(ctx)
 	if err != nil {
+		s.log().ErrorContext(ctx, "spent reset job failed", "err", err)
 		return err
 	}
 	if res.Daily > 0 || res.Monthly > 0 {
-		s.Log.Info("spent reset job ran", "daily", res.Daily, "monthly", res.Monthly)
+		s.log().InfoContext(ctx, "spent reset job ran", "daily", res.Daily, "monthly", res.Monthly)
 	}
 	return nil
 }

--- a/services/bank/internal/service/tax_settle.go
+++ b/services/bank/internal/service/tax_settle.go
@@ -46,10 +46,19 @@ func (s *Service) SettleCapitalGainsTax(ctx context.Context, in SettleCapitalGai
 
 	from, err := s.Store.GetAccountByID(ctx, in.AccountID)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "settle capital gains tax: account not found",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		} else {
+			s.log().ErrorContext(ctx, "settle capital gains tax: account lookup failed",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		}
 		return nil, err
 	}
 	state, err := s.Store.GetStateTaxAccount(ctx)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle capital gains tax: state tax account lookup failed",
+			"err", err, "op_id", in.OpID)
 		return nil, err
 	}
 
@@ -65,6 +74,9 @@ func (s *Service) SettleCapitalGainsTax(ctx context.Context, in SettleCapitalGai
 	if from.Currency != domain.CurrencyRSD {
 		_, conv, err := s.rateAndConvert(ctx, domain.CurrencyRSD, from.Currency, rsdAmt)
 		if err != nil {
+			s.log().ErrorContext(ctx, "settle capital gains tax: fx conversion failed",
+				"err", err, "op_id", in.OpID, "account_id", in.AccountID,
+				"amount_rsd", in.AmountRSD, "account_currency", from.Currency)
 			return nil, err
 		}
 		fromAmt = conv
@@ -91,7 +103,14 @@ func (s *Service) SettleCapitalGainsTax(ctx context.Context, in SettleCapitalGai
 		purpose = "Porez na kapitalni dobitak"
 	}
 
-	return s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
+	res, err := s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
 		return s.executeMoneyMove(ctx, tx, from, state, fromAmt, domain.TxKindTax, in.OpID, initiator, paymentMeta{Purpose: purpose}, 0)
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "capital gains tax settled",
+		"op_id", in.OpID, "account_id", in.AccountID, "amount_rsd", in.AmountRSD,
+		"account_currency", from.Currency, "legs", len(res.Transactions))
+	return res, nil
 }

--- a/services/bank/internal/service/trade_settle.go
+++ b/services/bank/internal/service/trade_settle.go
@@ -46,6 +46,14 @@ func (s *Service) idempotentSettle(
 			if lerr == nil && len(existing) > 0 {
 				return &domain.PaymentResult{OpID: opID, Status: domain.TxStatusRealized, Transactions: existing}, nil
 			}
+			if lerr != nil {
+				s.log().ErrorContext(ctx, "settle: re-read of racing legs failed", "err", lerr, "op_id", opID)
+			}
+		}
+		if clientClassErr(err) {
+			s.log().WarnContext(ctx, "settle rejected", "err", err, "op_id", opID)
+		} else {
+			s.log().ErrorContext(ctx, "settle failed", "err", err, "op_id", opID)
 		}
 		return nil, err
 	}
@@ -102,6 +110,13 @@ func (s *Service) SettleTrade(ctx context.Context, in SettleTradeInput) (*domain
 
 	user, err := s.Store.GetAccountByID(ctx, in.AccountID)
 	if err != nil {
+		if apperrIs(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "settle trade: account not found",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		} else {
+			s.log().ErrorContext(ctx, "settle trade: account lookup failed",
+				"err", err, "account_id", in.AccountID, "op_id", in.OpID)
+		}
 		return nil, err
 	}
 	// Spec p.56: zaposleni (aktuari) trguju sa bankinog računa. Refuse
@@ -113,10 +128,14 @@ func (s *Service) SettleTrade(ctx context.Context, in SettleTradeInput) (*domain
 	// orders settle from the fund's own bank account (KindFund), which
 	// is bank-owned too (owner_client_id = FundsOwnerID).
 	if in.IsActuary && user.Kind != domain.KindSystem && user.Kind != domain.KindForexBook && user.Kind != domain.KindFund {
+		s.log().WarnContext(ctx, "settle trade rejected: actuary on non-bank account",
+			"account_id", in.AccountID, "op_id", in.OpID, "account_kind", user.Kind)
 		return nil, apperr.FailedPrecondition("aktuari mogu trgovati samo sa bankinog računa")
 	}
 	house, err := s.Store.GetSystemAccount(ctx, in.Currency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle trade: house account lookup failed",
+			"err", err, "currency", in.Currency, "op_id", in.OpID)
 		return nil, err
 	}
 	// Same-account trade (actuary debiting a bank account and crediting
@@ -153,12 +172,17 @@ func (s *Service) SettleTrade(ctx context.Context, in SettleTradeInput) (*domain
 	if user.Currency != in.Currency {
 		fb, err := s.Store.GetForexBookAccount(ctx, in.Currency)
 		if err != nil {
+			s.log().ErrorContext(ctx, "settle trade: forex book account lookup failed",
+				"err", err, "currency", in.Currency, "op_id", in.OpID)
 			return nil, err
 		}
 		counterparty = fb
 		if dir == "debit" {
 			_, conv, cerr := s.rateAndConvert(ctx, in.Currency, user.Currency, amt)
 			if cerr != nil {
+				s.log().ErrorContext(ctx, "settle trade: fx conversion failed",
+					"err", cerr, "op_id", in.OpID, "from_currency", in.Currency,
+					"to_currency", user.Currency, "amount", in.Amount)
 				return nil, cerr
 			}
 			fromAmt = conv
@@ -197,9 +221,17 @@ func (s *Service) SettleTrade(ctx context.Context, in SettleTradeInput) (*domain
 		purpose = "Trgovinska poravnava"
 	}
 
-	return s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
+	res, err := s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
 		return s.executeMoneyMove(ctx, tx, from, to, fromAmt, domain.TxKindTrade, in.OpID, initiator, paymentMeta{Purpose: purpose}, 0)
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "trade settled",
+		"op_id", in.OpID, "account_id", in.AccountID, "direction", dir,
+		"amount", in.Amount, "currency", in.Currency, "is_actuary", in.IsActuary,
+		"legs", len(res.Transactions))
+	return res, nil
 }
 
 // SettleForexFillInput pairs the two cash legs of a forex pair fill
@@ -261,18 +293,26 @@ func (s *Service) SettleForexFill(ctx context.Context, in SettleForexFillInput) 
 
 	houseBase, err := s.Store.GetSystemAccount(ctx, in.BaseCurrency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle forex fill: house account lookup failed",
+			"err", err, "currency", in.BaseCurrency, "op_id", in.OpID)
 		return nil, err
 	}
 	houseQuote, err := s.Store.GetSystemAccount(ctx, in.QuoteCurrency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle forex fill: house account lookup failed",
+			"err", err, "currency", in.QuoteCurrency, "op_id", in.OpID)
 		return nil, err
 	}
 	bookBase, err := s.Store.GetForexBookAccount(ctx, in.BaseCurrency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle forex fill: forex book account lookup failed",
+			"err", err, "currency", in.BaseCurrency, "op_id", in.OpID)
 		return nil, err
 	}
 	bookQuote, err := s.Store.GetForexBookAccount(ctx, in.QuoteCurrency)
 	if err != nil {
+		s.log().ErrorContext(ctx, "settle forex fill: forex book account lookup failed",
+			"err", err, "currency", in.QuoteCurrency, "op_id", in.OpID)
 		return nil, err
 	}
 
@@ -303,7 +343,7 @@ func (s *Service) SettleForexFill(ctx context.Context, in SettleForexFillInput) 
 		fromBase, toBase = houseBase, bookBase
 	}
 
-	return s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
+	res, err := s.idempotentSettle(ctx, in.OpID, func(tx pgx.Tx) ([]*domain.Transaction, error) {
 		quoteLegs, err := s.executeMoneyMove(ctx, tx, fromQuote, toQuote, quoteAmt, domain.TxKindForex, in.OpID, initiator, paymentMeta{Purpose: purpose}, 0)
 		if err != nil {
 			return nil, err
@@ -314,4 +354,13 @@ func (s *Service) SettleForexFill(ctx context.Context, in SettleForexFillInput) 
 		}
 		return append(quoteLegs, baseLegs...), nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "forex fill settled",
+		"op_id", in.OpID, "direction", dir,
+		"base_amount", in.BaseAmount, "base_currency", in.BaseCurrency,
+		"quote_amount", in.QuoteAmount, "quote_currency", in.QuoteCurrency,
+		"legs", len(res.Transactions))
+	return res, nil
 }

--- a/services/bank/internal/service/transactions.go
+++ b/services/bank/internal/service/transactions.go
@@ -35,6 +35,8 @@ func (s *Service) ListTransactions(ctx context.Context, f domain.TransactionFilt
 				return nil, 0, err
 			}
 			if a.OwnerClientID != p.UserID {
+				s.log().WarnContext(ctx, "list transactions denied: account not owned by caller",
+					"account_id", f.AccountID, "user_id", p.UserID)
 				return nil, 0, apperr.PermissionDenied("nedovoljne permisije")
 			}
 		}

--- a/services/bank/internal/store/accounts.go
+++ b/services/bank/internal/store/accounts.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -75,6 +77,7 @@ func (s *Store) CreateAccount(ctx context.Context, a *domain.Account) (*domain.A
 		if isCheckViolation(err) {
 			return nil, apperr.Validation("account constraints violated (kind/company/subtype mismatch)")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create account failed", "err", err, "number", a.Number, "owner_client_id", a.OwnerClientID)
 		return nil, apperr.Internal("create account", err)
 	}
 	return out, nil
@@ -87,6 +90,7 @@ func (s *Store) GetAccountByID(ctx context.Context, id string) (*domain.Account,
 		if noRows(err) {
 			return nil, apperr.NotFound("account not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get account failed", "err", err, "account_id", id)
 		return nil, apperr.Internal("get account", err)
 	}
 	return out, nil
@@ -100,6 +104,7 @@ func (s *Store) GetSystemAccount(ctx context.Context, currency domain.Currency) 
 		if noRows(err) {
 			return nil, apperr.NotFound("system account not found for currency " + string(currency))
 		}
+		logger.From(ctx).ErrorContext(ctx, "get system account failed", "err", err, "currency", string(currency))
 		return nil, apperr.Internal("get system account", err)
 	}
 	return out, nil
@@ -116,6 +121,7 @@ func (s *Store) GetForexBookAccount(ctx context.Context, currency domain.Currenc
 		if noRows(err) {
 			return nil, apperr.NotFound("forex book account not found for currency " + string(currency))
 		}
+		logger.From(ctx).ErrorContext(ctx, "get forex book account failed", "err", err, "currency", string(currency))
 		return nil, apperr.Internal("get forex book account", err)
 	}
 	return out, nil
@@ -131,6 +137,7 @@ func (s *Store) GetStateTaxAccount(ctx context.Context) (*domain.Account, error)
 		if noRows(err) {
 			return nil, apperr.NotFound("state tax account not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get state tax account failed", "err", err)
 		return nil, apperr.Internal("get state tax account", err)
 	}
 	return out, nil
@@ -150,6 +157,7 @@ func (s *Store) UpdateAccountLimits(ctx context.Context, id, daily, monthly stri
 		if noRows(err) {
 			return nil, apperr.NotFound("account not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update limits failed", "err", err, "account_id", id)
 		return nil, apperr.Internal("update limits", err)
 	}
 	return out, nil
@@ -168,6 +176,7 @@ func (s *Store) UpdateAccountName(ctx context.Context, id, name string) (*domain
 		if noRows(err) {
 			return nil, apperr.NotFound("account not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update name failed", "err", err, "account_id", id)
 		return nil, apperr.Internal("update name", err)
 	}
 	return out, nil
@@ -189,6 +198,7 @@ func (s *Store) AccountNameTakenByOwner(ctx context.Context, ownerClientID, name
         )`
 	var taken bool
 	if err := s.DB.QueryRow(ctx, q, ownerClientID, name, excludeID).Scan(&taken); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "check name uniqueness failed", "err", err, "owner_client_id", ownerClientID)
 		return false, apperr.Internal("check name uniqueness", err)
 	}
 	return taken, nil
@@ -204,6 +214,7 @@ func (s *Store) SetAccountStatus(ctx context.Context, id string, status domain.A
 		if noRows(err) {
 			return nil, apperr.NotFound("account not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set status failed", "err", err, "account_id", id, "status", string(status))
 		return nil, apperr.Internal("set status", err)
 	}
 	return out, nil
@@ -222,6 +233,7 @@ func (s *Store) ListAccountsDueForMaintenance(ctx context.Context, cutoff time.T
               order by created_at`
 	rows, err := s.DB.Query(ctx, q, cutoff)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list maintenance-due failed", "err", err)
 		return nil, apperr.Internal("list maintenance-due", err)
 	}
 	defer rows.Close()
@@ -229,11 +241,16 @@ func (s *Store) ListAccountsDueForMaintenance(ctx context.Context, cutoff time.T
 	for rows.Next() {
 		a, err := scanAccount(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan maintenance-due account failed", "err", err)
 			return nil, apperr.Internal("scan", err)
 		}
 		out = append(out, a)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate maintenance-due accounts failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // MarkMaintenanceDebited stamps last_maintenance_debit = now() on the
@@ -242,6 +259,7 @@ func (s *Store) ListAccountsDueForMaintenance(ctx context.Context, cutoff time.T
 func (s *Store) MarkMaintenanceDebited(ctx context.Context, tx pgx.Tx, accountID string) error {
 	_, err := tx.Exec(ctx, `update "bank".accounts set last_maintenance_debit = now() where id = $1`, accountID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark maintenance debited failed", "err", err, "account_id", accountID)
 		return apperr.Internal("mark maintenance debited", err)
 	}
 	return nil
@@ -288,6 +306,7 @@ func (s *Store) ListAccounts(ctx context.Context, f domain.AccountFilter, page, 
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "bank".accounts`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count accounts failed", "err", err)
 		return nil, 0, apperr.Internal("count accounts", err)
 	}
 
@@ -298,6 +317,7 @@ func (s *Store) ListAccounts(ctx context.Context, f domain.AccountFilter, page, 
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list accounts failed", "err", err)
 		return nil, 0, apperr.Internal("list accounts", err)
 	}
 	defer rows.Close()
@@ -305,11 +325,16 @@ func (s *Store) ListAccounts(ctx context.Context, f domain.AccountFilter, page, 
 	for rows.Next() {
 		a, err := scanAccount(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan account failed", "err", err)
 			return nil, 0, apperr.Internal("scan account", err)
 		}
 		out = append(out, a)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate accounts failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // ResetSpentCounters zeroes daily_spent for every account whose recorded
@@ -331,9 +356,14 @@ func (s *Store) ListAccounts(ctx context.Context, f domain.AccountFilter, page, 
 func (s *Store) ResetSpentCounters(ctx context.Context) (daily, monthly int64, err error) {
 	tx, err := s.DB.Begin(ctx)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "begin spent-reset tx failed", "err", err)
 		return 0, 0, apperr.Internal("begin spent-reset tx", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() {
+		if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+			logger.From(ctx).WarnContext(ctx, "rollback spent-reset tx failed", "err", rbErr)
+		}
+	}()
 
 	const dailyQ = `
         update "bank".accounts
@@ -343,6 +373,7 @@ func (s *Store) ResetSpentCounters(ctx context.Context) (daily, monthly int64, e
          where daily_spent_reset_on < current_date`
 	tag, err := tx.Exec(ctx, dailyQ)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset daily spent failed", "err", err)
 		return 0, 0, apperr.Internal("reset daily spent", err)
 	}
 	daily = tag.RowsAffected()
@@ -355,11 +386,13 @@ func (s *Store) ResetSpentCounters(ctx context.Context) (daily, monthly int64, e
          where date_trunc('month', monthly_spent_reset_on) < date_trunc('month', current_date)`
 	tag, err = tx.Exec(ctx, monthlyQ)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset monthly spent failed", "err", err)
 		return daily, 0, apperr.Internal("reset monthly spent", err)
 	}
 	monthly = tag.RowsAffected()
 
 	if err := tx.Commit(ctx); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "commit spent-reset tx failed", "err", err)
 		return 0, 0, apperr.Internal("commit spent-reset tx", err)
 	}
 	return daily, monthly, nil

--- a/services/bank/internal/store/authorized_persons.go
+++ b/services/bank/internal/store/authorized_persons.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -39,6 +40,7 @@ func (s *Store) CreateAuthorizedPerson(ctx context.Context, p *domain.Authorized
 		p.Email, p.Phone, p.Address,
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create authorized person failed", "err", err, "company_id", p.CompanyID)
 		return nil, apperr.Internal("create authorized person", err)
 	}
 	return out, nil
@@ -51,6 +53,7 @@ func (s *Store) GetAuthorizedPersonByID(ctx context.Context, id string) (*domain
 		if noRows(err) {
 			return nil, apperr.NotFound("ovlašćeno lice ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get authorized person failed", "err", err, "authorized_person_id", id)
 		return nil, apperr.Internal("get authorized person", err)
 	}
 	return out, nil
@@ -60,6 +63,7 @@ func (s *Store) ListAuthorizedPersonsByCompany(ctx context.Context, companyID st
 	const q = `select ` + authorizedPersonColumns + ` from "bank".authorized_persons where company_id = $1 order by last_name, first_name`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, companyID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list authorized persons failed", "err", err, "company_id", companyID)
 		return nil, apperr.Internal("list authorized persons", err)
 	}
 	defer rows.Close()
@@ -67,9 +71,14 @@ func (s *Store) ListAuthorizedPersonsByCompany(ctx context.Context, companyID st
 	for rows.Next() {
 		p, err := scanAuthorizedPerson(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan authorized person failed", "err", err)
 			return nil, apperr.Internal("scan authorized person", err)
 		}
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate authorized persons failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }

--- a/services/bank/internal/store/cards.go
+++ b/services/bank/internal/store/cards.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -46,6 +47,7 @@ func (s *Store) CreateCard(ctx context.Context, c *domain.Card) (*domain.Card, e
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("card number collision")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create card failed", "err", err, "account_id", c.AccountID)
 		return nil, apperr.Internal("create card", err)
 	}
 	return out, nil
@@ -58,6 +60,7 @@ func (s *Store) GetCardByID(ctx context.Context, id string) (*domain.Card, error
 		if noRows(err) {
 			return nil, apperr.NotFound("kartica ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get card failed", "err", err, "card_id", id)
 		return nil, apperr.Internal("get card", err)
 	}
 	return out, nil
@@ -67,6 +70,7 @@ func (s *Store) ListCardsByAccount(ctx context.Context, accountID string) ([]*do
 	const q = `select ` + cardColumns + ` from "bank".cards where account_id = $1 order by created_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, accountID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list cards failed", "err", err, "account_id", accountID)
 		return nil, apperr.Internal("list cards", err)
 	}
 	defer rows.Close()
@@ -74,11 +78,16 @@ func (s *Store) ListCardsByAccount(ctx context.Context, accountID string) ([]*do
 	for rows.Next() {
 		c, err := scanCard(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan card failed", "err", err)
 			return nil, apperr.Internal("scan card", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate cards failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListCardsByOwner returns every card whose owning account belongs to
@@ -93,6 +102,7 @@ func (s *Store) ListCardsByOwner(ctx context.Context, ownerClientID string) ([]*
 	           order by c.created_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, ownerClientID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list cards by owner failed", "err", err, "owner_client_id", ownerClientID)
 		return nil, apperr.Internal("list cards by owner", err)
 	}
 	defer rows.Close()
@@ -100,11 +110,16 @@ func (s *Store) ListCardsByOwner(ctx context.Context, ownerClientID string) ([]*
 	for rows.Next() {
 		c, err := scanCard(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan card failed", "err", err)
 			return nil, apperr.Internal("scan card", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate cards by owner failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListAllCards returns every card in the system. Reserved for
@@ -114,6 +129,7 @@ func (s *Store) ListAllCards(ctx context.Context) ([]*domain.Card, error) {
 	const q = `select ` + cardColumns + ` from "bank".cards order by created_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list all cards failed", "err", err)
 		return nil, apperr.Internal("list all cards", err)
 	}
 	defer rows.Close()
@@ -121,11 +137,16 @@ func (s *Store) ListAllCards(ctx context.Context) ([]*domain.Card, error) {
 	for rows.Next() {
 		c, err := scanCard(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan card failed", "err", err)
 			return nil, apperr.Internal("scan card", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate all cards failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // CountActiveCards returns the count of non-deactivated cards on
@@ -144,6 +165,7 @@ func (s *Store) CountActiveCards(ctx context.Context, accountID, authorizedPerso
 	}
 	var n int
 	if err := s.DB.QueryRow(ctx, q, args...).Scan(&n); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count cards failed", "err", err, "account_id", accountID)
 		return 0, apperr.Internal("count cards", err)
 	}
 	return n, nil
@@ -159,6 +181,7 @@ func (s *Store) SetCardStatus(ctx context.Context, id string, status domain.Card
 		if noRows(err) {
 			return nil, apperr.NotFound("kartica ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set card status failed", "err", err, "card_id", id, "status", string(status))
 		return nil, apperr.Internal("set card status", err)
 	}
 	return out, nil
@@ -174,6 +197,7 @@ func (s *Store) UpdateCardLimit(ctx context.Context, id, cardLimit string) (*dom
 		if noRows(err) {
 			return nil, apperr.NotFound("kartica ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update card limit failed", "err", err, "card_id", id)
 		return nil, apperr.Internal("update card limit", err)
 	}
 	return out, nil

--- a/services/bank/internal/store/companies.go
+++ b/services/bank/internal/store/companies.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -40,6 +41,7 @@ func (s *Store) CreateCompany(ctx context.Context, c *domain.Company) (*domain.C
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("company with this matični broj or PIB already exists")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create company failed", "err", err, "owner_client_id", c.OwnerClientID)
 		return nil, apperr.Internal("create company", err)
 	}
 	return out, nil
@@ -52,6 +54,7 @@ func (s *Store) GetCompanyByID(ctx context.Context, id string) (*domain.Company,
 		if noRows(err) {
 			return nil, apperr.NotFound("company not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get company failed", "err", err, "company_id", id)
 		return nil, apperr.Internal("get company", err)
 	}
 	return out, nil
@@ -72,6 +75,7 @@ func (s *Store) UpdateCompany(ctx context.Context, c *domain.Company) (*domain.C
 		if noRows(err) {
 			return nil, apperr.NotFound("company not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update company failed", "err", err, "company_id", c.ID)
 		return nil, apperr.Internal("update company", err)
 	}
 	return out, nil
@@ -102,6 +106,7 @@ func (s *Store) ListCompanies(ctx context.Context, f domain.CompanyFilter, page,
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "bank".companies`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count companies failed", "err", err)
 		return nil, 0, apperr.Internal("count companies", err)
 	}
 
@@ -112,6 +117,7 @@ func (s *Store) ListCompanies(ctx context.Context, f domain.CompanyFilter, page,
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list companies failed", "err", err)
 		return nil, 0, apperr.Internal("list companies", err)
 	}
 	defer rows.Close()
@@ -119,9 +125,14 @@ func (s *Store) ListCompanies(ctx context.Context, f domain.CompanyFilter, page,
 	for rows.Next() {
 		c, err := scanCompany(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan company failed", "err", err)
 			return nil, 0, apperr.Internal("scan company", err)
 		}
 		out = append(out, c)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate companies failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }

--- a/services/bank/internal/store/forex_forward.go
+++ b/services/bank/internal/store/forex_forward.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -39,6 +40,7 @@ func (s *Store) GetForexForwardSpread(ctx context.Context, base, quote domain.Cu
 		if noRows(err) {
 			return nil, apperr.NotFound("spread za valutni par nije podešen")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get forex spread failed", "err", err, "base", string(base), "quote", string(quote))
 		return nil, apperr.Internal("get forex spread", err)
 	}
 	return sp, nil
@@ -50,6 +52,7 @@ func (s *Store) ListForexForwardSpreads(ctx context.Context) ([]*domain.ForexFor
         from "bank".forex_forward_spreads order by base_currency, quote_currency`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list forex spreads failed", "err", err)
 		return nil, apperr.Internal("list forex spreads", err)
 	}
 	defer rows.Close()
@@ -57,11 +60,16 @@ func (s *Store) ListForexForwardSpreads(ctx context.Context) ([]*domain.ForexFor
 	for rows.Next() {
 		sp, err := scanForexSpread(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan forex spread failed", "err", err)
 			return nil, apperr.Internal("scan forex spread", err)
 		}
 		out = append(out, sp)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate forex spreads failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // UpsertForexForwardSpread inserts or updates a pair's SpreadFactor,
@@ -78,6 +86,7 @@ func (s *Store) UpsertForexForwardSpread(ctx context.Context, sp *domain.ForexFo
 	out, err := scanForexSpread(s.DB.QueryRow(ctx, q,
 		string(sp.BaseCurrency), string(sp.QuoteCurrency), sp.SpreadFactor, sp.UpdatedBy))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert forex spread failed", "err", err, "base", string(sp.BaseCurrency), "quote", string(sp.QuoteCurrency))
 		return nil, apperr.Internal("upsert forex spread", err)
 	}
 	return out, nil
@@ -128,6 +137,7 @@ func (s *Store) InsertForexForward(ctx context.Context, tx pgx.Tx, f *domain.For
 		f.FromAccountID, f.ToAccountID, f.SettlementDate,
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert forex forward failed", "err", err, "client_id", f.ClientID, "from_account_id", f.FromAccountID)
 		return nil, apperr.Internal("insert forex forward", err)
 	}
 	return out, nil
@@ -141,6 +151,7 @@ func (s *Store) GetForexForward(ctx context.Context, id string) (*domain.ForexFo
 		if noRows(err) {
 			return nil, apperr.NotFound("terminski ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get forex forward failed", "err", err, "forward_id", id)
 		return nil, apperr.Internal("get forex forward", err)
 	}
 	return f, nil
@@ -167,6 +178,7 @@ func (s *Store) ListDueForexForwards(ctx context.Context, now time.Time) ([]*dom
 func (s *Store) queryForexForwards(ctx context.Context, q string, args ...any) ([]*domain.ForexForward, error) {
 	rows, err := s.DB.Query(ctx, q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list forex forwards failed", "err", err)
 		return nil, apperr.Internal("list forex forwards", err)
 	}
 	defer rows.Close()
@@ -174,11 +186,16 @@ func (s *Store) queryForexForwards(ctx context.Context, q string, args ...any) (
 	for rows.Next() {
 		f, err := scanForexForward(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan forex forward failed", "err", err)
 			return nil, apperr.Internal("scan forex forward", err)
 		}
 		out = append(out, f)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate forex forwards failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // MarkForexForwardSettled flips an 'active' row to 'settled' and stamps
@@ -189,6 +206,7 @@ func (s *Store) MarkForexForwardSettled(ctx context.Context, id string, at time.
            set status = 'settled', settled_at = $2, failure_reason = null
          where id = $1 and status = 'active'`
 	if _, err := s.DB.Exec(ctx, q, id, at); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark forex forward settled failed", "err", err, "forward_id", id)
 		return apperr.Internal("mark forex forward settled", err)
 	}
 	return nil
@@ -202,6 +220,7 @@ func (s *Store) MarkForexForwardFailed(ctx context.Context, id, reason string, a
            set status = 'failed', settled_at = $2, failure_reason = $3
          where id = $1 and status = 'active'`
 	if _, err := s.DB.Exec(ctx, q, id, at, reason); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark forex forward failed failed", "err", err, "forward_id", id)
 		return apperr.Internal("mark forex forward failed", err)
 	}
 	return nil
@@ -228,6 +247,7 @@ func (s *Store) CancelForexForward(ctx context.Context, id, clientID string) (*d
 			}
 			return nil, apperr.FailedPrecondition("terminski ugovor se više ne može otkazati")
 		}
+		logger.From(ctx).ErrorContext(ctx, "cancel forex forward failed", "err", err, "forward_id", id, "client_id", clientID)
 		return nil, apperr.Internal("cancel forex forward", err)
 	}
 	return f, nil

--- a/services/bank/internal/store/interbank.go
+++ b/services/bank/internal/store/interbank.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -70,6 +71,7 @@ func (s *Store) InsertInterbankTx(ctx context.Context, tx pgx.Tx, t *domain.Inte
 		if IsUniqueViolation(err) {
 			return nil, apperr.Conflict("transaction already exists")
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert interbank tx failed", "err", err, "sender_routing", t.SenderRoutingNumber, "tx_id", t.TransactionID)
 		return nil, apperr.Internal("insert interbank tx", err)
 	}
 	return out, nil
@@ -95,6 +97,7 @@ func (s *Store) GetInterbankTx(ctx context.Context, tx pgx.Tx, senderRouting int
 		if noRows(err) {
 			return nil, apperr.NotFound("interbank transaction not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get interbank tx failed", "err", err, "sender_routing", senderRouting, "tx_id", txID)
 		return nil, apperr.Internal("get interbank tx", err)
 	}
 	return out, nil
@@ -117,6 +120,7 @@ func (s *Store) MarkInterbankTxStatus(ctx context.Context, tx pgx.Tx, senderRout
 		if noRows(err) {
 			return nil, apperr.NotFound("interbank transaction not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "mark interbank tx status failed", "err", err, "sender_routing", senderRouting, "tx_id", txID, "next_status", string(next))
 		return nil, apperr.Internal("mark interbank tx status", err)
 	}
 	return out, nil
@@ -164,6 +168,7 @@ func (s *Store) UpsertInterbankMessage(ctx context.Context, tx pgx.Tx, m *domain
 		m.TransactionID, m.ResponseStatus, m.ResponseBody,
 	)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert interbank message failed", "err", err, "sender_routing", m.SenderRoutingNumber, "idempotence_key", m.IdempotenceKey)
 		return apperr.Internal("upsert interbank message", err)
 	}
 	return nil
@@ -180,6 +185,7 @@ func (s *Store) GetInterbankMessage(ctx context.Context, senderRouting int, key 
 		if noRows(err) {
 			return nil, apperr.NotFound("interbank message not seen")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get interbank message failed", "err", err, "sender_routing", senderRouting, "key", key)
 		return nil, apperr.Internal("get interbank message", err)
 	}
 	return out, nil
@@ -226,6 +232,7 @@ func (s *Store) ListInterbankTransactions(ctx context.Context, f InterbankTxFilt
 
 	var total int64
 	if err := s.DB.QueryRow(ctx, `select count(*) from "bank".interbank_protocol_transactions `+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count interbank transactions failed", "err", err)
 		return nil, 0, apperr.Internal("count interbank transactions", err)
 	}
 
@@ -235,6 +242,7 @@ func (s *Store) ListInterbankTransactions(ctx context.Context, f InterbankTxFilt
 		fmt.Sprintf(" order by created_at desc, transaction_id desc limit $%d offset $%d", len(args)-1, len(args))
 	rows, err := s.DB.Query(ctx, q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list interbank transactions failed", "err", err)
 		return nil, 0, apperr.Internal("list interbank transactions", err)
 	}
 	defer rows.Close()
@@ -242,11 +250,13 @@ func (s *Store) ListInterbankTransactions(ctx context.Context, f InterbankTxFilt
 	for rows.Next() {
 		t, serr := scanInterbankTx(rows)
 		if serr != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan interbank transaction failed", "err", serr)
 			return nil, 0, apperr.Internal("scan interbank transaction", serr)
 		}
 		out = append(out, t)
 	}
 	if rows.Err() != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate interbank transactions failed", "err", rows.Err())
 		return nil, 0, apperr.Internal("iterate interbank transactions", rows.Err())
 	}
 	return out, total, nil
@@ -285,6 +295,7 @@ func (s *Store) ListInterbankMessages(ctx context.Context, f InterbankMsgFilter,
 
 	var total int64
 	if err := s.DB.QueryRow(ctx, `select count(*) from "bank".interbank_protocol_messages `+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count interbank messages failed", "err", err)
 		return nil, 0, apperr.Internal("count interbank messages", err)
 	}
 
@@ -294,6 +305,7 @@ func (s *Store) ListInterbankMessages(ctx context.Context, f InterbankMsgFilter,
 		fmt.Sprintf(" order by created_at desc, idempotence_key desc limit $%d offset $%d", len(args)-1, len(args))
 	rows, err := s.DB.Query(ctx, q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list interbank messages failed", "err", err)
 		return nil, 0, apperr.Internal("list interbank messages", err)
 	}
 	defer rows.Close()
@@ -301,11 +313,13 @@ func (s *Store) ListInterbankMessages(ctx context.Context, f InterbankMsgFilter,
 	for rows.Next() {
 		m, serr := scanInterbankMsg(rows)
 		if serr != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan interbank message failed", "err", serr)
 			return nil, 0, apperr.Internal("scan interbank message", serr)
 		}
 		out = append(out, m)
 	}
 	if rows.Err() != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate interbank messages failed", "err", rows.Err())
 		return nil, 0, apperr.Internal("iterate interbank messages", rows.Err())
 	}
 	return out, total, nil
@@ -337,6 +351,7 @@ func (s *Store) IsBlacklisted(ctx context.Context, senderRouting int) (bool, err
 	    where sender_routing_number = $1 and active)`
 	var ok bool
 	if err := s.DB.QueryRow(ctx, q, senderRouting).Scan(&ok); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "check interbank blacklist failed", "err", err, "sender_routing", senderRouting)
 		return false, apperr.Internal("check interbank blacklist", err)
 	}
 	return ok, nil
@@ -359,6 +374,7 @@ func (s *Store) BlockBank(ctx context.Context, senderRouting int, reason, blocke
 	    returning ` + interbankBlacklistCols
 	out, err := scanBlacklistEntry(s.DB.QueryRow(ctx, q, senderRouting, reason, blockedBy))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "block bank failed", "err", err, "sender_routing", senderRouting)
 		return nil, apperr.Internal("block bank", err)
 	}
 	return out, nil
@@ -377,6 +393,7 @@ func (s *Store) UnblockBank(ctx context.Context, senderRouting int) (*domain.Int
 		if noRows(err) {
 			return nil, apperr.NotFound("no active blacklist entry for routing number")
 		}
+		logger.From(ctx).ErrorContext(ctx, "unblock bank failed", "err", err, "sender_routing", senderRouting)
 		return nil, apperr.Internal("unblock bank", err)
 	}
 	return out, nil
@@ -392,6 +409,7 @@ func (s *Store) ListBlacklist(ctx context.Context, activeOnly bool) ([]*domain.I
 	q += ` order by blocked_at desc`
 	rows, err := s.DB.Query(ctx, q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list blacklist failed", "err", err)
 		return nil, apperr.Internal("list blacklist", err)
 	}
 	defer rows.Close()
@@ -399,11 +417,13 @@ func (s *Store) ListBlacklist(ctx context.Context, activeOnly bool) ([]*domain.I
 	for rows.Next() {
 		e, serr := scanBlacklistEntry(rows)
 		if serr != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan blacklist entry failed", "err", serr)
 			return nil, apperr.Internal("scan blacklist entry", serr)
 		}
 		out = append(out, e)
 	}
 	if rows.Err() != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate blacklist failed", "err", rows.Err())
 		return nil, apperr.Internal("iterate blacklist", rows.Err())
 	}
 	return out, nil
@@ -423,6 +443,7 @@ func (s *Store) RecordPartnerFailure(ctx context.Context, senderRouting int) (in
 	    returning consecutive_failures`
 	var n int
 	if err := s.DB.QueryRow(ctx, q, senderRouting).Scan(&n); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "record partner failure failed", "err", err, "sender_routing", senderRouting)
 		return 0, apperr.Internal("record partner failure", err)
 	}
 	return n, nil
@@ -437,6 +458,7 @@ func (s *Store) ResetPartnerFailures(ctx context.Context, senderRouting int) err
 	    set consecutive_failures = 0, updated_at = now()
 	    where sender_routing_number = $1 and consecutive_failures <> 0`
 	if _, err := s.DB.Exec(ctx, q, senderRouting); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset partner failures failed", "err", err, "sender_routing", senderRouting)
 		return apperr.Internal("reset partner failures", err)
 	}
 	return nil

--- a/services/bank/internal/store/loans.go
+++ b/services/bank/internal/store/loans.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -68,6 +69,7 @@ func (s *Store) CreateLoanRequest(ctx context.Context, r *domain.LoanRequest) (*
 		r.EmploymentDurationMonths, r.InstallmentsTotal, r.ContactPhone,
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create loan request failed", "err", err, "client_id", r.ClientID, "account_id", r.AccountID)
 		return nil, apperr.Internal("create loan request", err)
 	}
 	return out, nil
@@ -80,6 +82,7 @@ func (s *Store) GetLoanRequestByID(ctx context.Context, id string) (*domain.Loan
 		if noRows(err) {
 			return nil, apperr.NotFound("zahtev za kredit ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get loan request failed", "err", err, "request_id", id)
 		return nil, apperr.Internal("get loan request", err)
 	}
 	return out, nil
@@ -98,6 +101,7 @@ func (s *Store) DecideLoanRequest(ctx context.Context, tx pgx.Tx, id, employeeID
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("zahtev je već obrađen ili ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "decide loan request failed", "err", err, "request_id", id, "status", string(status))
 		return nil, apperr.Internal("decide loan request", err)
 	}
 	return out, nil
@@ -134,6 +138,7 @@ func (s *Store) ListLoanRequests(ctx context.Context, f domain.LoanRequestFilter
 	}
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "bank".loan_requests`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count loan requests failed", "err", err)
 		return nil, 0, apperr.Internal("count loan requests", err)
 	}
 	listArgs := append([]any{}, args...)
@@ -142,6 +147,7 @@ func (s *Store) ListLoanRequests(ctx context.Context, f domain.LoanRequestFilter
 		fmt.Sprintf(" order by created_at desc limit $%d offset $%d", len(args)+1, len(args)+2)
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list loan requests failed", "err", err)
 		return nil, 0, apperr.Internal("list loan requests", err)
 	}
 	defer rows.Close()
@@ -149,11 +155,16 @@ func (s *Store) ListLoanRequests(ctx context.Context, f domain.LoanRequestFilter
 	for rows.Next() {
 		r, err := scanLoanRequest(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan loan request failed", "err", err)
 			return nil, 0, apperr.Internal("scan loan request", err)
 		}
 		out = append(out, r)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate loan requests failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // =====================================================================
@@ -221,6 +232,7 @@ func (s *Store) CreateLoan(ctx context.Context, tx pgx.Tx, l *domain.Loan) (*dom
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("loan number collision")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create loan failed", "err", err, "client_id", l.ClientID, "request_id", l.RequestID)
 		return nil, apperr.Internal("create loan", err)
 	}
 	return out, nil
@@ -233,6 +245,7 @@ func (s *Store) GetLoanByID(ctx context.Context, id string) (*domain.Loan, error
 		if noRows(err) {
 			return nil, apperr.NotFound("kredit ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get loan failed", "err", err, "loan_id", id)
 		return nil, apperr.Internal("get loan", err)
 	}
 	return out, nil
@@ -252,6 +265,7 @@ func (s *Store) UpdateLoanAfterInstallment(ctx context.Context, tx pgx.Tx, loanI
             updated_at = now()
         where id = $1`
 	if _, err := tx.Exec(ctx, q, loanID, newRemaining, nextDate, nextAmount, string(status)); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "update loan failed", "err", err, "loan_id", loanID)
 		return apperr.Internal("update loan", err)
 	}
 	return nil
@@ -271,6 +285,7 @@ func (s *Store) UpdateVariableRate(ctx context.Context, tx pgx.Tx, loanID, newOf
             updated_at = now()
         where id = $1`
 	if _, err := tx.Exec(ctx, q, loanID, newOffset, newInstallmentAmount); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "update variable rate failed", "err", err, "loan_id", loanID)
 		return apperr.Internal("update variable rate", err)
 	}
 	return nil
@@ -307,6 +322,7 @@ func (s *Store) ListLoans(ctx context.Context, f domain.LoanFilter, page, pageSi
 	}
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "bank".loans`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count loans failed", "err", err)
 		return nil, 0, apperr.Internal("count loans", err)
 	}
 	listArgs := append([]any{}, args...)
@@ -315,6 +331,7 @@ func (s *Store) ListLoans(ctx context.Context, f domain.LoanFilter, page, pageSi
 		fmt.Sprintf(" order by contracted_at desc limit $%d offset $%d", len(args)+1, len(args)+2)
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list loans failed", "err", err)
 		return nil, 0, apperr.Internal("list loans", err)
 	}
 	defer rows.Close()
@@ -322,11 +339,16 @@ func (s *Store) ListLoans(ctx context.Context, f domain.LoanFilter, page, pageSi
 	for rows.Next() {
 		l, err := scanLoan(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan loan failed", "err", err)
 			return nil, 0, apperr.Internal("scan loan", err)
 		}
 		out = append(out, l)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate loans failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 func (s *Store) ListActiveVariableLoans(ctx context.Context) ([]*domain.Loan, error) {
@@ -335,6 +357,7 @@ func (s *Store) ListActiveVariableLoans(ctx context.Context) ([]*domain.Loan, er
               order by id`
 	rows, err := s.DB.Query(ctx, q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list variable loans failed", "err", err)
 		return nil, apperr.Internal("list variable loans", err)
 	}
 	defer rows.Close()
@@ -342,11 +365,16 @@ func (s *Store) ListActiveVariableLoans(ctx context.Context) ([]*domain.Loan, er
 	for rows.Next() {
 		l, err := scanLoan(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan variable loan failed", "err", err)
 			return nil, apperr.Internal("scan variable loan", err)
 		}
 		out = append(out, l)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate variable loans failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // =====================================================================
@@ -388,6 +416,7 @@ func (s *Store) CreateInstallment(ctx context.Context, tx pgx.Tx, i *domain.Loan
 		i.ExpectedDueDate, string(i.Status),
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create installment failed", "err", err, "loan_id", i.LoanID)
 		return nil, apperr.Internal("create installment", err)
 	}
 	return out, nil
@@ -396,6 +425,7 @@ func (s *Store) CreateInstallment(ctx context.Context, tx pgx.Tx, i *domain.Loan
 func (s *Store) MarkInstallmentPaid(ctx context.Context, tx pgx.Tx, id string) error {
 	const q = `update "bank".loan_installments set status = 'paid', actual_paid_at = now(), updated_at = now() where id = $1`
 	if _, err := tx.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark installment paid failed", "err", err, "installment_id", id)
 		return apperr.Internal("mark installment paid", err)
 	}
 	return nil
@@ -408,6 +438,7 @@ func (s *Store) CountPaidInstallments(ctx context.Context, loanID string) (int, 
 	const q = `select count(*) from "bank".loan_installments where loan_id = $1 and status = 'paid'`
 	var n int
 	if err := s.DB.QueryRow(ctx, q, loanID).Scan(&n); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count paid installments failed", "err", err, "loan_id", loanID)
 		return 0, apperr.Internal("count paid installments", err)
 	}
 	return n, nil
@@ -425,6 +456,7 @@ func (s *Store) MarkInstallmentOverdue(ctx context.Context, tx pgx.Tx, id string
                updated_at    = now()
          where id = $1`
 	if _, err := tx.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark installment overdue failed", "err", err, "installment_id", id)
 		return apperr.Internal("mark installment overdue", err)
 	}
 	return nil
@@ -440,6 +472,7 @@ func (s *Store) RescheduleOverdueRetry(ctx context.Context, tx pgx.Tx, id string
                updated_at    = now()
          where id = $1`
 	if _, err := tx.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reschedule overdue retry failed", "err", err, "installment_id", id)
 		return apperr.Internal("reschedule overdue retry", err)
 	}
 	return nil
@@ -472,8 +505,10 @@ func (s *Store) ApplyLatePenalty(
 	if err != nil {
 		if noRows(err) {
 			// Already applied — nothing to do.
+			logger.From(ctx).WarnContext(ctx, "late penalty already applied, skipping", "loan_id", loanID)
 			return nil
 		}
+		logger.From(ctx).ErrorContext(ctx, "apply late penalty failed", "err", err, "loan_id", loanID)
 		return apperr.Internal("apply late penalty", err)
 	}
 	const instQ = `
@@ -484,6 +519,7 @@ func (s *Store) ApplyLatePenalty(
          where loan_id = $1
            and status in ('unpaid','overdue')`
 	if _, err := tx.Exec(ctx, instQ, loanID, newInstallmentAmount, newRateAtDue); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "rewrite installments after penalty failed", "err", err, "loan_id", loanID)
 		return apperr.Internal("rewrite installments after penalty", err)
 	}
 	return nil
@@ -511,6 +547,7 @@ func (s *Store) ListInstallmentsDueOn(ctx context.Context, dueOn time.Time) ([]*
          order by expected_due_date, sequence_number`
 	rows, err := s.DB.Query(ctx, q, dueOn)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due installments failed", "err", err, "due_on", dueOn)
 		return nil, apperr.Internal("list due installments", err)
 	}
 	defer rows.Close()
@@ -518,11 +555,16 @@ func (s *Store) ListInstallmentsDueOn(ctx context.Context, dueOn time.Time) ([]*
 	for rows.Next() {
 		i, err := scanInstallment(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan installment failed", "err", err)
 			return nil, apperr.Internal("scan installment", err)
 		}
 		out = append(out, i)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate due installments failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func (s *Store) ListInstallmentsByLoan(ctx context.Context, loanID string) ([]*domain.LoanInstallment, error) {
@@ -530,6 +572,7 @@ func (s *Store) ListInstallmentsByLoan(ctx context.Context, loanID string) ([]*d
               where loan_id = $1 order by sequence_number`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, loanID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list installments failed", "err", err, "loan_id", loanID)
 		return nil, apperr.Internal("list installments", err)
 	}
 	defer rows.Close()
@@ -537,9 +580,14 @@ func (s *Store) ListInstallmentsByLoan(ctx context.Context, loanID string) ([]*d
 	for rows.Next() {
 		i, err := scanInstallment(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan installment failed", "err", err)
 			return nil, apperr.Internal("scan installment", err)
 		}
 		out = append(out, i)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate installments failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }

--- a/services/bank/internal/store/recipients.go
+++ b/services/bank/internal/store/recipients.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -27,6 +28,7 @@ func (s *Store) UpsertPaymentRecipient(ctx context.Context, r *domain.PaymentRec
         returning ` + recipientColumns
 	out, err := scanRecipient(s.DB.QueryRow(ctx, q, r.ClientID, r.Name, r.AccountNumber))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert recipient failed", "err", err, "client_id", r.ClientID)
 		return nil, apperr.Internal("upsert recipient", err)
 	}
 	return out, nil
@@ -36,6 +38,7 @@ func (s *Store) ListPaymentRecipients(ctx context.Context, clientID string) ([]*
 	const q = `select ` + recipientColumns + ` from "bank".payment_recipients where client_id = $1 order by lower(name)`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, clientID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list recipients failed", "err", err, "client_id", clientID)
 		return nil, apperr.Internal("list recipients", err)
 	}
 	defer rows.Close()
@@ -43,11 +46,16 @@ func (s *Store) ListPaymentRecipients(ctx context.Context, clientID string) ([]*
 	for rows.Next() {
 		r, err := scanRecipient(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan recipient failed", "err", err)
 			return nil, apperr.Internal("scan recipient", err)
 		}
 		out = append(out, r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate recipients failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func (s *Store) UpdatePaymentRecipient(ctx context.Context, r *domain.PaymentRecipient) (*domain.PaymentRecipient, error) {
@@ -60,6 +68,7 @@ func (s *Store) UpdatePaymentRecipient(ctx context.Context, r *domain.PaymentRec
 		if noRows(err) {
 			return nil, apperr.NotFound("primalac ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update recipient failed", "err", err, "recipient_id", r.ID, "client_id", r.ClientID)
 		return nil, apperr.Internal("update recipient", err)
 	}
 	return out, nil
@@ -69,6 +78,7 @@ func (s *Store) DeletePaymentRecipient(ctx context.Context, id, clientID string)
 	const q = `delete from "bank".payment_recipients where id = $1 and client_id = $2`
 	tag, err := s.DB.Exec(ctx, q, id, clientID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "delete recipient failed", "err", err, "recipient_id", id, "client_id", clientID)
 		return apperr.Internal("delete recipient", err)
 	}
 	if tag.RowsAffected() == 0 {

--- a/services/bank/internal/store/reservations.go
+++ b/services/bank/internal/store/reservations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
 
@@ -44,6 +45,7 @@ func (s *Store) InsertReservation(ctx context.Context, tx pgx.Tx, r *domain.Rese
 		if isUniqueViolation(err) {
 			return nil, ErrReservationExists
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert reservation failed", "err", err, "op_id", r.OpID, "account_id", r.AccountID)
 		return nil, apperr.Internal("insert reservation", err)
 	}
 	return out, nil
@@ -60,6 +62,7 @@ func (s *Store) GetReservationByOpID(ctx context.Context, opID string) (*domain.
 		if noRows(err) {
 			return nil, apperr.NotFound("reservation not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get reservation failed", "err", err, "op_id", opID)
 		return nil, apperr.Internal("get reservation", err)
 	}
 	return out, nil
@@ -74,6 +77,7 @@ func (s *Store) GetReservationByOpIDTx(ctx context.Context, tx pgx.Tx, opID stri
 		if noRows(err) {
 			return nil, apperr.NotFound("reservation not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get reservation tx failed", "err", err, "op_id", opID)
 		return nil, apperr.Internal("get reservation tx", err)
 	}
 	return out, nil
@@ -94,6 +98,7 @@ func (s *Store) MarkReservationState(ctx context.Context, tx pgx.Tx, opID string
 		if noRows(err) {
 			return apperr.NotFound("reservation not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update reservation state failed", "err", err, "op_id", opID, "state", string(state))
 		return apperr.Internal("update reservation state", err)
 	}
 	return nil

--- a/services/bank/internal/store/scheduled_payments.go
+++ b/services/bank/internal/store/scheduled_payments.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 )
@@ -46,6 +47,7 @@ func (s *Store) InsertScheduledPayment(ctx context.Context, sp *domain.Scheduled
 		sp.RecipientName, sp.PaymentCode, sp.Purpose, sp.Model, sp.ReferenceNumber, sp.ScheduledDate,
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert scheduled payment failed", "err", err, "client_id", sp.ClientID, "from_account_id", sp.FromAccountID)
 		return nil, apperr.Internal("insert scheduled payment", err)
 	}
 	return out, nil
@@ -58,6 +60,7 @@ func (s *Store) ListScheduledPaymentsByClient(ctx context.Context, clientID stri
         from "bank".scheduled_payments where client_id = $1 order by scheduled_date desc, created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, clientID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list scheduled payments failed", "err", err, "client_id", clientID)
 		return nil, apperr.Internal("list scheduled payments", err)
 	}
 	defer rows.Close()
@@ -65,11 +68,16 @@ func (s *Store) ListScheduledPaymentsByClient(ctx context.Context, clientID stri
 	for rows.Next() {
 		sp, err := scanScheduledPayment(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan scheduled payment failed", "err", err)
 			return nil, apperr.Internal("scan scheduled payment", err)
 		}
 		out = append(out, sp)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate scheduled payments failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // GetScheduledPayment loads a single row by id.
@@ -80,6 +88,7 @@ func (s *Store) GetScheduledPayment(ctx context.Context, id string) (*domain.Sch
 		if noRows(err) {
 			return nil, apperr.NotFound("zakazano plaćanje ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get scheduled payment failed", "err", err, "scheduled_payment_id", id)
 		return nil, apperr.Internal("get scheduled payment", err)
 	}
 	return sp, nil
@@ -108,6 +117,7 @@ func (s *Store) CancelScheduledPayment(ctx context.Context, id, clientID string)
 			}
 			return nil, apperr.FailedPrecondition("zakazano plaćanje se više ne može otkazati")
 		}
+		logger.From(ctx).ErrorContext(ctx, "cancel scheduled payment failed", "err", err, "scheduled_payment_id", id, "client_id", clientID)
 		return nil, apperr.Internal("cancel scheduled payment", err)
 	}
 	return sp, nil
@@ -123,6 +133,7 @@ func (s *Store) ListDueScheduledPayments(ctx context.Context, now time.Time) ([]
        order by scheduled_date asc`
 	rows, err := s.DB.Query(ctx, q, now)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due scheduled payments failed", "err", err)
 		return nil, apperr.Internal("list due scheduled payments", err)
 	}
 	defer rows.Close()
@@ -130,11 +141,16 @@ func (s *Store) ListDueScheduledPayments(ctx context.Context, now time.Time) ([]
 	for rows.Next() {
 		sp, err := scanScheduledPayment(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan scheduled payment failed", "err", err)
 			return nil, apperr.Internal("scan scheduled payment", err)
 		}
 		out = append(out, sp)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate due scheduled payments failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // MarkScheduledPaymentCompleted flips a 'scheduled' row to 'completed'
@@ -145,6 +161,7 @@ func (s *Store) MarkScheduledPaymentCompleted(ctx context.Context, id string, at
            set status = 'completed', executed_at = $2, failure_reason = null
          where id = $1 and status = 'scheduled'`
 	if _, err := s.DB.Exec(ctx, q, id, at); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark scheduled payment completed failed", "err", err, "scheduled_payment_id", id)
 		return apperr.Internal("mark scheduled payment completed", err)
 	}
 	return nil
@@ -159,6 +176,7 @@ func (s *Store) MarkScheduledPaymentFailed(ctx context.Context, id, reason strin
            set status = 'failed', executed_at = $2, failure_reason = $3
          where id = $1 and status = 'scheduled'`
 	if _, err := s.DB.Exec(ctx, q, id, at, reason); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark scheduled payment failed failed", "err", err, "scheduled_payment_id", id)
 		return apperr.Internal("mark scheduled payment failed", err)
 	}
 	return nil

--- a/services/bank/internal/store/transactions.go
+++ b/services/bank/internal/store/transactions.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/bank/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -131,6 +132,7 @@ func (s *Store) AdjustBalance(ctx context.Context, tx pgx.Tx, accountID, delta s
 		if noRows(err) {
 			return ErrInsufficientFunds
 		}
+		logger.From(ctx).ErrorContext(ctx, "adjust balance failed", "err", err, "account_id", accountID)
 		return apperr.Internal("adjust balance", err)
 	}
 	return nil
@@ -165,6 +167,7 @@ func (s *Store) AdjustAvailableBalance(ctx context.Context, tx pgx.Tx, accountID
 		if noRows(err) {
 			return ErrInsufficientFunds
 		}
+		logger.From(ctx).ErrorContext(ctx, "adjust available balance failed", "err", err, "account_id", accountID)
 		return apperr.Internal("adjust available balance", err)
 	}
 	return nil
@@ -189,6 +192,7 @@ func (s *Store) AdjustBalanceOnly(ctx context.Context, tx pgx.Tx, accountID, del
 		if noRows(err) {
 			return ErrInsufficientFunds
 		}
+		logger.From(ctx).ErrorContext(ctx, "adjust balance only failed", "err", err, "account_id", accountID)
 		return apperr.Internal("adjust balance only", err)
 	}
 	return nil
@@ -208,6 +212,7 @@ func (s *Store) CheckLimits(ctx context.Context, tx pgx.Tx, accountID, amount st
         from "bank".accounts where id = $1 for update`
 	var dl, ml, ds, ms string
 	if err := tx.QueryRow(ctx, q, accountID).Scan(&dl, &ml, &ds, &ms); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "read limits failed", "err", err, "account_id", accountID)
 		return apperr.Internal("read limits", err)
 	}
 
@@ -224,6 +229,7 @@ func (s *Store) CheckLimits(ctx context.Context, tx pgx.Tx, accountID, amount st
 		var ok bool
 		err := tx.QueryRow(ctx, "select ($1::numeric + $2::numeric) <= $3::numeric", c.spent, amount, c.limit).Scan(&ok)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "limit math failed", "err", err, "account_id", accountID)
 			return apperr.Internal("limit math", err)
 		}
 		if !ok {
@@ -261,6 +267,7 @@ func (s *Store) InsertTransaction(ctx context.Context, tx pgx.Tx, t *domain.Tran
 	)
 	out, err := scanTransaction(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert transaction failed", "err", err, "op_id", t.OpID, "op_kind", string(t.Kind), "leg_index", t.LegIndex)
 		return nil, apperr.Internal("insert transaction", err)
 	}
 	return out, nil
@@ -309,6 +316,7 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "bank".transactions t`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count transactions failed", "err", err)
 		return nil, 0, apperr.Internal("count transactions", err)
 	}
 
@@ -319,6 +327,7 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list transactions failed", "err", err)
 		return nil, 0, apperr.Internal("list transactions", err)
 	}
 	defer rows.Close()
@@ -326,11 +335,16 @@ func (s *Store) ListTransactions(ctx context.Context, f domain.TransactionFilter
 	for rows.Next() {
 		t, err := scanTransactionWithNumbers(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan transaction failed", "err", err)
 			return nil, 0, apperr.Internal("scan transaction", err)
 		}
 		out = append(out, t)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate transactions failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // GetTransactionsByOpID returns every leg of a single op (UX-level
@@ -340,6 +354,7 @@ func (s *Store) GetTransactionsByOpID(ctx context.Context, opID string) ([]*doma
 	q := `select ` + transactionReadColumns + transactionReadFrom + ` where t.op_id = $1 order by t.leg_index`
 	rows, err := s.DB.Query(ctx, q, opID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "transactions by op failed", "err", err, "op_id", opID)
 		return nil, apperr.Internal("transactions by op", err)
 	}
 	defer rows.Close()
@@ -347,11 +362,16 @@ func (s *Store) GetTransactionsByOpID(ctx context.Context, opID string) ([]*doma
 	for rows.Next() {
 		t, err := scanTransactionWithNumbers(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan tx by op failed", "err", err)
 			return nil, apperr.Internal("scan tx by op", err)
 		}
 		out = append(out, t)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "iterate transactions by op failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // GetAccountByNumber returns the account row for an 18-digit number,
@@ -363,6 +383,7 @@ func (s *Store) GetAccountByNumber(ctx context.Context, number string) (*domain.
 		if noRows(err) {
 			return nil, apperr.NotFound("primalac (račun) ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get account by number failed", "err", err, "number", number)
 		return nil, apperr.Internal("get account by number", err)
 	}
 	return out, nil

--- a/services/exchange/internal/app/app.go
+++ b/services/exchange/internal/app/app.go
@@ -36,6 +36,7 @@ func Run() error {
 
 	prov, err := otelinit.Init(ctx, "exchange")
 	if err != nil {
+		log.ErrorContext(ctx, "otel init failed", "err", err)
 		return fmt.Errorf("otelinit: %w", err)
 	}
 	defer func() { _ = prov.Shutdown(context.Background()) }()
@@ -46,15 +47,17 @@ func Run() error {
 	// the standby; writes and transactions stay on the primary.
 	db, err := postgres.OpenPair(ctx, config.MustString("DATABASE_URL"), config.String("DATABASE_READ_URL", ""))
 	if err != nil {
+		log.ErrorContext(ctx, "postgres open failed", "err", err)
 		return fmt.Errorf("postgres: %w", err)
 	}
 	defer db.Close()
 	if db.RO != nil {
-		log.Info("read replica routing enabled")
+		log.InfoContext(ctx, "read replica routing enabled")
 	}
 
 	rdb, err := pkgredis.Open(ctx, config.MustString("REDIS_ADDR"), config.String("REDIS_PASSWORD", ""))
 	if err != nil {
+		log.ErrorContext(ctx, "redis open failed", "err", err)
 		return fmt.Errorf("redis: %w", err)
 	}
 	defer rdb.Close()
@@ -109,13 +112,14 @@ func Run() error {
 			return feeder.Run(gctx, feedInterval)
 		})
 	} else {
-		log.Info("fx feed loop disabled (JOBS_ENABLED=false or FX_FEED_INTERVAL=0); refresh available via RPC")
+		log.InfoContext(ctx, "fx feed loop disabled (JOBS_ENABLED=false or FX_FEED_INTERVAL=0); refresh available via RPC")
 	}
 
 	probeSrv.MarkReady()
-	log.Info("exchange service ready", "grpc", grpcAddr)
+	log.InfoContext(ctx, "exchange service ready", "grpc", grpcAddr)
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		log.ErrorContext(ctx, "service terminated", "err", err)
 		return err
 	}
 	return nil

--- a/services/exchange/internal/feed/feed.go
+++ b/services/exchange/internal/feed/feed.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/exchange/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/exchange/internal/store"
 )
@@ -45,7 +46,7 @@ type Feeder struct {
 // interval. The first tick fires immediately.
 func (f *Feeder) Run(ctx context.Context, interval time.Duration) error {
 	if _, err := f.Once(ctx); err != nil {
-		f.Log.Warn("fx feed initial fetch failed", "error", err)
+		f.Log.ErrorContext(ctx, "fx feed initial fetch failed", "err", err)
 	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -55,7 +56,7 @@ func (f *Feeder) Run(ctx context.Context, interval time.Duration) error {
 			return nil
 		case <-t.C:
 			if _, err := f.Once(ctx); err != nil {
-				f.Log.Warn("fx feed tick failed", "error", err)
+				f.Log.ErrorContext(ctx, "fx feed tick failed", "err", err)
 			}
 		}
 	}
@@ -82,18 +83,20 @@ func (f *Feeder) Once(ctx context.Context) (int, error) {
 			Ask:  formatRate(ask),
 		}
 		if _, err := f.Store.UpsertRate(ctx, r); err != nil {
-			f.Log.Warn("fx feed upsert failed", "from", cur, "error", err)
+			f.Log.ErrorContext(ctx, "fx feed upsert failed",
+				"err", err, "from", string(cur), "to", string(domain.CurrencyRSD))
 			continue
 		}
 		// Append an append-only history point so the mobile last-month
 		// kursna lista accrues over time. A history write failure must
 		// not abort the latest-only update — log and carry on.
 		if err := f.Store.InsertRateHistory(ctx, r); err != nil {
-			f.Log.Warn("fx feed history insert failed", "from", cur, "error", err)
+			f.Log.ErrorContext(ctx, "fx feed history insert failed",
+				"err", err, "from", string(cur), "to", string(domain.CurrencyRSD))
 		}
 		written++
 	}
-	f.Log.Info("fx feed updated", "rows", written)
+	f.Log.InfoContext(ctx, "fx rates refreshed", "rows", written)
 	return written, nil
 }
 
@@ -147,6 +150,8 @@ func (o *OpenERAPI) Fetch(ctx context.Context) (map[domain.Currency]float64, err
 	for code, rsdAsBase := range body.Rates {
 		// rsdAsBase is "1 RSD = rsdAsBase <code>". We want "1 <code> in RSD".
 		if rsdAsBase <= 0 {
+			logger.From(ctx).WarnContext(ctx, "fx feed rate skipped (non-positive)",
+				"code", code, "rate", rsdAsBase, "source", url)
 			continue
 		}
 		out[domain.Currency(code)] = 1 / rsdAsBase

--- a/services/exchange/internal/store/postgres.go
+++ b/services/exchange/internal/store/postgres.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/exchange/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -40,8 +41,12 @@ func (s *Store) UpsertRate(ctx context.Context, r *domain.Rate) (*domain.Rate, e
 		// returns 400.
 		var pe interface{ SQLState() string }
 		if errors.As(err, &pe) && pe.SQLState() == "23514" {
+			logger.From(ctx).WarnContext(ctx, "upsert fx rate rejected by check constraint",
+				"err", err, "from", string(r.From), "to", string(r.To))
 			return nil, apperr.Validation("fx rate violates a check constraint (positive amounts and ask ≥ bid)")
 		}
+		logger.From(ctx).ErrorContext(ctx, "upsert fx rate failed",
+			"err", err, "from", string(r.From), "to", string(r.To))
 		return nil, apperr.Internal("upsert fx rate", err)
 	}
 	return out, nil
@@ -58,6 +63,8 @@ func (s *Store) GetRate(ctx context.Context, from, to domain.Currency) (*domain.
 		if noRows(err) {
 			return nil, apperr.NotFound("fx rate not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fx rate failed",
+			"err", err, "from", string(from), "to", string(to))
 		return nil, apperr.Internal("get fx rate", err)
 	}
 	return out, nil
@@ -76,6 +83,7 @@ func (s *Store) ListRates(ctx context.Context, from domain.Currency) ([]*domain.
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fx rates failed", "err", err, "from", string(from))
 		return nil, apperr.Internal("list fx rates", err)
 	}
 	defer rows.Close()
@@ -84,11 +92,16 @@ func (s *Store) ListRates(ctx context.Context, from domain.Currency) ([]*domain.
 	for rows.Next() {
 		r, err := scanRate(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fx rate failed", "err", err)
 			return nil, apperr.Internal("scan fx rate", err)
 		}
 		out = append(out, r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fx rates rows failed", "err", err, "from", string(from))
+		return out, err
+	}
+	return out, nil
 }
 
 // InsertRateHistory appends one append-only observation of a pair. Called
@@ -101,8 +114,12 @@ func (s *Store) InsertRateHistory(ctx context.Context, r *domain.Rate) error {
 	if _, err := s.DB.Exec(ctx, q, string(r.From), string(r.To), r.Bid, r.Ask); err != nil {
 		var pe interface{ SQLState() string }
 		if errors.As(err, &pe) && pe.SQLState() == "23514" {
+			logger.From(ctx).WarnContext(ctx, "insert fx rate history rejected by check constraint",
+				"err", err, "from", string(r.From), "to", string(r.To))
 			return apperr.Validation("fx rate history violates a check constraint (positive amounts and ask ≥ bid)")
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert fx rate history failed",
+			"err", err, "from", string(r.From), "to", string(r.To))
 		return apperr.Internal("insert fx rate history", err)
 	}
 	return nil
@@ -118,6 +135,8 @@ func (s *Store) ListRateHistory(ctx context.Context, from, to domain.Currency, s
         order by recorded_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, string(from), string(to), since)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fx rate history failed",
+			"err", err, "from", string(from), "to", string(to))
 		return nil, apperr.Internal("list fx rate history", err)
 	}
 	defer rows.Close()
@@ -126,11 +145,18 @@ func (s *Store) ListRateHistory(ctx context.Context, from, to domain.Currency, s
 	for rows.Next() {
 		var p domain.RateHistoryPoint
 		if err := rows.Scan(&p.Bid, &p.Ask, &p.RecordedAt); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fx rate history failed",
+				"err", err, "from", string(from), "to", string(to))
 			return nil, apperr.Internal("scan fx rate history", err)
 		}
 		out = append(out, &p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fx rate history rows failed",
+			"err", err, "from", string(from), "to", string(to))
+		return out, err
+	}
+	return out, nil
 }
 
 func scanRate(row interface{ Scan(...any) error }) (*domain.Rate, error) {

--- a/services/gateway/cmd/gateway/main.go
+++ b/services/gateway/cmd/gateway/main.go
@@ -5,15 +5,18 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/gateway/internal/app"
 )
 
 func main() {
 	if err := app.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "gateway: %v\n", err)
+		// The error is wrapped with the failing dependency by app.Run
+		// ("otelinit: …", "dial upstreams: …", "redis: …", "mount
+		// router: …"), so one structured line names the culprit.
+		logger.New("gateway").Error("gateway exited", "err", err)
 		os.Exit(1)
 	}
 }

--- a/services/gateway/internal/app/access_log.go
+++ b/services/gateway/internal/app/access_log.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 )
 
 // accessLog wraps an http.Handler so every request emits one slog line
@@ -19,6 +21,10 @@ import (
 // doesn't expose the written status otherwise.
 func accessLog(log *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Make the service logger available downstream via
+		// logger.From(r.Context()) so handlers and middleware emit
+		// through the same JSON handler with trace correlation.
+		r = r.WithContext(logger.Inject(r.Context(), log))
 		if isSilentPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
@@ -35,13 +41,20 @@ func accessLog(log *slog.Logger, next http.Handler) http.Handler {
 		case sr.status >= 400:
 			level = slog.LevelInfo
 		}
-		log.LogAttrs(r.Context(), level, "http",
+		attrs := []slog.Attr{
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.Int("status", sr.status),
 			slog.Duration("dur", dur),
 			slog.String("remote", clientIP(r)),
-		)
+		}
+		// On a failure, attach the error response body (the JSON error
+		// envelope every handler writes) so a bare `status=500` line
+		// still names its cause without trace-spelunking.
+		if sr.status >= 400 && len(sr.errBody) > 0 {
+			attrs = append(attrs, slog.String("err", string(sr.errBody)))
+		}
+		log.LogAttrs(r.Context(), level, "http", attrs...)
 	})
 }
 
@@ -59,10 +72,17 @@ func clientIP(r *http.Request) string {
 	return r.RemoteAddr
 }
 
+// errBodyMax caps how much of a 4xx/5xx response body the access log
+// retains. Error envelopes are short JSON; the cap guards the log line.
+const errBodyMax = 512
+
 type statusRecorder struct {
 	http.ResponseWriter
 	status      int
 	wroteHeader bool
+	// errBody holds the first errBodyMax bytes of a 4xx/5xx response
+	// body so the access log can carry the failure cause.
+	errBody []byte
 }
 
 func (s *statusRecorder) WriteHeader(code int) {
@@ -77,6 +97,13 @@ func (s *statusRecorder) WriteHeader(code int) {
 func (s *statusRecorder) Write(b []byte) (int, error) {
 	if !s.wroteHeader {
 		s.wroteHeader = true
+	}
+	if s.status >= 400 && len(s.errBody) < errBodyMax {
+		n := errBodyMax - len(s.errBody)
+		if n > len(b) {
+			n = len(b)
+		}
+		s.errBody = append(s.errBody, b[:n]...)
 	}
 	return s.ResponseWriter.Write(b)
 }

--- a/services/gateway/internal/app/access_log.go
+++ b/services/gateway/internal/app/access_log.go
@@ -51,7 +51,11 @@ func accessLog(log *slog.Logger, next http.Handler) http.Handler {
 		// On a failure, attach the error response body (the JSON error
 		// envelope every handler writes) so a bare `status=500` line
 		// still names its cause without trace-spelunking.
-		if sr.status >= 400 && len(sr.errBody) > 0 {
+		// Auth routes excluded as defense-in-depth: their error
+		// envelopes are token-free today, but one future handler
+		// echoing a credential into an error message must not end
+		// up in Loki.
+		if sr.status >= 400 && len(sr.errBody) > 0 && !strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
 			attrs = append(attrs, slog.String("err", string(sr.errBody)))
 		}
 		log.LogAttrs(r.Context(), level, "http", attrs...)

--- a/services/gateway/internal/app/app.go
+++ b/services/gateway/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -42,6 +43,10 @@ import (
 // Run blocks until shutdown.
 func Run() error {
 	log := logger.New("gateway")
+	// Make logger.From(ctx) fallbacks and slog.Default() callers (e.g.
+	// the router's response-write helpers) emit through the same JSON
+	// handler instead of the stdlib text logger.
+	slog.SetDefault(log)
 
 	ctx, cancel := shutdown.Context()
 	defer cancel()
@@ -50,25 +55,40 @@ func Run() error {
 	if err != nil {
 		return fmt.Errorf("otelinit: %w", err)
 	}
-	defer func() { _ = prov.Shutdown(context.Background()) }()
+	defer func() {
+		if err := prov.Shutdown(context.Background()); err != nil {
+			log.Warn("otel provider shutdown failed", "err", err)
+		}
+	}()
 
-	cs, err := clients.Dial(clients.Addrs{
+	addrs := clients.Addrs{
 		User:         config.MustString("USER_GRPC_ADDR"),
 		Bank:         config.String("BANK_GRPC_ADDR", ""),
 		Trading:      config.String("TRADING_GRPC_ADDR", ""),
 		Exchange:     config.String("EXCHANGE_GRPC_ADDR", ""),
 		Notification: config.String("NOTIFICATION_GRPC_ADDR", ""),
-	}, clients.WithStatsHandler(prov.GRPCClientHandler()))
+	}
+	cs, err := clients.Dial(addrs, clients.WithStatsHandler(prov.GRPCClientHandler()))
 	if err != nil {
 		return fmt.Errorf("dial upstreams: %w", err)
 	}
 	defer cs.Close()
+	log.Info(
+		"upstream grpc clients dialed",
+		"user", addrs.User,
+		"bank", addrs.Bank,
+		"trading", addrs.Trading,
+		"exchange", addrs.Exchange,
+		"notification", addrs.Notification,
+	)
 
-	rdb, err := pkgredis.Open(ctx, config.MustString("REDIS_ADDR"), config.String("REDIS_PASSWORD", ""))
+	redisAddr := config.MustString("REDIS_ADDR")
+	rdb, err := pkgredis.Open(ctx, redisAddr, config.String("REDIS_PASSWORD", ""))
 	if err != nil {
 		return fmt.Errorf("redis: %w", err)
 	}
 	defer rdb.Close()
+	log.Info("redis connected", "addr", redisAddr)
 
 	sessionCache := &sessionversion.Cache{
 		R:   rdb,
@@ -155,6 +175,13 @@ func Run() error {
 			TradingOTC:        cs.ExternalOTC,
 			Interbank:         cs.InterbankProtocol,
 		}
+		log.Info(
+			"interbank partner surface enabled",
+			"otc", r.PartnerOTC != nil,
+			"payments", r.PartnerPayments != nil,
+			"banka2", true,
+			"sign_key_set", config.String("INTERBANK_SIGN_KEY", "") != "",
+		)
 	}
 
 	// Annotator forwards the authenticated principal (set on the request

--- a/services/gateway/internal/app/errors.go
+++ b/services/gateway/internal/app/errors.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
+
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,8 +19,29 @@ import (
 // through to the default handler unchanged.
 func unavailableFriendly() runtime.ErrorHandlerFunc {
 	return func(ctx context.Context, mux *runtime.ServeMux, m runtime.Marshaler, w http.ResponseWriter, req *http.Request, err error) {
+		log := logger.From(ctx)
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+			// Log the raw dialer/upstream error before it's rewritten —
+			// the friendly 503 body intentionally hides the detail the
+			// on-call person needs.
+			log.ErrorContext(
+				ctx, "upstream unavailable",
+				"err", err,
+				"method", req.Method,
+				"path", req.URL.Path,
+			)
 			err = status.Error(codes.Unavailable, "Servis trenutno nije dostupan. Pokušajte ponovo za par trenutaka.")
+		} else if st != nil {
+			if httpCode := runtime.HTTPStatusFromCode(st.Code()); httpCode >= 500 {
+				log.ErrorContext(
+					ctx, "upstream grpc call failed",
+					"err", err,
+					"code", st.Code().String(),
+					"status", httpCode,
+					"method", req.Method,
+					"path", req.URL.Path,
+				)
+			}
 		}
 		runtime.DefaultHTTPErrorHandler(ctx, mux, m, w, req, err)
 	}

--- a/services/gateway/internal/auth/middleware.go
+++ b/services/gateway/internal/auth/middleware.go
@@ -23,6 +23,7 @@ import (
 
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/user/v1"
 	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/sessionversion"
 )
 
@@ -59,23 +60,39 @@ func Middleware(cfg Config) func(http.Handler) http.Handler {
 				return
 			}
 
+			ctx := r.Context()
+			log := logger.From(ctx)
+
 			tok := bearer(r)
 			if tok == "" {
+				log.WarnContext(ctx, "missing access token",
+					"method", r.Method, "path", r.URL.Path)
 				writeAuthError(w, http.StatusUnauthorized, "missing access token")
 				return
 			}
 			claims, err := pkgauth.Verify(tok, cfg.JWTKey)
 			if err != nil {
+				log.WarnContext(ctx, "jwt validation failed",
+					"err", err, "method", r.Method, "path", r.URL.Path)
 				writeAuthError(w, http.StatusUnauthorized, "invalid access token")
 				return
 			}
 
-			currentSV, err := currentSessionVersion(r.Context(), cfg, claims.UserKind, claims.UserID)
+			currentSV, err := currentSessionVersion(ctx, cfg, claims.UserKind, claims.UserID)
 			if err != nil {
+				// Redis miss + user-service lookup both failed — infra,
+				// not the client; maps to a 503.
+				log.ErrorContext(ctx, "session version lookup failed",
+					"err", err, "user_id", claims.UserID,
+					"method", r.Method, "path", r.URL.Path)
 				writeAuthError(w, http.StatusServiceUnavailable, "session check failed")
 				return
 			}
 			if claims.SessionVersion < currentSV {
+				log.WarnContext(ctx, "session revoked",
+					"user_id", claims.UserID,
+					"token_sv", claims.SessionVersion, "current_sv", currentSV,
+					"method", r.Method, "path", r.URL.Path)
 				writeAuthError(w, http.StatusUnauthorized, "session revoked")
 				return
 			}
@@ -86,7 +103,7 @@ func Middleware(cfg Config) func(http.Handler) http.Handler {
 				Permissions:    claims.Permissions,
 				SessionVersion: claims.SessionVersion,
 			}
-			ctx := pkgauth.WithPrincipal(r.Context(), p)
+			ctx = pkgauth.WithPrincipal(ctx, p)
 			ctx = pkgauth.AttachToOutgoing(ctx, p)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -125,7 +142,12 @@ func currentSessionVersion(ctx context.Context, cfg Config, kind pkgauth.UserKin
 	if err != nil {
 		return 0, err
 	}
-	_ = cfg.SessionCache.Set(ctx, string(kind), userID, resp.GetSessionVersion())
+	if serr := cfg.SessionCache.Set(ctx, string(kind), userID, resp.GetSessionVersion()); serr != nil {
+		// Best-effort cache fill — the lookup already succeeded, so the
+		// request proceeds; the next request just re-hits the user service.
+		logger.From(ctx).WarnContext(ctx, "session version cache set failed",
+			"err", serr, "user_id", userID)
+	}
 	return resp.GetSessionVersion(), nil
 }
 

--- a/services/gateway/internal/clients/clients.go
+++ b/services/gateway/internal/clients/clients.go
@@ -4,6 +4,7 @@ package clients
 
 import (
 	"fmt"
+	"log/slog"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
 	exchangepb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/exchange/v1"
@@ -121,7 +122,11 @@ func Dial(addrs Addrs, opts ...Option) (*Set, error) {
 // Close releases every dialed connection.
 func (s *Set) Close() {
 	for _, c := range s.conns {
-		_ = c.Close()
+		if err := c.Close(); err != nil {
+			// Shutdown-path only; nothing to recover, but don't swallow.
+			slog.Default().Warn("grpc conn close failed",
+				"err", err, "target", c.Target())
+		}
 	}
 }
 

--- a/services/gateway/internal/idempotency/middleware.go
+++ b/services/gateway/internal/idempotency/middleware.go
@@ -69,6 +69,8 @@ func Middleware(cache Cache, log *slog.Logger) func(http.Handler) http.Handler {
 				return
 			}
 			if len(key) > MaxKeyLen {
+				log.WarnContext(r.Context(), "idempotency key rejected: too long",
+					"key_len", len(key), "method", r.Method, "path", r.URL.Path)
 				http.Error(w, "Idempotency-Key too long", http.StatusBadRequest)
 				return
 			}
@@ -81,8 +83,8 @@ func Middleware(cache Cache, log *slog.Logger) func(http.Handler) http.Handler {
 				replay(w, entry)
 				return
 			} else if !errors.Is(err, pkgidem.ErrMiss) {
-				log.Warn("idempotency: cache get failed; bypassing",
-					"user", userID, "error", err)
+				log.WarnContext(r.Context(), "idempotency: cache get failed; bypassing",
+					"err", err, "user", userID, "method", r.Method, "path", r.URL.Path)
 			}
 
 			// Capture the response, run the handler, and cache on 2xx.
@@ -96,8 +98,8 @@ func Middleware(cache Cache, log *slog.Logger) func(http.Handler) http.Handler {
 					Body:    cw.body.Bytes(),
 				}
 				if err := cache.Set(r.Context(), userID, key, e); err != nil {
-					log.Warn("idempotency: cache set failed",
-						"user", userID, "error", err)
+					log.WarnContext(r.Context(), "idempotency: cache set failed",
+						"err", err, "user", userID, "method", r.Method, "path", r.URL.Path)
 				}
 			}
 		})

--- a/services/gateway/internal/router/auth_handlers.go
+++ b/services/gateway/internal/router/auth_handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/user/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 )
 
 // refreshCookieName is the http-only cookie holding the opaque refresh
@@ -43,8 +44,11 @@ type loginResponseBody struct {
 // returns the access token + metadata in the body.
 func (r *Router) LoginHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		var body loginRequestBody
 		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			// No body snippet here — login payloads carry credentials.
+			logger.From(ctx).WarnContext(ctx, "login payload decode failed", "err", err)
 			writeError(w, http.StatusBadRequest, "invalid JSON body")
 			return
 		}
@@ -54,7 +58,7 @@ func (r *Router) LoginHandler() http.HandlerFunc {
 			LongLivedSession: body.LongLivedSession,
 		})
 		if err != nil {
-			writeGRPCError(w, err)
+			writeGRPCError(w, req, err)
 			return
 		}
 		out := loginResponseBody{
@@ -104,7 +108,7 @@ func (r *Router) RefreshHandler() http.HandlerFunc {
 			})
 			if rerr != nil {
 				clearRefreshCookie(w, r.SecureCookies)
-				writeGRPCError(w, rerr)
+				writeGRPCError(w, req, rerr)
 				return
 			}
 			setRefreshCookie(w, resp.GetRefreshToken(), r.SecureCookies)
@@ -118,6 +122,9 @@ func (r *Router) RefreshHandler() http.HandlerFunc {
 		// No cookie → mobile body path.
 		var body refreshRequestBody
 		if err := json.NewDecoder(req.Body).Decode(&body); err != nil || body.RefreshToken == "" {
+			// Token contents stay out of the log.
+			ctx := req.Context()
+			logger.From(ctx).WarnContext(ctx, "refresh rejected: no refresh token", "err", err)
 			writeError(w, http.StatusUnauthorized, "no refresh token")
 			return
 		}
@@ -126,7 +133,7 @@ func (r *Router) RefreshHandler() http.HandlerFunc {
 			LongLivedSession: body.LongLivedSession,
 		})
 		if err != nil {
-			writeGRPCError(w, err)
+			writeGRPCError(w, req, err)
 			return
 		}
 		writeJSON(w, http.StatusOK, refreshResponseBody{
@@ -140,14 +147,21 @@ func (r *Router) RefreshHandler() http.HandlerFunc {
 // LogoutHandler revokes the refresh token and clears the cookie.
 func (r *Router) LogoutHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		if c, err := req.Cookie(refreshCookieName); err == nil && c.Value != "" {
-			_, _ = r.Users.Logout(req.Context(), &userpb.LogoutRequest{RefreshToken: c.Value})
+			if _, lerr := r.Users.Logout(req.Context(), &userpb.LogoutRequest{RefreshToken: c.Value}); lerr != nil {
+				// Response stays 204 either way; the un-revoked row is
+				// worth a line (token value itself is never logged).
+				logger.From(ctx).WarnContext(ctx, "logout revoke failed", "err", lerr)
+			}
 		} else {
 			// Mobile path: refresh token in the body so the
 			// server-side row is actually revoked on sign-out.
 			var body refreshRequestBody
 			if json.NewDecoder(req.Body).Decode(&body) == nil && body.RefreshToken != "" {
-				_, _ = r.Users.Logout(req.Context(), &userpb.LogoutRequest{RefreshToken: body.RefreshToken})
+				if _, lerr := r.Users.Logout(req.Context(), &userpb.LogoutRequest{RefreshToken: body.RefreshToken}); lerr != nil {
+					logger.From(ctx).WarnContext(ctx, "logout revoke failed", "err", lerr)
+				}
 			}
 		}
 		clearRefreshCookie(w, r.SecureCookies)

--- a/services/gateway/internal/router/partner_banka2.go
+++ b/services/gateway/internal/router/partner_banka2.go
@@ -44,6 +44,7 @@ import (
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1"
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/user/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -117,6 +118,11 @@ func (p *PartnerBanka2) guard(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		got := []byte(r.Header.Get("X-Api-Key"))
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			ctx := r.Context()
+			// Never log the presented key itself.
+			logger.From(ctx).WarnContext(ctx, "partner api key rejected",
+				"method", r.Method, "path", r.URL.Path,
+				"key_present", len(got) > 0, "remote", r.RemoteAddr)
 			writeError(w, http.StatusUnauthorized, "invalid X-Api-Key")
 			return
 		}
@@ -248,28 +254,49 @@ type b2UserInformation struct {
 // =====================================================================
 
 func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
+		log.WarnContext(ctx, "partner request body read failed",
+			"err", err, "method", r.Method, "path", r.URL.Path)
 		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}
 	var env b2Envelope
 	if err := json.Unmarshal(raw, &env); err != nil {
+		log.WarnContext(ctx, "interbank envelope decode failed",
+			"err", err, "path", r.URL.Path, "body", bodySnippet(raw))
 		writeError(w, http.StatusBadRequest, "invalid envelope JSON")
 		return
 	}
 	if env.IdempotenceKey.LocallyGeneratedKey == "" || env.IdempotenceKey.RoutingNumber == 0 {
+		log.WarnContext(ctx, "interbank envelope rejected: missing idempotenceKey",
+			"message_type", env.MessageType, "body", bodySnippet(raw))
 		writeError(w, http.StatusBadRequest, "envelope missing idempotenceKey")
 		return
 	}
 	sender := env.IdempotenceKey.RoutingNumber
+	// Carry the partner identity + envelope type on the request logger
+	// so every downstream line (votes, writeGRPCError, cache writes)
+	// names the exchange.
+	log = log.With("partner_bank", sender, "message_type", env.MessageType)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 
 	// Idempotency replay — keyed by (sender_routing, locally_generated_key).
-	hit, _ := p.Interbank.GetInboundMessage(partnerCtx(r.Context()), &bankpb.GetInboundMessageRequest{
+	hit, herr := p.Interbank.GetInboundMessage(partnerCtx(r.Context()), &bankpb.GetInboundMessageRequest{
 		SenderRoutingNumber: int32(sender),
 		IdempotenceKey:      env.IdempotenceKey.LocallyGeneratedKey,
 	})
+	if herr != nil {
+		// Best-effort lookup — a miss just re-runs the handler, but a
+		// broken audit store deserves a line.
+		log.WarnContext(ctx, "interbank replay lookup failed; proceeding", "err", herr)
+	}
 	if hit != nil && hit.GetFound() {
+		log.InfoContext(ctx, "interbank envelope replayed from cache",
+			"status", hit.GetResponseStatus())
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		st := int(hit.GetResponseStatus())
 		if st == http.StatusNoContent {
@@ -277,7 +304,9 @@ func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.WriteHeader(st)
-		_, _ = w.Write([]byte(hit.GetResponseBody()))
+		if _, werr := w.Write([]byte(hit.GetResponseBody())); werr != nil {
+			log.WarnContext(ctx, "response write failed", "err", werr)
+		}
 		return
 	}
 
@@ -285,6 +314,8 @@ func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
 	case "NEW_TX":
 		var tx b2Transaction
 		if err := json.Unmarshal(env.Message, &tx); err != nil {
+			log.WarnContext(ctx, "interbank envelope rejected: invalid NEW_TX body",
+				"err", err, "body", bodySnippet(env.Message))
 			writeError(w, http.StatusBadRequest, "NEW_TX: invalid Transaction body")
 			return
 		}
@@ -292,6 +323,8 @@ func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
 	case "COMMIT_TX":
 		var body b2CommitTransaction
 		if err := json.Unmarshal(env.Message, &body); err != nil {
+			log.WarnContext(ctx, "interbank envelope rejected: invalid COMMIT_TX body",
+				"err", err, "body", bodySnippet(env.Message))
 			writeError(w, http.StatusBadRequest, "COMMIT_TX: invalid body")
 			return
 		}
@@ -299,11 +332,14 @@ func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
 	case "ROLLBACK_TX":
 		var body b2RollbackTransaction
 		if err := json.Unmarshal(env.Message, &body); err != nil {
+			log.WarnContext(ctx, "interbank envelope rejected: invalid ROLLBACK_TX body",
+				"err", err, "body", bodySnippet(env.Message))
 			writeError(w, http.StatusBadRequest, "ROLLBACK_TX: invalid body")
 			return
 		}
 		p.handleRollbackTX(w, r, env.IdempotenceKey, body)
 	default:
+		log.WarnContext(ctx, "interbank envelope rejected: unknown messageType")
 		writeError(w, http.StatusBadRequest, "unknown messageType: "+env.MessageType)
 	}
 }
@@ -313,6 +349,10 @@ func (p *PartnerBanka2) handleEnvelope(w http.ResponseWriter, r *http.Request) {
 // TxAccount.OPTION pseudo-account) is rejected with UNACCEPTABLE_ASSET
 // for now — the SAGA exercise path is not wired through the envelope.
 func (p *PartnerBanka2) handleNewTX(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, tx b2Transaction) {
+	// Stamp the 2PC transaction id on the request logger so the vote
+	// decision lines (and any upstream-error lines) carry it.
+	r = r.WithContext(logger.Inject(r.Context(),
+		logger.From(r.Context()).With("transaction_id", tx.TransactionID.ID)))
 	if len(tx.Postings) == 0 {
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "UNBALANCED_TX", nil)
 		return
@@ -337,8 +377,8 @@ func (p *PartnerBanka2) handleNewTX(w http.ResponseWriter, r *http.Request, key 
 	if ourRouting == "" {
 		ourRouting = "333"
 	}
-	var ourIdx = -1
-	var otherIdx = -1
+	ourIdx := -1
+	otherIdx := -1
 	for i, post := range tx.Postings {
 		if post.Account.Type != "ACCOUNT" || post.Account.Num == "" {
 			// PERSON / OPTION mid-payment — out of scope here.
@@ -397,6 +437,10 @@ func (p *PartnerBanka2) handleNewTX(w http.ResponseWriter, r *http.Request, key 
 	})
 	if err != nil {
 		// Map gRPC-level rejections to NO votes with a best-guess reason.
+		// The wire reason loses the upstream detail, so log it here.
+		ctx := r.Context()
+		logger.From(ctx).WarnContext(ctx, "interbank prepare failed",
+			"err", err, "currency", currency, "amount", amountStr)
 		reason := banka2NoVoteFromGRPC(err)
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, reason, nil)
 		return
@@ -432,6 +476,8 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 	}
 	intent, err := parseB2OTCSettlement(tx, ourRoutings...)
 	if err != nil {
+		ctx := r.Context()
+		logger.From(ctx).WarnContext(ctx, "otc settlement envelope parse failed", "err", err)
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "UNACCEPTABLE_ASSET", nil)
 		return
 	}
@@ -464,6 +510,8 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 		Quantity:       intent.Quantity,
 	})
 	if err != nil {
+		logger.From(ctx).WarnContext(ctx, "otc settlement prepare failed",
+			"err", err, "kind", kind.String(), "ticker", intent.Ticker)
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, banka2NoVoteFromGRPC(err), nil)
 		return
 	}
@@ -490,12 +538,18 @@ func (p *PartnerBanka2) handleOTCSettlementNewTX(w http.ResponseWriter, r *http.
 			Purpose:             "OTC " + strings.ToLower(kind.String()),
 		})
 		if perr != nil || prep.GetStatus() != bankpb.InterbankTxStatus_INTERBANK_TX_STATUS_PREPARED {
+			logger.From(ctx).WarnContext(ctx, "otc settlement cash leg prepare failed",
+				"err", perr, "prepare_status", prep.GetStatus().String(),
+				"currency", intent.CashCurrency, "amount", intent.CashAmount)
 			// Release the trading prepare (shares) so we don't strand them.
-			_, _ = p.TradingOTC.SettleExternalOTCOption(ctx, &tradingpb.SettleExternalOTCOptionRequest{
+			if _, rbErr := p.TradingOTC.SettleExternalOTCOption(ctx, &tradingpb.SettleExternalOTCOptionRequest{
 				Phase:          tradingpb.ExternalOTCSettlementPhase_EXTERNAL_OTC_SETTLEMENT_PHASE_ROLLBACK,
 				SenderBankCode: strconv.Itoa(key.RoutingNumber),
 				TransactionId:  tx.TransactionID.ID,
-			})
+			}); rbErr != nil {
+				// Stranded share reservation — needs operator attention.
+				logger.From(ctx).ErrorContext(ctx, "otc settlement rollback failed", "err", rbErr)
+			}
 			reason := "INSUFFICIENT_ASSET"
 			if perr != nil {
 				reason = banka2NoVoteFromGRPC(perr)
@@ -523,6 +577,8 @@ func (p *PartnerBanka2) handleBuyerAcceptNewTX(w http.ResponseWriter, r *http.Re
 		RemoteBankCode: strconv.Itoa(key.RoutingNumber),
 	})
 	if err != nil {
+		logger.From(ctx).WarnContext(ctx, "buyer accept thread lookup failed",
+			"err", err, "option_ref", intent.OptionRef.ID)
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, "OPTION_NEGOTIATION_NOT_FOUND", nil)
 		return
 	}
@@ -551,6 +607,9 @@ func (p *PartnerBanka2) handleBuyerAcceptNewTX(w http.ResponseWriter, r *http.Re
 		Purpose:             "OTC premija (kupac) — nit " + t.GetId(),
 	})
 	if perr != nil {
+		logger.From(ctx).WarnContext(ctx, "buyer accept premium prepare failed",
+			"err", perr, "thread_id", t.GetId(),
+			"currency", intent.CashCurrency, "amount", intent.CashAmount)
 		p.respondVoteNO(w, r, key, tx.TransactionID.ID, banka2NoVoteFromGRPC(perr), nil)
 		return
 	}
@@ -574,6 +633,8 @@ func buyerAccountFromPostings(tx b2Transaction) string {
 }
 
 func (p *PartnerBanka2) handleCommitTX(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, body b2CommitTransaction) {
+	r = r.WithContext(logger.Inject(r.Context(),
+		logger.From(r.Context()).With("transaction_id", body.TransactionID.ID)))
 	ctx := partnerCtx(r.Context())
 	// OTC share/contract leg (no-op for a plain cash tx — handled=false).
 	if p.TradingOTC != nil {
@@ -582,7 +643,7 @@ func (p *PartnerBanka2) handleCommitTX(w http.ResponseWriter, r *http.Request, k
 			SenderBankCode: strconv.Itoa(key.RoutingNumber),
 			TransactionId:  body.TransactionID.ID,
 		}); err != nil {
-			writeGRPCError(w, err)
+			writeGRPCError(w, r, err)
 			return
 		}
 	}
@@ -591,13 +652,16 @@ func (p *PartnerBanka2) handleCommitTX(w http.ResponseWriter, r *http.Request, k
 		TransactionId:       body.TransactionID.ID,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	logger.From(r.Context()).InfoContext(r.Context(), "interbank commit applied")
 	p.write204AndCache(w, r, key, body.TransactionID.ID, bankpb.InterbankMessageType_INTERBANK_MESSAGE_TYPE_COMMIT_TX)
 }
 
 func (p *PartnerBanka2) handleRollbackTX(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, body b2RollbackTransaction) {
+	r = r.WithContext(logger.Inject(r.Context(),
+		logger.From(r.Context()).With("transaction_id", body.TransactionID.ID)))
 	ctx := partnerCtx(r.Context())
 	if p.TradingOTC != nil {
 		if _, err := p.TradingOTC.SettleExternalOTCOption(ctx, &tradingpb.SettleExternalOTCOptionRequest{
@@ -605,7 +669,7 @@ func (p *PartnerBanka2) handleRollbackTX(w http.ResponseWriter, r *http.Request,
 			SenderBankCode: strconv.Itoa(key.RoutingNumber),
 			TransactionId:  body.TransactionID.ID,
 		}); err != nil {
-			writeGRPCError(w, err)
+			writeGRPCError(w, r, err)
 			return
 		}
 	}
@@ -615,49 +679,74 @@ func (p *PartnerBanka2) handleRollbackTX(w http.ResponseWriter, r *http.Request,
 		Reason:              "partner rollback",
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	logger.From(r.Context()).InfoContext(r.Context(), "interbank rollback applied")
 	p.write204AndCache(w, r, key, body.TransactionID.ID, bankpb.InterbankMessageType_INTERBANK_MESSAGE_TYPE_ROLLBACK_TX)
 }
 
 func (p *PartnerBanka2) respondVoteYES(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, txID string) {
-	body, _ := json.Marshal(b2TransactionVote{Vote: "YES"})
+	ctx := r.Context()
+	// partner_bank + transaction_id ride the injected request logger.
+	logger.From(ctx).InfoContext(ctx, "interbank tx vote YES")
+	body, err := json.Marshal(b2TransactionVote{Vote: "YES"})
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "interbank vote marshal failed", "err", err)
+	}
 	p.write200AndCache(w, r, key, txID, bankpb.InterbankMessageType_INTERBANK_MESSAGE_TYPE_NEW_TX, body)
 }
 
 func (p *PartnerBanka2) respondVoteNO(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, txID, reason string, posting *b2Posting) {
-	body, _ := json.Marshal(b2TransactionVote{
+	ctx := r.Context()
+	logger.From(ctx).WarnContext(ctx, "interbank tx vote NO", "reason", reason)
+	body, err := json.Marshal(b2TransactionVote{
 		Vote:    "NO",
 		Reasons: []b2NoVoteReason{{Reason: reason, Posting: posting}},
 	})
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "interbank vote marshal failed", "err", err)
+	}
 	p.write200AndCache(w, r, key, txID, bankpb.InterbankMessageType_INTERBANK_MESSAGE_TYPE_NEW_TX, body)
 }
 
 func (p *PartnerBanka2) write200AndCache(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, txID string, msgType bankpb.InterbankMessageType, body []byte) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
-	_, _ = p.Interbank.RecordInboundMessage(partnerCtx(r.Context()), &bankpb.RecordInboundMessageRequest{
+	if _, err := w.Write(body); err != nil {
+		log.WarnContext(ctx, "response write failed", "err", err, "transaction_id", txID)
+	}
+	if _, err := p.Interbank.RecordInboundMessage(partnerCtx(ctx), &bankpb.RecordInboundMessageRequest{
 		SenderRoutingNumber: int32(key.RoutingNumber),
 		IdempotenceKey:      key.LocallyGeneratedKey,
 		MessageType:         msgType,
 		TransactionId:       txID,
 		ResponseStatus:      http.StatusOK,
 		ResponseBody:        string(body),
-	})
+	}); err != nil {
+		// Best-effort idempotency audit; a retry will simply re-run.
+		log.WarnContext(ctx, "interbank inbound message cache write failed",
+			"err", err, "transaction_id", txID)
+	}
 }
 
 func (p *PartnerBanka2) write204AndCache(w http.ResponseWriter, r *http.Request, key b2IdempotenceKey, txID string, msgType bankpb.InterbankMessageType) {
+	ctx := r.Context()
 	w.WriteHeader(http.StatusNoContent)
-	_, _ = p.Interbank.RecordInboundMessage(partnerCtx(r.Context()), &bankpb.RecordInboundMessageRequest{
+	if _, err := p.Interbank.RecordInboundMessage(partnerCtx(ctx), &bankpb.RecordInboundMessageRequest{
 		SenderRoutingNumber: int32(key.RoutingNumber),
 		IdempotenceKey:      key.LocallyGeneratedKey,
 		MessageType:         msgType,
 		TransactionId:       txID,
 		ResponseStatus:      http.StatusNoContent,
 		ResponseBody:        "",
-	})
+	}); err != nil {
+		// Best-effort idempotency audit; a retry will simply re-run.
+		logger.From(ctx).WarnContext(ctx, "interbank inbound message cache write failed",
+			"err", err, "transaction_id", txID)
+	}
 }
 
 func postingsBalanced(postings []b2Posting) bool {
@@ -721,7 +810,7 @@ func banka2NoVoteFromGRPC(err error) string {
 func (p *PartnerBanka2) handlePublicStock(w http.ResponseWriter, r *http.Request) {
 	resp, err := p.Trading.ListPublicHoldings(partnerCtx(r.Context()), &tradingpb.ListPublicHoldingsRequest{})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
 	ourRouting, _ := strconv.Atoi(p.BankRoutingNumber)
@@ -755,13 +844,22 @@ func (p *PartnerBanka2) handlePublicStock(w http.ResponseWriter, r *http.Request
 // =====================================================================
 
 func (p *PartnerBanka2) handleCreateNegotiation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var offer b2OtcOffer
-	if err := json.NewDecoder(r.Body).Decode(&offer); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&offer); err != nil {
+		log.WarnContext(ctx, "partner negotiation payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid OtcOffer JSON")
 		return
 	}
+	log = log.With("partner_bank", offer.BuyerID.RoutingNumber, "ticker", offer.Stock.Ticker)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	settle, perr := parseBanka2Date(offer.SettlementDate)
 	if perr != nil {
+		log.WarnContext(ctx, "partner negotiation rejected: bad settlement date", "err", perr)
 		writeError(w, http.StatusBadRequest, "settlementDate: "+perr.Error())
 		return
 	}
@@ -772,6 +870,7 @@ func (p *PartnerBanka2) handleCreateNegotiation(w http.ResponseWriter, r *http.R
 	// by the partner and persist via remote_thread_id.
 	syntheticThreadID, err := synthesizeBanka2ThreadID(offer.BuyerID.RoutingNumber)
 	if err != nil {
+		log.ErrorContext(ctx, "partner negotiation thread-id generation failed", "err", err)
 		writeError(w, http.StatusInternalServerError, "thread-id gen: "+err.Error())
 		return
 	}
@@ -780,10 +879,16 @@ func (p *PartnerBanka2) handleCreateNegotiation(w http.ResponseWriter, r *http.R
 	// (ticker, seller_user_ref) → holding_id by walking ListPublicHoldings.
 	holdingID, err := p.resolveBanka2Holding(r.Context(), offer.Stock.Ticker, offer.SellerID.ID)
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
-	qty, _ := strconv.ParseInt(offer.Amount.String(), 10, 32)
+	qty, qerr := strconv.ParseInt(offer.Amount.String(), 10, 32)
+	if qerr != nil {
+		// The offer proceeds with quantity 0 (and is then judged by the
+		// trading service); record what the partner actually sent.
+		log.WarnContext(ctx, "partner negotiation amount unparsable; using 0",
+			"err", qerr, "amount", offer.Amount.String())
+	}
 	out, err := p.TradingOTC.ReceiveExternalOTCOffer(partnerCtx(r.Context()), &tradingpb.ReceiveExternalOTCOfferRequest{
 		SenderBankCode:    strconv.Itoa(offer.BuyerID.RoutingNumber),
 		SenderUserRef:     offer.BuyerID.ID,
@@ -796,9 +901,14 @@ func (p *PartnerBanka2) handleCreateNegotiation(w http.ResponseWriter, r *http.R
 		SettlementDate:    timestamppb.New(settle),
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner negotiation created",
+		"local_thread_id", out.GetLocalMirror().GetId(),
+		"sender_thread_id", syntheticThreadID, "quantity", qty,
+		"price_per_unit", offer.PricePerUnit.Amount.String(),
+		"premium", offer.Premium.Amount.String())
 	ourRouting, _ := strconv.Atoi(p.BankRoutingNumber)
 	writeJSON(w, http.StatusOK, b2ForeignID{
 		RoutingNumber: ourRouting,
@@ -807,8 +917,15 @@ func (p *PartnerBanka2) handleCreateNegotiation(w http.ResponseWriter, r *http.R
 }
 
 func (p *PartnerBanka2) handleReadNegotiation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx).With(
+		"partner_bank", r.PathValue("routing_number"), "thread_id", r.PathValue("thread_id"),
+	)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	threadID := r.PathValue("thread_id")
 	if threadID == "" {
+		log.WarnContext(ctx, "partner negotiation read rejected: missing thread_id")
 		writeError(w, http.StatusBadRequest, "thread_id required")
 		return
 	}
@@ -817,11 +934,12 @@ func (p *PartnerBanka2) handleReadNegotiation(w http.ResponseWriter, r *http.Req
 		RemoteBankCode: r.PathValue("routing_number"),
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
 	t := resp.GetThread()
 	if t == nil {
+		log.WarnContext(ctx, "partner negotiation not found")
 		writeError(w, http.StatusNotFound, "thread not found")
 		return
 	}
@@ -858,23 +976,37 @@ func (p *PartnerBanka2) handleReadNegotiation(w http.ResponseWriter, r *http.Req
 }
 
 func (p *PartnerBanka2) handleCounterNegotiation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx).With(
+		"partner_bank", r.PathValue("routing_number"), "thread_id", r.PathValue("thread_id"),
+	)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	var offer b2OtcOffer
-	if err := json.NewDecoder(r.Body).Decode(&offer); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&offer); err != nil {
+		log.WarnContext(ctx, "partner counter payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid OtcOffer JSON")
 		return
 	}
 	settle, perr := parseBanka2Date(offer.SettlementDate)
 	if perr != nil {
+		log.WarnContext(ctx, "partner counter rejected: bad settlement date", "err", perr)
 		writeError(w, http.StatusBadRequest, "settlementDate: "+perr.Error())
 		return
 	}
 	threadID := r.PathValue("thread_id")
 	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
-	qty, _ := strconv.ParseInt(offer.Amount.String(), 10, 32)
+	qty, qerr := strconv.ParseInt(offer.Amount.String(), 10, 32)
+	if qerr != nil {
+		log.WarnContext(ctx, "partner counter amount unparsable; using 0",
+			"err", qerr, "amount", offer.Amount.String())
+	}
 	_, err = p.TradingOTC.ReceiveExternalOTCCounter(partnerCtx(r.Context()), &tradingpb.ReceiveExternalOTCCounterRequest{
 		SenderBankCode: senderBank,
 		SenderThreadId: senderThread,
@@ -884,17 +1016,27 @@ func (p *PartnerBanka2) handleCounterNegotiation(w http.ResponseWriter, r *http.
 		SettlementDate: timestamppb.New(settle),
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner counter received",
+		"sender_thread_id", senderThread, "quantity", qty,
+		"price_per_unit", offer.PricePerUnit.Amount.String(),
+		"premium", offer.Premium.Amount.String())
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (p *PartnerBanka2) handleCloseNegotiation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx).With(
+		"partner_bank", r.PathValue("routing_number"), "thread_id", r.PathValue("thread_id"),
+	)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	threadID := r.PathValue("thread_id")
 	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
 	_, err = p.TradingOTC.ReceiveExternalOTCWithdraw(partnerCtx(r.Context()), &tradingpb.ReceiveExternalOTCActionRequest{
@@ -902,17 +1044,24 @@ func (p *PartnerBanka2) handleCloseNegotiation(w http.ResponseWriter, r *http.Re
 		SenderThreadId: senderThread,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner withdraw received", "sender_thread_id", senderThread)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (p *PartnerBanka2) handleAcceptNegotiation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx).With(
+		"partner_bank", r.PathValue("routing_number"), "thread_id", r.PathValue("thread_id"),
+	)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	threadID := r.PathValue("thread_id")
 	senderBank, senderThread, err := p.lookupRemoteRef(r.Context(), r.PathValue("routing_number"), threadID)
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
 	// Banka-2 spec §3.6: blocks until 2PC finishes; on failure surfaces
@@ -923,9 +1072,10 @@ func (p *PartnerBanka2) handleAcceptNegotiation(w http.ResponseWriter, r *http.R
 		SenderThreadId: senderThread,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner accept settled", "sender_thread_id", senderThread)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -978,6 +1128,8 @@ func (p *PartnerBanka2) lookupRemoteRef(ctx context.Context, routing, threadID s
 // =====================================================================
 
 func (p *PartnerBanka2) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	wantRouting := r.PathValue("routing_number")
 	wantID := r.PathValue("user_id")
 	ours := p.BankRoutingNumber
@@ -985,20 +1137,30 @@ func (p *PartnerBanka2) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 		ours = "333"
 	}
 	if wantRouting != ours {
+		log.WarnContext(ctx, "partner user lookup rejected: routing not ours",
+			"requested_routing", wantRouting, "our_routing", ours, "user_id", wantID)
 		writeError(w, http.StatusNotFound, "routing number is not ours")
 		return
 	}
 	// Try client first, then employee. Both share the UUID id space.
 	display := ""
-	if c, err := p.Users.GetClient(partnerCtx(r.Context()), &userpb.GetClientRequest{Id: wantID}); err == nil && c != nil {
+	c, cerr := p.Users.GetClient(partnerCtx(r.Context()), &userpb.GetClientRequest{Id: wantID})
+	if cerr == nil && c != nil {
 		display = strings.TrimSpace(c.GetFirstName() + " " + c.GetLastName())
 	}
+	var eerr error
 	if display == "" {
-		if e, err := p.Users.GetEmployee(partnerCtx(r.Context()), &userpb.GetEmployeeRequest{Id: wantID}); err == nil && e != nil {
+		e, err := p.Users.GetEmployee(partnerCtx(r.Context()), &userpb.GetEmployeeRequest{Id: wantID})
+		eerr = err
+		if err == nil && e != nil {
 			display = strings.TrimSpace(e.GetFirstName() + " " + e.GetLastName())
 		}
 	}
 	if display == "" {
+		// Both lookups missed (or errored) — surface the per-branch
+		// errors that the 404 body hides.
+		log.WarnContext(ctx, "partner user lookup failed",
+			"user_id", wantID, "client_err", cerr, "employee_err", eerr)
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}

--- a/services/gateway/internal/router/partner_otc.go
+++ b/services/gateway/internal/router/partner_otc.go
@@ -12,14 +12,49 @@
 package router
 
 import (
+	"bytes"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"time"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// snippetMax bounds the partner-payload excerpt attached to decode-
+// failure logs. These are partner-bank protocol bodies (no user
+// secrets); the cap keeps a hostile payload from flooding a log line.
+const snippetMax = 512
+
+// bodySnippet truncates raw to snippetMax bytes for logging.
+func bodySnippet(raw []byte) string {
+	if len(raw) > snippetMax {
+		raw = raw[:snippetMax]
+	}
+	return string(raw)
+}
+
+// snippetWriter retains the first snippetMax bytes written through it.
+// Tee a request body through one so a JSON decode failure can log what
+// the partner actually sent without re-reading the stream.
+type snippetWriter struct{ buf bytes.Buffer }
+
+func (s *snippetWriter) Write(p []byte) (int, error) {
+	if room := snippetMax - s.buf.Len(); room > 0 {
+		if len(p) > room {
+			s.buf.Write(p[:room])
+		} else {
+			s.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (s *snippetWriter) String() string { return s.buf.String() }
 
 // PartnerOTC holds the deps the partner-facing handlers need. Set on
 // the Router when celina-5 is configured (INTERBANK_API_KEY and the
@@ -122,6 +157,9 @@ type nativePublicHolding struct {
 // protocol detection so it's intentionally unauthenticated.
 func (p *PartnerOTC) ListPublic(w http.ResponseWriter, r *http.Request) {
 	if p.Trading == nil {
+		ctx := r.Context()
+		logger.From(ctx).ErrorContext(ctx, "partner public listing unavailable: trading not wired",
+			"method", r.Method, "path", r.URL.Path)
 		writeError(w, http.StatusServiceUnavailable, "trading not wired")
 		return
 	}
@@ -130,7 +168,7 @@ func (p *PartnerOTC) ListPublic(w http.ResponseWriter, r *http.Request) {
 		Ticker: ticker,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
 	bankCode := p.BankRoutingNumber
@@ -198,6 +236,11 @@ func (p *PartnerOTC) guard(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		got := []byte(r.Header.Get("X-Api-Key"))
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			ctx := r.Context()
+			// Never log the presented key itself.
+			logger.From(ctx).WarnContext(ctx, "partner api key rejected",
+				"method", r.Method, "path", r.URL.Path,
+				"key_present", len(got) > 0, "remote", r.RemoteAddr)
 			writeError(w, http.StatusUnauthorized, "invalid X-Api-Key")
 			return
 		}
@@ -207,13 +250,24 @@ func (p *PartnerOTC) guard(h http.HandlerFunc) http.HandlerFunc {
 
 // ReceiveOffer handles a partner's CreateOffer call.
 func (p *PartnerOTC) ReceiveOffer(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in partnerOfferRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); err != nil {
+		log.WarnContext(ctx, "partner offer payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	// Carry the partner identity + thread id on the request logger so
+	// the shared writeGRPCError line names the failing exchange too.
+	log = log.With("partner_bank", in.SenderBankCode, "sender_thread_id", in.SenderThreadID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	settle, err := parsePartnerDate(in.SettlementDate)
 	if err != nil {
+		log.WarnContext(ctx, "partner offer rejected: bad settlement date", "err", err)
 		writeError(w, http.StatusBadRequest, "invalid settlement_date: "+err.Error())
 		return
 	}
@@ -229,9 +283,13 @@ func (p *PartnerOTC) ReceiveOffer(w http.ResponseWriter, r *http.Request) {
 		SettlementDate:    timestamppb.New(settle),
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner offer received",
+		"local_thread_id", out.GetLocalMirror().GetId(),
+		"quantity", in.Quantity, "price_per_unit", in.PricePerUnit,
+		"premium", in.Premium)
 	writeJSON(w, http.StatusOK, partnerOfferResponse{
 		RemoteThreadID:    out.GetLocalMirror().GetId(),
 		RemoteDisplayName: out.GetLocalMirror().GetLocalUserId(),
@@ -241,14 +299,14 @@ func (p *PartnerOTC) ReceiveOffer(w http.ResponseWriter, r *http.Request) {
 
 // ReceiveCounter handles a partner's counter-offer.
 func (p *PartnerOTC) ReceiveCounter(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in partnerCounterRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); err != nil {
+		log.WarnContext(ctx, "partner counter payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	settle, err := parsePartnerDate(in.SettlementDate)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid settlement_date: "+err.Error())
 		return
 	}
 	bankCode := r.PathValue("bank_code")
@@ -259,6 +317,15 @@ func (p *PartnerOTC) ReceiveCounter(w http.ResponseWriter, r *http.Request) {
 	if in.SenderThreadID == "" {
 		in.SenderThreadID = threadID
 	}
+	log = log.With("partner_bank", in.SenderBankCode, "sender_thread_id", in.SenderThreadID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
+	settle, err := parsePartnerDate(in.SettlementDate)
+	if err != nil {
+		log.WarnContext(ctx, "partner counter rejected: bad settlement date", "err", err)
+		writeError(w, http.StatusBadRequest, "invalid settlement_date: "+err.Error())
+		return
+	}
 	_, err = p.TradingOTC.ReceiveExternalOTCCounter(r.Context(), &tradingpb.ReceiveExternalOTCCounterRequest{
 		SenderBankCode: in.SenderBankCode,
 		SenderThreadId: in.SenderThreadID,
@@ -268,9 +335,12 @@ func (p *PartnerOTC) ReceiveCounter(w http.ResponseWriter, r *http.Request) {
 		SettlementDate: timestamppb.New(settle),
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner counter received",
+		"quantity", in.Quantity, "price_per_unit", in.PricePerUnit,
+		"premium", in.Premium)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -291,10 +361,17 @@ const (
 )
 
 func (p *PartnerOTC) dispatchAction(w http.ResponseWriter, r *http.Request, kind partnerActionKind) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in partnerActionRequest
 	// Bodies may be empty for action endpoints; ignore decode errors
-	// when body length is 0.
-	_ = json.NewDecoder(r.Body).Decode(&in)
+	// when body length is 0 (io.EOF). Anything else is a malformed
+	// partner payload worth a line even though we proceed regardless.
+	var snip snippetWriter
+	if derr := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); derr != nil && !errors.Is(derr, io.EOF) {
+		log.WarnContext(ctx, "partner action payload ignored: decode failed",
+			"err", derr, "path", r.URL.Path, "body", snip.String())
+	}
 	bankCode := r.PathValue("bank_code")
 	threadID := r.PathValue("thread_id")
 	if in.SenderBankCode == "" {
@@ -303,6 +380,13 @@ func (p *PartnerOTC) dispatchAction(w http.ResponseWriter, r *http.Request, kind
 	if in.SenderThreadID == "" {
 		in.SenderThreadID = threadID
 	}
+	action := "withdraw"
+	if kind == acceptAction {
+		action = "accept"
+	}
+	log = log.With("partner_bank", in.SenderBankCode, "sender_thread_id", in.SenderThreadID, "action", action)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	req := &tradingpb.ReceiveExternalOTCActionRequest{
 		SenderBankCode: in.SenderBankCode,
 		SenderThreadId: in.SenderThreadID,
@@ -315,16 +399,22 @@ func (p *PartnerOTC) dispatchAction(w http.ResponseWriter, r *http.Request, kind
 		_, err = p.TradingOTC.ReceiveExternalOTCAccept(r.Context(), req)
 	}
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner otc action applied")
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // ReceiveExerciseNotice handles a partner's exercise notification.
 func (p *PartnerOTC) ReceiveExerciseNotice(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in partnerExerciseRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); err != nil {
+		log.WarnContext(ctx, "partner exercise payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -336,7 +426,12 @@ func (p *PartnerOTC) ReceiveExerciseNotice(w http.ResponseWriter, r *http.Reques
 	if in.SenderContractID == "" {
 		in.SenderContractID = contractID
 	}
+	log = log.With("partner_bank", in.SenderBankCode,
+		"sender_contract_id", in.SenderContractID, "exercise_op_id", in.ExerciseOpID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	if in.ExerciseOpID == "" {
+		log.WarnContext(ctx, "partner exercise rejected: missing exercise_op_id")
 		writeError(w, http.StatusBadRequest, "exercise_op_id is required")
 		return
 	}
@@ -346,9 +441,10 @@ func (p *PartnerOTC) ReceiveExerciseNotice(w http.ResponseWriter, r *http.Reques
 		ExerciseOpId:     in.ExerciseOpID,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "partner exercise notice received")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/services/gateway/internal/router/partner_otc_settlement.go
+++ b/services/gateway/internal/router/partner_otc_settlement.go
@@ -3,6 +3,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 )
@@ -188,7 +189,13 @@ func parseB2OTCSettlement(tx b2Transaction, ourRoutings ...int) (*b2OTCSettlemen
 				}
 			case "STOCK":
 				_, abs := b2AmountSign(p.Amount)
-				out.Quantity, _ = strconv.ParseInt(abs, 10, 64)
+				qty, qerr := strconv.ParseInt(abs, 10, 64)
+				if qerr != nil {
+					// No ctx in this parser — package-level slog.
+					slog.Warn("otc exercise settlement: malformed stock quantity",
+						"err", qerr, "amount", string(p.Amount))
+				}
+				out.Quantity = qty
 				out.Ticker = stockTicker(p.Asset)
 			}
 		}
@@ -209,6 +216,11 @@ func optionNegotiationID(a b2Asset) b2ForeignID {
 	}
 	var body b2OptionAssetBody
 	if err := json.Unmarshal(*a.Asset, &body); err != nil {
+		// No ctx in this parser — package-level slog. Returning the zero
+		// id makes the caller report "no OPTION posting"; this log keeps
+		// the real cause visible.
+		slog.Warn("otc settlement: option asset body unmarshal failed",
+			"err", err, "asset", bodySnippet(*a.Asset))
 		return b2ForeignID{}
 	}
 	return body.NegotiationID
@@ -221,6 +233,8 @@ func stockTicker(a b2Asset) string {
 	}
 	var body b2StockAssetBody
 	if err := json.Unmarshal(*a.Asset, &body); err != nil {
+		slog.Warn("otc settlement: stock asset body unmarshal failed",
+			"err", err, "asset", bodySnippet(*a.Asset))
 		return ""
 	}
 	return body.Ticker

--- a/services/gateway/internal/router/partner_payments.go
+++ b/services/gateway/internal/router/partner_payments.go
@@ -28,6 +28,7 @@ import (
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
 	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/signature"
 )
@@ -118,8 +119,14 @@ func (p *PartnerPayments) guard(h http.HandlerFunc) http.HandlerFunc {
 	expected := []byte(p.APIKey)
 	verifier := signature.New(p.SignKey)
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		log := logger.From(ctx)
 		got := []byte(r.Header.Get("X-Api-Key"))
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			// Never log the presented key itself.
+			log.WarnContext(ctx, "partner api key rejected",
+				"method", r.Method, "path", r.URL.Path,
+				"key_present", len(got) > 0, "remote", r.RemoteAddr)
 			writeError(w, http.StatusUnauthorized, "invalid X-Api-Key")
 			return
 		}
@@ -131,13 +138,24 @@ func (p *PartnerPayments) guard(h http.HandlerFunc) http.HandlerFunc {
 			body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 			_ = r.Body.Close()
 			if err != nil {
+				log.WarnContext(ctx, "partner request body read failed",
+					"err", err, "method", r.Method, "path", r.URL.Path)
 				writeError(w, http.StatusBadRequest, "read body: "+err.Error())
 				return
 			}
 			if err := verifier.Verify(body, r.Header.Get("X-Timestamp"), r.Header.Get("X-Signature")); err != nil {
+				// err names the failed check (stale/malformed timestamp
+				// vs signature mismatch). The signature value and key
+				// stay out of the log; the body is a partner protocol
+				// payload, not a user secret.
+				log.WarnContext(ctx, "interbank signature rejected",
+					"err", err, "method", r.Method, "path", r.URL.Path,
+					"ts", r.Header.Get("X-Timestamp"), "body", bodySnippet(body))
 				writeError(w, http.StatusUnauthorized, "invalid signature: "+err.Error())
 				return
 			}
+			log.DebugContext(ctx, "interbank signature verified",
+				"method", r.Method, "path", r.URL.Path)
 			r.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		h(w, r)
@@ -191,16 +209,25 @@ func statusToWire(s bankpb.InterbankTxStatus) string {
 
 // handlePrepare — POST /bank/api/v1/interbank/transactions.
 func (p *PartnerPayments) handlePrepare(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
+		log.WarnContext(ctx, "partner request body read failed",
+			"err", err, "method", r.Method, "path", r.URL.Path)
 		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}
 	var in preparePaymentRequest
 	if err := json.Unmarshal(body, &in); err != nil {
+		log.WarnContext(ctx, "interbank prepare payload decode failed",
+			"err", err, "path", r.URL.Path, "body", bodySnippet(body))
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	log = log.With("partner_bank", in.SenderRoutingNumber, "transaction_id", in.TransactionID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	if replayed := p.tryReplay(w, r, in.SenderRoutingNumber); replayed {
 		return
 	}
@@ -216,9 +243,12 @@ func (p *PartnerPayments) handlePrepare(w http.ResponseWriter, r *http.Request) 
 		Purpose:             in.Purpose,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "interbank prepare accepted",
+		"status", statusToWire(resp.GetStatus()), "direction", in.Direction,
+		"currency", in.Currency, "amount", in.Amount)
 	out := preparePaymentResponse{
 		TransactionID: resp.GetTransactionId(),
 		Status:        statusToWire(resp.GetStatus()),
@@ -230,23 +260,33 @@ func (p *PartnerPayments) handlePrepare(w http.ResponseWriter, r *http.Request) 
 
 // handleCommit — POST /bank/api/v1/interbank/transactions/{transaction_id}/commit.
 func (p *PartnerPayments) handleCommit(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in commitPaymentRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); err != nil {
+		log.WarnContext(ctx, "interbank commit payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	txID := r.PathValue("transaction_id")
+	log = log.With("partner_bank", in.SenderRoutingNumber, "transaction_id", txID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	if replayed := p.tryReplay(w, r, in.SenderRoutingNumber); replayed {
 		return
 	}
-	txID := r.PathValue("transaction_id")
 	resp, err := p.Interbank.CommitPayment(partnerCtx(r.Context()), &bankpb.CommitPaymentRequest{
 		SenderRoutingNumber: int32(in.SenderRoutingNumber),
 		TransactionId:       txID,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "interbank commit accepted",
+		"status", statusToWire(resp.GetStatus()), "op_id", resp.GetOpId())
 	out := commitPaymentResponse{
 		TransactionID: resp.GetTransactionId(),
 		Status:        statusToWire(resp.GetStatus()),
@@ -258,24 +298,34 @@ func (p *PartnerPayments) handleCommit(w http.ResponseWriter, r *http.Request) {
 
 // handleRollback — POST /bank/api/v1/interbank/transactions/{transaction_id}/rollback.
 func (p *PartnerPayments) handleRollback(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	var in rollbackPaymentRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+	var snip snippetWriter
+	if err := json.NewDecoder(io.TeeReader(r.Body, &snip)).Decode(&in); err != nil {
+		log.WarnContext(ctx, "interbank rollback payload decode failed",
+			"err", err, "path", r.URL.Path, "body", snip.String())
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	txID := r.PathValue("transaction_id")
+	log = log.With("partner_bank", in.SenderRoutingNumber, "transaction_id", txID)
+	r = r.WithContext(logger.Inject(ctx, log))
+	ctx = r.Context()
 	if replayed := p.tryReplay(w, r, in.SenderRoutingNumber); replayed {
 		return
 	}
-	txID := r.PathValue("transaction_id")
 	resp, err := p.Interbank.RollbackPayment(partnerCtx(r.Context()), &bankpb.RollbackPaymentRequest{
 		SenderRoutingNumber: int32(in.SenderRoutingNumber),
 		TransactionId:       txID,
 		Reason:              in.Reason,
 	})
 	if err != nil {
-		writeGRPCError(w, err)
+		writeGRPCError(w, r, err)
 		return
 	}
+	log.InfoContext(ctx, "interbank rollback accepted",
+		"status", statusToWire(resp.GetStatus()), "reason", in.Reason)
 	out := rollbackPaymentResponse{
 		TransactionID: resp.GetTransactionId(),
 		Status:        statusToWire(resp.GetStatus()),
@@ -292,40 +342,63 @@ func (p *PartnerPayments) tryReplay(w http.ResponseWriter, r *http.Request, send
 	if key == "" || sender == 0 {
 		return false
 	}
-	hit, err := p.Interbank.GetInboundMessage(partnerCtx(r.Context()), &bankpb.GetInboundMessageRequest{
+	ctx := r.Context()
+	log := logger.From(ctx)
+	hit, err := p.Interbank.GetInboundMessage(partnerCtx(ctx), &bankpb.GetInboundMessageRequest{
 		SenderRoutingNumber: int32(sender),
 		IdempotenceKey:      key,
 	})
 	if err != nil || hit == nil || !hit.GetFound() {
+		if err != nil {
+			// Best-effort lookup — a miss just re-runs the handler, but
+			// a broken audit store deserves a line.
+			log.WarnContext(ctx, "interbank replay lookup failed; proceeding",
+				"err", err, "partner_bank", sender)
+		}
 		return false
 	}
+	log.InfoContext(ctx, "interbank message replayed from cache",
+		"partner_bank", sender, "status", hit.GetResponseStatus())
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(int(hit.GetResponseStatus()))
-	_, _ = w.Write([]byte(hit.GetResponseBody()))
+	if _, werr := w.Write([]byte(hit.GetResponseBody())); werr != nil {
+		log.WarnContext(ctx, "response write failed", "err", werr, "partner_bank", sender)
+	}
 	return true
 }
 
 // writeAndCache writes the JSON response and (when the partner sent
 // X-Idempotence-Key) stashes it for replay. Cache write is best-effort.
 func (p *PartnerPayments) writeAndCache(w http.ResponseWriter, r *http.Request, sender int, txID string, msgType bankpb.InterbankMessageType, status int, payload any) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	buf, err := json.Marshal(payload)
 	if err != nil {
+		log.ErrorContext(ctx, "interbank response marshal failed",
+			"err", err, "partner_bank", sender, "transaction_id", txID)
 		writeError(w, http.StatusInternalServerError, "marshal response: "+err.Error())
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	_, _ = w.Write(buf)
+	if _, werr := w.Write(buf); werr != nil {
+		log.WarnContext(ctx, "response write failed",
+			"err", werr, "partner_bank", sender, "transaction_id", txID)
+	}
 	key := r.Header.Get("X-Idempotence-Key")
 	if key == "" || sender == 0 {
 		return
 	}
-	_, _ = p.Interbank.RecordInboundMessage(partnerCtx(r.Context()), &bankpb.RecordInboundMessageRequest{
+	if _, rerr := p.Interbank.RecordInboundMessage(partnerCtx(ctx), &bankpb.RecordInboundMessageRequest{
 		SenderRoutingNumber: int32(sender),
 		IdempotenceKey:      key,
 		MessageType:         msgType,
 		TransactionId:       txID,
 		ResponseStatus:      int32(status),
 		ResponseBody:        string(buf),
-	})
+	}); rerr != nil {
+		// Best-effort idempotency audit; a retry will simply re-run.
+		log.WarnContext(ctx, "interbank inbound message cache write failed",
+			"err", rerr, "partner_bank", sender, "transaction_id", txID)
+	}
 }

--- a/services/gateway/internal/router/router.go
+++ b/services/gateway/internal/router/router.go
@@ -3,12 +3,14 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/user/v1"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/clock"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/verification"
 
@@ -127,7 +129,11 @@ func (r *Router) Mount(ctx context.Context, gwMux *runtime.ServeMux, registerGW 
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		// Almost always a client that hung up mid-response; no request
+		// context here, so the default (service) logger carries it.
+		slog.Default().Warn("response write failed", "err", err, "status", status)
+	}
 }
 
 // DebugClockSetHandler handles POST /api/v1/_debug/clock with body
@@ -139,25 +145,35 @@ func (r *Router) DebugClockSetHandler() http.HandlerFunc {
 		Offset string `json:"offset"`
 	}
 	return func(w http.ResponseWriter, httpReq *http.Request) {
-		p, ok := auth.PrincipalFrom(httpReq.Context())
+		ctx := httpReq.Context()
+		log := logger.From(ctx)
+		p, ok := auth.PrincipalFrom(ctx)
 		if !ok || !permissions.Has(p.Permissions, permissions.Admin) {
+			log.WarnContext(ctx, "debug clock set rejected: admin only",
+				"path", httpReq.URL.Path)
 			writeJSON(w, http.StatusForbidden, errBody{Code: http.StatusForbidden, Message: "admin only"})
 			return
 		}
 		var in req
 		if err := json.NewDecoder(httpReq.Body).Decode(&in); err != nil {
+			log.WarnContext(ctx, "debug clock set rejected: invalid body", "err", err)
 			writeJSON(w, http.StatusBadRequest, errBody{Code: http.StatusBadRequest, Message: "invalid body"})
 			return
 		}
 		d, err := time.ParseDuration(in.Offset)
 		if err != nil {
+			log.WarnContext(ctx, "debug clock set rejected: bad offset", "err", err)
 			writeJSON(w, http.StatusBadRequest, errBody{Code: http.StatusBadRequest, Message: "offset: " + err.Error()})
 			return
 		}
-		if err := r.Clock.SetOffset(httpReq.Context(), d); err != nil {
+		if err := r.Clock.SetOffset(ctx, d); err != nil {
+			log.ErrorContext(ctx, "debug clock offset persist failed",
+				"err", err, "offset", d.String())
 			writeJSON(w, http.StatusInternalServerError, errBody{Code: http.StatusInternalServerError, Message: err.Error()})
 			return
 		}
+		log.InfoContext(ctx, "debug clock offset set",
+			"offset", d.String(), "user_id", p.UserID)
 		writeJSON(w, http.StatusOK, map[string]any{
 			"offset": d.String(),
 			"now":    r.Clock.Now().Format(time.RFC3339),
@@ -187,13 +203,29 @@ func writeError(w http.ResponseWriter, code int, msg string) {
 }
 
 // writeGRPCError translates a gRPC status to an HTTP error JSON body.
-func writeGRPCError(w http.ResponseWriter, err error) {
+// It is the router package's gRPC→HTTP translation choke point, so it
+// also emits the structured log line for the failure: Error for 5xx
+// (upstream/internal), Warn for client-class 4xx.
+func writeGRPCError(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
+	log := logger.From(ctx)
 	st, ok := status.FromError(err)
 	if !ok || st == nil {
+		log.ErrorContext(ctx, "upstream call failed",
+			"err", err, "method", r.Method, "path", r.URL.Path)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	httpCode := runtime.HTTPStatusFromCode(st.Code())
+	if httpCode >= 500 {
+		log.ErrorContext(ctx, "upstream call failed",
+			"err", err, "code", st.Code().String(), "status", httpCode,
+			"method", r.Method, "path", r.URL.Path)
+	} else {
+		log.WarnContext(ctx, "upstream call rejected",
+			"err", err, "code", st.Code().String(), "status", httpCode,
+			"method", r.Method, "path", r.URL.Path)
+	}
 	writeError(w, httpCode, st.Message())
 }
 

--- a/services/gateway/internal/router/verification.go
+++ b/services/gateway/internal/router/verification.go
@@ -8,6 +8,7 @@ import (
 
 	userpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/user/v1"
 	pkgauth "github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/verification"
 )
 
@@ -108,11 +109,17 @@ func (r *Router) VerificationPendingHandler() http.HandlerFunc {
 		}
 		p, ok := pkgauth.PrincipalFrom(req.Context())
 		if !ok {
+			ctx := req.Context()
+			logger.From(ctx).WarnContext(ctx, "verification pending rejected: missing principal",
+				"path", req.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing access token")
 			return
 		}
 		recs, err := lister.ListPending(req.Context(), p.UserID)
 		if err != nil {
+			ctx := req.Context()
+			logger.From(ctx).ErrorContext(ctx, "verification pending list failed",
+				"err", err, "user_id", p.UserID)
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 			return
 		}
@@ -157,8 +164,11 @@ type historyResponse struct {
 // row older than the code TTL to "expired" here.
 func (r *Router) VerificationHistoryHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		p, ok := pkgauth.PrincipalFrom(req.Context())
+		ctx := req.Context()
+		p, ok := pkgauth.PrincipalFrom(ctx)
 		if !ok {
+			logger.From(ctx).WarnContext(ctx, "verification history rejected: missing principal",
+				"path", req.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing access token")
 			return
 		}
@@ -166,6 +176,8 @@ func (r *Router) VerificationHistoryHandler() http.HandlerFunc {
 			UserId: p.UserID,
 		})
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "verification history list failed",
+				"err", err, "user_id", p.UserID)
 			writeError(w, http.StatusServiceUnavailable, "Istorija verifikacija privremeno nedostupna.")
 			return
 		}
@@ -195,27 +207,39 @@ func (r *Router) VerificationHistoryHandler() http.HandlerFunc {
 // is already on the context.
 func (r *Router) VerificationHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		log := logger.From(ctx)
 		if r.Verifier == nil {
+			log.ErrorContext(ctx, "verification request failed: verifier not configured",
+				"path", req.URL.Path)
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija nije konfigurisana.")
 			return
 		}
 		var body VerificationRequest
 		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			log.WarnContext(ctx, "verification request rejected: invalid body", "err", err)
 			writeError(w, http.StatusBadRequest, "neispravan zahtev")
 			return
 		}
 		kind, ok := allowedKinds[body.ActionKind]
 		if !ok {
+			log.WarnContext(ctx, "verification request rejected: unknown action kind",
+				"action_kind", body.ActionKind)
 			writeError(w, http.StatusBadRequest, "nepoznat tip akcije")
 			return
 		}
 		p, ok := pkgauth.PrincipalFrom(req.Context())
 		if !ok {
+			log.WarnContext(ctx, "verification request rejected: missing principal",
+				"path", req.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing access token")
 			return
 		}
 		id, code, exp, err := r.Verifier.Issue(req.Context(), p.UserID, kind)
 		if err != nil {
+			// The 6-digit code is never logged, here or anywhere.
+			log.ErrorContext(ctx, "verification code issue failed",
+				"err", err, "user_id", p.UserID, "action_kind", string(kind))
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 			return
 		}
@@ -244,22 +268,31 @@ type approveResponse struct {
 // approve their own records (ownership enforced in verification.Approve).
 func (r *Router) VerificationApproveHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		log := logger.From(ctx)
 		if r.Verifier == nil {
+			log.ErrorContext(ctx, "verification approve failed: verifier not configured",
+				"path", req.URL.Path)
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija nije konfigurisana.")
 			return
 		}
 		ap, ok := r.Verifier.(verification.Approver)
 		if !ok {
+			log.ErrorContext(ctx, "verification approve failed: approver not supported",
+				"path", req.URL.Path)
 			writeError(w, http.StatusServiceUnavailable, "Brzo odobravanje nije dostupno.")
 			return
 		}
 		id := req.PathValue("id")
 		if id == "" {
+			log.WarnContext(ctx, "verification approve rejected: missing id")
 			writeError(w, http.StatusBadRequest, "neispravan zahtev")
 			return
 		}
 		p, ok := pkgauth.PrincipalFrom(req.Context())
 		if !ok {
+			log.WarnContext(ctx, "verification approve rejected: missing principal",
+				"path", req.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing access token")
 			return
 		}
@@ -270,8 +303,12 @@ func (r *Router) VerificationApproveHandler() http.HandlerFunc {
 		case errors.Is(err, verification.ErrNotFound):
 			// Not owned, expired, or already consumed — indistinguishable
 			// on purpose (don't let a caller probe foreign records).
+			log.WarnContext(ctx, "verification approve rejected: record not found",
+				"verification_id", id, "user_id", p.UserID)
 			writeError(w, http.StatusNotFound, "Zahtev za verifikaciju nije pronađen ili je istekao.")
 		default:
+			log.ErrorContext(ctx, "verification approve failed",
+				"err", err, "verification_id", id, "user_id", p.UserID)
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 		}
 	}
@@ -292,13 +329,17 @@ type statusResponse struct {
 // own pending list so no foreign record can be probed.
 func (r *Router) VerificationStatusHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 		id := req.PathValue("id")
 		if id == "" {
+			logger.From(ctx).WarnContext(ctx, "verification status rejected: missing id")
 			writeError(w, http.StatusBadRequest, "neispravan zahtev")
 			return
 		}
 		p, ok := pkgauth.PrincipalFrom(req.Context())
 		if !ok {
+			logger.From(ctx).WarnContext(ctx, "verification status rejected: missing principal",
+				"path", req.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing access token")
 			return
 		}
@@ -309,6 +350,9 @@ func (r *Router) VerificationStatusHandler() http.HandlerFunc {
 		}
 		recs, err := lister.ListPending(req.Context(), p.UserID)
 		if err != nil {
+			ctx := req.Context()
+			logger.From(ctx).ErrorContext(ctx, "verification status list failed",
+				"err", err, "verification_id", id, "user_id", p.UserID)
 			writeError(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 			return
 		}

--- a/services/gateway/internal/verification/middleware.go
+++ b/services/gateway/internal/verification/middleware.go
@@ -114,9 +114,14 @@ func Middleware(v verification.Verifier, rules []Rule, log *slog.Logger) func(ht
 				next.ServeHTTP(w, r)
 				return
 			}
+			ctx := r.Context()
+			// The verification id is an opaque handle, safe to log; the
+			// 6-digit code is a secret and never appears in a log line.
 			id := r.Header.Get(HeaderID)
 			code := r.Header.Get(HeaderCode)
 			if id == "" {
+				log.WarnContext(ctx, "verification rejected: missing id",
+					"kind", string(kind), "method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je obavezan.")
 				return
 			}
@@ -130,26 +135,45 @@ func Middleware(v verification.Verifier, rules []Rule, log *slog.Logger) func(ht
 			if code == "" || code == QuickApproveSentinel {
 				ap, ok := v.(verification.Approver)
 				if !ok {
+					log.WarnContext(ctx, "verification rejected: quick-approve unsupported",
+						"verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je obavezan.")
 					return
 				}
 				p, ok := pkgauth.PrincipalFrom(r.Context())
 				if !ok {
+					log.WarnContext(ctx, "verification rejected: missing principal",
+						"verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusUnauthorized, "missing access token")
 					return
 				}
 				aerr := ap.ConsumeApproved(r.Context(), p.UserID, id, kind)
 				switch {
 				case aerr == nil:
+					log.DebugContext(ctx, "verification quick-approve consumed",
+						"verification_id", id, "kind", string(kind), "path", r.URL.Path)
 					next.ServeHTTP(w, r)
 				case errors.Is(aerr, verification.ErrNotApproved):
+					log.WarnContext(ctx, "verification rejected: not approved yet",
+						"verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusUnauthorized, "Zahtev još nije odobren sa telefona.")
 				case errors.Is(aerr, verification.ErrNotFound):
+					log.WarnContext(ctx, "verification rejected: record expired or not found",
+						"verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je istekao. Zatraži novi.")
 				case errors.Is(aerr, verification.ErrMismatch):
+					log.WarnContext(ctx, "verification rejected: action kind mismatch",
+						"verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusUnauthorized, "Verifikacioni kod ne odgovara ovoj akciji.")
 				default:
-					log.Warn("verification quick-approve consume failed", "error", aerr)
+					log.ErrorContext(ctx, "verification quick-approve consume failed",
+						"err", aerr, "verification_id", id, "kind", string(kind),
+						"method", r.Method, "path", r.URL.Path)
 					writeErr(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 				}
 				return
@@ -158,17 +182,33 @@ func Middleware(v verification.Verifier, rules []Rule, log *slog.Logger) func(ht
 			err := v.Consume(r.Context(), id, code, kind)
 			switch {
 			case err == nil:
+				log.DebugContext(ctx, "verification consumed",
+					"verification_id", id, "kind", string(kind), "path", r.URL.Path)
 				next.ServeHTTP(w, r)
 			case errors.Is(err, verification.ErrWrongCode):
+				log.WarnContext(ctx, "verification rejected: wrong code",
+					"verification_id", id, "kind", string(kind),
+					"method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusUnauthorized, "Pogrešan verifikacioni kod.")
 			case errors.Is(err, verification.ErrTooMany):
+				log.WarnContext(ctx, "verification rejected: too many attempts",
+					"verification_id", id, "kind", string(kind),
+					"method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusUnauthorized, "Previše neuspešnih pokušaja. Zatraži novi kod.")
 			case errors.Is(err, verification.ErrNotFound):
+				log.WarnContext(ctx, "verification rejected: record expired or not found",
+					"verification_id", id, "kind", string(kind),
+					"method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusUnauthorized, "Verifikacioni kod je istekao. Zatraži novi.")
 			case errors.Is(err, verification.ErrMismatch):
+				log.WarnContext(ctx, "verification rejected: action kind mismatch",
+					"verification_id", id, "kind", string(kind),
+					"method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusUnauthorized, "Verifikacioni kod ne odgovara ovoj akciji.")
 			default:
-				log.Warn("verification consume failed", "error", err)
+				log.ErrorContext(ctx, "verification consume failed",
+					"err", err, "verification_id", id, "kind", string(kind),
+					"method", r.Method, "path", r.URL.Path)
 				writeErr(w, http.StatusServiceUnavailable, "Verifikacija privremeno nedostupna.")
 			}
 		})
@@ -183,5 +223,9 @@ type errBody struct {
 func writeErr(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(errBody{Code: status, Message: msg})
+	if err := json.NewEncoder(w).Encode(errBody{Code: status, Message: msg}); err != nil {
+		// Almost always a client that hung up mid-response; no request
+		// context here, so the default (service) logger carries it.
+		slog.Default().Warn("response write failed", "err", err, "status", status)
+	}
 }

--- a/services/gateway/internal/verification/recorder.go
+++ b/services/gateway/internal/verification/recorder.go
@@ -50,7 +50,7 @@ func (r *RecordingVerifier) Issue(ctx context.Context, userID string, kind verif
 		UserId:     userID,
 		ActionKind: string(kind),
 	}); rerr != nil {
-		r.Log.Warn("verification history: record failed", "error", rerr, "id", id)
+		r.Log.WarnContext(rctx, "verification history: record failed", "err", rerr, "id", id)
 	}
 	return id, code, exp, nil
 }
@@ -77,7 +77,7 @@ func (r *RecordingVerifier) resolve(ctx context.Context, id string, success bool
 		Id:      id,
 		Success: success,
 	}); err != nil {
-		r.Log.Warn("verification history: resolve failed", "error", err, "id", id, "success", success)
+		r.Log.WarnContext(rctx, "verification history: resolve failed", "err", err, "id", id, "success", success)
 	}
 }
 

--- a/services/notification/internal/app/app.go
+++ b/services/notification/internal/app/app.go
@@ -33,18 +33,21 @@ func Run() error {
 
 	prov, err := otelinit.Init(ctx, "notification")
 	if err != nil {
+		log.ErrorContext(ctx, "otel init failed", "err", err)
 		return fmt.Errorf("otelinit: %w", err)
 	}
 	defer func() { _ = prov.Shutdown(context.Background()) }()
 
 	pool, err := postgres.Open(ctx, config.MustString("DATABASE_URL"))
 	if err != nil {
+		log.ErrorContext(ctx, "postgres open failed", "err", err)
 		return fmt.Errorf("postgres: %w", err)
 	}
 	defer pool.Close()
 
 	rdb, err := pkgredis.Open(ctx, config.MustString("REDIS_ADDR"), config.String("REDIS_PASSWORD", ""))
 	if err != nil {
+		log.ErrorContext(ctx, "redis open failed", "err", err)
 		return fmt.Errorf("redis: %w", err)
 	}
 	defer rdb.Close()
@@ -83,9 +86,10 @@ func Run() error {
 	})
 
 	probeSrv.MarkReady()
-	log.Info("notification service ready", "grpc", grpcAddr)
+	log.InfoContext(ctx, "notification service ready", "grpc", grpcAddr)
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		log.ErrorContext(ctx, "service terminated", "err", err)
 		return err
 	}
 	return nil

--- a/services/notification/internal/server/notifications.go
+++ b/services/notification/internal/server/notifications.go
@@ -36,7 +36,7 @@ func (s *Server) CreateNotification(ctx context.Context, in *notifpb.CreateNotif
 	if err != nil {
 		return nil, err
 	}
-	s.Log.Info("in-app notification created",
+	s.Log.InfoContext(ctx, "in-app notification created",
 		"user_id", n.UserID, "kind", n.Kind)
 	return toProto(n), nil
 }

--- a/services/notification/internal/server/server.go
+++ b/services/notification/internal/server/server.go
@@ -36,12 +36,12 @@ func (s *Server) SendEmail(ctx context.Context, in *notifpb.SendEmailRequest) (*
 		Body:    in.GetBody(),
 		HTML:    in.GetHtml(),
 	}); err != nil {
-		s.Log.Warn("send email failed",
-			"to", in.GetTo(), "kind", in.GetKind().String(),
-			"origin", in.GetOriginService(), "err", err.Error())
+		s.Log.ErrorContext(ctx, "smtp send failed",
+			"err", err, "to", in.GetTo(), "kind", in.GetKind().String(),
+			"origin", in.GetOriginService())
 		return nil, err
 	}
-	s.Log.Info("send email ok",
+	s.Log.InfoContext(ctx, "email sent",
 		"to", in.GetTo(), "kind", in.GetKind().String(),
 		"origin", in.GetOriginService())
 	return &notifpb.SendEmailResponse{}, nil

--- a/services/notification/internal/store/notifications.go
+++ b/services/notification/internal/store/notifications.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/notification/internal/domain"
 )
 
@@ -31,10 +32,13 @@ func (s *Store) Insert(ctx context.Context, n *domain.Notification) (*domain.Not
         insert into "notification".notifications (user_id, user_kind, kind, title, body)
         values ($1, $2, $3, $4, $5)
         returning ` + notifCols
-	out, err := scanNotification(s.Pool.QueryRow(ctx, q,
+	out, err := scanNotification(s.Pool.QueryRow(
+		ctx, q,
 		n.UserID, n.UserKind, n.Kind, n.Title, n.Body,
 	))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert notification failed",
+			"err", err, "user_id", n.UserID, "kind", n.Kind)
 		return nil, apperr.Internal("insert notification", err)
 	}
 	return out, nil
@@ -50,6 +54,7 @@ func (s *Store) ListByUser(ctx context.Context, userID string, unreadOnly bool, 
 	q += ` order by created_at desc limit $2 offset $3`
 	rows, err := s.Pool.Query(ctx, q, userID, limit, offset)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list notifications failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list notifications", err)
 	}
 	defer rows.Close()
@@ -57,11 +62,16 @@ func (s *Store) ListByUser(ctx context.Context, userID string, unreadOnly bool, 
 	for rows.Next() {
 		n, err := scanNotification(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan notification failed", "err", err, "user_id", userID)
 			return nil, apperr.Internal("scan notification", err)
 		}
 		out = append(out, n)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list notifications rows failed", "err", err, "user_id", userID)
+		return out, err
+	}
+	return out, nil
 }
 
 // CountByUser counts the user's notifications matching the filter (used
@@ -73,6 +83,7 @@ func (s *Store) CountByUser(ctx context.Context, userID string, unreadOnly bool)
 	}
 	var total int64
 	if err := s.Pool.QueryRow(ctx, q, userID).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count notifications failed", "err", err, "user_id", userID)
 		return 0, apperr.Internal("count notifications", err)
 	}
 	return total, nil
@@ -84,6 +95,7 @@ func (s *Store) CountUnread(ctx context.Context, userID string) (int64, error) {
 	const q = `select count(*) from "notification".notifications where user_id = $1 and read_at is null`
 	var n int64
 	if err := s.Pool.QueryRow(ctx, q, userID).Scan(&n); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count unread notifications failed", "err", err, "user_id", userID)
 		return 0, apperr.Internal("count unread notifications", err)
 	}
 	return n, nil
@@ -104,6 +116,8 @@ func (s *Store) MarkRead(ctx context.Context, userID, id string) (*domain.Notifi
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, apperr.NotFound("notification not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "mark notification read failed",
+			"err", err, "notification_id", id, "user_id", userID)
 		return nil, apperr.Internal("mark notification read", err)
 	}
 	return out, nil
@@ -118,6 +132,7 @@ func (s *Store) MarkAllRead(ctx context.Context, userID string) (int64, error) {
         where user_id = $1 and read_at is null`
 	tag, err := s.Pool.Exec(ctx, q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark all notifications read failed", "err", err, "user_id", userID)
 		return 0, apperr.Internal("mark all notifications read", err)
 	}
 	return tag.RowsAffected(), nil

--- a/services/scheduler/internal/app/app.go
+++ b/services/scheduler/internal/app/app.go
@@ -48,13 +48,14 @@ func Run() error {
 
 	prov, err := otelinit.Init(ctx, "scheduler")
 	if err != nil {
+		log.ErrorContext(ctx, "otel init failed", "err", err)
 		return fmt.Errorf("otelinit: %w", err)
 	}
 	defer func() { _ = prov.Shutdown(context.Background()) }()
 
 	belgrade, err := time.LoadLocation("Europe/Belgrade")
 	if err != nil {
-		log.Warn("Europe/Belgrade timezone unavailable, falling back to UTC", "error", err)
+		log.WarnContext(ctx, "Europe/Belgrade timezone unavailable, falling back to UTC", "err", err)
 		belgrade = time.UTC
 	}
 
@@ -63,7 +64,7 @@ func Run() error {
 	var closers []func()
 	dial := func(name, addr string) *grpc.ClientConn {
 		if addr == "" {
-			log.Warn("grpc addr not set; jobs for this service disabled", "service", name)
+			log.WarnContext(ctx, "grpc addr not set; jobs for this service disabled", "service", name)
 			return nil
 		}
 		conn, err := grpc.NewClient(
@@ -72,7 +73,7 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
-			log.Error("dial failed; jobs for this service disabled", "service", name, "err", err.Error())
+			log.ErrorContext(ctx, "dial failed; jobs for this service disabled", "err", err.Error(), "service", name)
 			return nil
 		}
 		closers = append(closers, func() { _ = conn.Close() })
@@ -109,9 +110,10 @@ func Run() error {
 	})
 
 	probeSrv.MarkReady()
-	log.Info("scheduler ready")
+	log.InfoContext(ctx, "scheduler ready")
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		log.ErrorContext(ctx, "service terminated", "err", err)
 		return err
 	}
 	return nil

--- a/services/scheduler/internal/app/jobs.go
+++ b/services/scheduler/internal/app/jobs.go
@@ -159,7 +159,9 @@ func (a *App) once(name string, fn func(context.Context) error) job {
 // fire invokes one trigger with the admin context, logging failures
 // (but swallowing them so one bad tick never kills the job loop).
 func (a *App) fire(ctx context.Context, name string, fn func(context.Context) error) {
-	a.log.InfoContext(ctx, "job triggered", "job", name)
+	// Debug, not Info: the tightest jobs tick every 5s, and the target
+	// services already log batch summaries when a tick does real work.
+	a.log.DebugContext(ctx, "job triggered", "job", name)
 	start := time.Now()
 	if err := fn(a.adminCtx(ctx)); err != nil {
 		if ctx.Err() != nil {
@@ -169,7 +171,7 @@ func (a *App) fire(ctx context.Context, name string, fn func(context.Context) er
 			"err", err.Error(), "job", name, "duration", time.Since(start).String())
 		return
 	}
-	a.log.InfoContext(ctx, "job completed", "job", name, "duration", time.Since(start).String())
+	a.log.DebugContext(ctx, "job completed", "job", name, "duration", time.Since(start).String())
 }
 
 // --- Triggers: one gRPC call each ---

--- a/services/scheduler/internal/app/jobs.go
+++ b/services/scheduler/internal/app/jobs.go
@@ -93,10 +93,10 @@ func (a *App) buildJobs() []job {
 func (a *App) interval(name string, d time.Duration, fireNow bool, fn func(context.Context) error) job {
 	return job{name: name, run: func(ctx context.Context) {
 		if d <= 0 {
-			a.log.Info("job disabled (interval<=0)", "job", name)
+			a.log.InfoContext(ctx, "job disabled (interval<=0)", "job", name)
 			return
 		}
-		a.log.Info("interval job started", "job", name, "interval", d.String())
+		a.log.InfoContext(ctx, "interval job started", "job", name, "interval", d.String())
 		if fireNow {
 			a.fire(ctx, name, fn)
 		}
@@ -118,7 +118,7 @@ func (a *App) daily(name string, h, m int, fn func(context.Context) error) job {
 	return job{name: name, run: func(ctx context.Context) {
 		for {
 			next := nextDailyOccurrence(time.Now().In(a.loc), h, m)
-			a.log.Info("daily job scheduled", "job", name, "next", next.Format(time.RFC3339))
+			a.log.InfoContext(ctx, "daily job scheduled", "job", name, "next", next.Format(time.RFC3339))
 			t := time.NewTimer(time.Until(next))
 			select {
 			case <-ctx.Done():
@@ -136,7 +136,7 @@ func (a *App) monthlyEnd(name string, h, m int, fn func(context.Context) error) 
 	return job{name: name, run: func(ctx context.Context) {
 		for {
 			next := nextEndOfMonthAfter(time.Now().In(a.loc), h, m)
-			a.log.Info("monthly job scheduled", "job", name, "next", next.Format(time.RFC3339))
+			a.log.InfoContext(ctx, "monthly job scheduled", "job", name, "next", next.Format(time.RFC3339))
 			t := time.NewTimer(time.Until(next))
 			select {
 			case <-ctx.Done():
@@ -159,12 +159,17 @@ func (a *App) once(name string, fn func(context.Context) error) job {
 // fire invokes one trigger with the admin context, logging failures
 // (but swallowing them so one bad tick never kills the job loop).
 func (a *App) fire(ctx context.Context, name string, fn func(context.Context) error) {
+	a.log.InfoContext(ctx, "job triggered", "job", name)
+	start := time.Now()
 	if err := fn(a.adminCtx(ctx)); err != nil {
 		if ctx.Err() != nil {
 			return // shutting down / lost leadership
 		}
-		a.log.Warn("job failed", "job", name, "err", err.Error())
+		a.log.ErrorContext(ctx, "job failed",
+			"err", err.Error(), "job", name, "duration", time.Since(start).String())
+		return
 	}
+	a.log.InfoContext(ctx, "job completed", "job", name, "duration", time.Since(start).String())
 }
 
 // --- Triggers: one gRPC call each ---
@@ -175,7 +180,7 @@ func (a *App) bankInstallments(ctx context.Context) error {
 		return err
 	}
 	if r.GetProcessed() > 0 {
-		a.log.Info("installments ran", "processed", r.GetProcessed(), "paid", r.GetPaid(), "overdue", r.GetOverdue())
+		a.log.InfoContext(ctx, "installments ran", "processed", r.GetProcessed(), "paid", r.GetPaid(), "overdue", r.GetOverdue())
 	}
 	return nil
 }
@@ -186,7 +191,7 @@ func (a *App) bankVariableRate(ctx context.Context) error {
 		return err
 	}
 	if r.GetUpdated() > 0 {
-		a.log.Info("variable-rate ran", "updated", r.GetUpdated())
+		a.log.InfoContext(ctx, "variable-rate ran", "updated", r.GetUpdated())
 	}
 	return nil
 }
@@ -197,7 +202,7 @@ func (a *App) bankMaintenance(ctx context.Context) error {
 		return err
 	}
 	if r.GetProcessed() > 0 {
-		a.log.Info("maintenance-fee ran", "processed", r.GetProcessed(), "charged", r.GetCharged(), "skipped", r.GetSkipped())
+		a.log.InfoContext(ctx, "maintenance-fee ran", "processed", r.GetProcessed(), "charged", r.GetCharged(), "skipped", r.GetSkipped())
 	}
 	return nil
 }
@@ -208,7 +213,7 @@ func (a *App) bankSpentReset(ctx context.Context) error {
 		return err
 	}
 	if r.GetDaily() > 0 || r.GetMonthly() > 0 {
-		a.log.Info("spent-reset ran", "daily", r.GetDaily(), "monthly", r.GetMonthly())
+		a.log.InfoContext(ctx, "spent-reset ran", "daily", r.GetDaily(), "monthly", r.GetMonthly())
 	}
 	return nil
 }
@@ -219,7 +224,7 @@ func (a *App) bankScheduledPayments(ctx context.Context) error {
 		return err
 	}
 	if r.GetProcessed() > 0 {
-		a.log.Info("scheduled payments ran", "processed", r.GetProcessed(), "succeeded", r.GetSucceeded(), "failed", r.GetFailed())
+		a.log.InfoContext(ctx, "scheduled payments ran", "processed", r.GetProcessed(), "succeeded", r.GetSucceeded(), "failed", r.GetFailed())
 	}
 	return nil
 }
@@ -230,7 +235,7 @@ func (a *App) bankForexForwardSettlement(ctx context.Context) error {
 		return err
 	}
 	if r.GetProcessed() > 0 {
-		a.log.Info("forex forward settlement ran", "processed", r.GetProcessed(), "settled", r.GetSettled(), "failed", r.GetFailed())
+		a.log.InfoContext(ctx, "forex forward settlement ran", "processed", r.GetProcessed(), "settled", r.GetSettled(), "failed", r.GetFailed())
 	}
 	return nil
 }
@@ -241,7 +246,7 @@ func (a *App) tradingExecution(ctx context.Context) error {
 		return err
 	}
 	if r.GetFired() > 0 {
-		a.log.Info("execution tick", "fired", r.GetFired())
+		a.log.InfoContext(ctx, "execution tick", "fired", r.GetFired())
 	}
 	return nil
 }
@@ -252,7 +257,7 @@ func (a *App) tradingSagaRecovery(ctx context.Context) error {
 		return err
 	}
 	if r.GetResumed() > 0 {
-		a.log.Info("saga recovery tick", "resumed", r.GetResumed())
+		a.log.InfoContext(ctx, "saga recovery tick", "resumed", r.GetResumed())
 	}
 	return nil
 }
@@ -263,7 +268,7 @@ func (a *App) tradingOTCExpiry(ctx context.Context) error {
 		return err
 	}
 	if r.GetContractsExpired() > 0 {
-		a.log.Info("otc expiry sweep", "contracts", r.GetContractsExpired(), "shares_released", r.GetSharesReleased())
+		a.log.InfoContext(ctx, "otc expiry sweep", "contracts", r.GetContractsExpired(), "shares_released", r.GetSharesReleased())
 	}
 	return nil
 }
@@ -273,7 +278,7 @@ func (a *App) tradingOptionsRefresh(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("options refresh ran", "underlyings", r.GetUnderlyingsProcessed(), "options", r.GetOptionsUpserted(), "skipped", r.GetSkipped())
+	a.log.InfoContext(ctx, "options refresh ran", "underlyings", r.GetUnderlyingsProcessed(), "options", r.GetOptionsUpserted(), "skipped", r.GetSkipped())
 	return nil
 }
 
@@ -282,7 +287,7 @@ func (a *App) tradingMarketData(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("market-data refresh ran", "stocks", r.GetStocksUpdated(), "forex", r.GetForexUpdated(),
+	a.log.InfoContext(ctx, "market-data refresh ran", "stocks", r.GetStocksUpdated(), "forex", r.GetForexUpdated(),
 		"skipped", r.GetSkipped(), "errors", r.GetUpstreamErrors(), "throttled", r.GetUpstreamThrottled())
 	return nil
 }
@@ -292,7 +297,7 @@ func (a *App) tradingStockBackfill(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("stock-history backfill ran", "symbols", r.GetSymbolsBackfilled(), "rows", r.GetRowsWritten(),
+	a.log.InfoContext(ctx, "stock-history backfill ran", "symbols", r.GetSymbolsBackfilled(), "rows", r.GetRowsWritten(),
 		"skipped", r.GetSkipped(), "errors", r.GetUpstreamErrors(), "throttled", r.GetUpstreamThrottled())
 	return nil
 }
@@ -302,7 +307,7 @@ func (a *App) tradingActuaryReset(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("actuary used-limit reset ran", "affected", r.GetAffected())
+	a.log.InfoContext(ctx, "actuary used-limit reset ran", "affected", r.GetAffected())
 	return nil
 }
 
@@ -311,7 +316,7 @@ func (a *App) tradingTax(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("monthly tax ran", "users_taxed", r.GetUsersTaxed(), "total_rsd", r.GetTotalCollectedRsd())
+	a.log.InfoContext(ctx, "monthly tax ran", "users_taxed", r.GetUsersTaxed(), "total_rsd", r.GetTotalCollectedRsd())
 	return nil
 }
 
@@ -321,7 +326,7 @@ func (a *App) tradingDividends(ctx context.Context) error {
 		return err
 	}
 	if r.GetRan() {
-		a.log.Info("quarterly dividend payout ran", "paid", r.GetPaid(), "skipped", r.GetSkipped(), "total_rsd", r.GetTotalRsd())
+		a.log.InfoContext(ctx, "quarterly dividend payout ran", "paid", r.GetPaid(), "skipped", r.GetSkipped(), "total_rsd", r.GetTotalRsd())
 	}
 	return nil
 }
@@ -331,7 +336,7 @@ func (a *App) tradingFundPerf(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	a.log.Info("fund performance snapshot ran", "funds", r.GetFunds())
+	a.log.InfoContext(ctx, "fund performance snapshot ran", "funds", r.GetFunds())
 	return nil
 }
 
@@ -341,7 +346,7 @@ func (a *App) tradingPriceAlerts(ctx context.Context) error {
 		return err
 	}
 	if r.GetTriggered() > 0 {
-		a.log.Info("price alert sweep ran", "triggered", r.GetTriggered())
+		a.log.InfoContext(ctx, "price alert sweep ran", "triggered", r.GetTriggered())
 	}
 	return nil
 }
@@ -352,7 +357,7 @@ func (a *App) tradingDCA(ctx context.Context) error {
 		return err
 	}
 	if r.GetCreated() > 0 {
-		a.log.Info("dca recurring orders ran", "created", r.GetCreated())
+		a.log.InfoContext(ctx, "dca recurring orders ran", "created", r.GetCreated())
 	}
 	return nil
 }
@@ -363,7 +368,7 @@ func (a *App) tradingInterbankRetry(ctx context.Context) error {
 		return err
 	}
 	if r.GetSettled() > 0 {
-		a.log.Info("interbank retry tick", "settled", r.GetSettled())
+		a.log.InfoContext(ctx, "interbank retry tick", "settled", r.GetSettled())
 	}
 	return nil
 }
@@ -374,7 +379,7 @@ func (a *App) tradingScheduledInterbank(ctx context.Context) error {
 		return err
 	}
 	if r.GetSubmitted() > 0 {
-		a.log.Info("scheduled interbank payments ran", "submitted", r.GetSubmitted())
+		a.log.InfoContext(ctx, "scheduled interbank payments ran", "submitted", r.GetSubmitted())
 	}
 	return nil
 }
@@ -385,7 +390,7 @@ func (a *App) exchangeFXRefresh(ctx context.Context) error {
 		return err
 	}
 	if r.GetWritten() > 0 {
-		a.log.Info("fx refresh ran", "written", r.GetWritten())
+		a.log.InfoContext(ctx, "fx refresh ran", "written", r.GetWritten())
 	}
 	return nil
 }

--- a/services/scheduler/internal/app/leader.go
+++ b/services/scheduler/internal/app/leader.go
@@ -20,7 +20,7 @@ import (
 // every job loop returns and runJobs unblocks.
 func (a *App) runJobs(ctx context.Context) {
 	jobs := a.buildJobs()
-	a.log.Info("starting scheduled jobs", "count", len(jobs))
+	a.log.InfoContext(ctx, "starting scheduled jobs", "count", len(jobs))
 	var wg sync.WaitGroup
 	for _, j := range jobs {
 		wg.Add(1)
@@ -30,7 +30,7 @@ func (a *App) runJobs(ctx context.Context) {
 		}(j)
 	}
 	wg.Wait()
-	a.log.Info("all scheduled jobs stopped")
+	a.log.InfoContext(ctx, "all scheduled jobs stopped")
 }
 
 // runWithLeaderElection runs the jobs gated by a k8s Lease when
@@ -39,17 +39,19 @@ func (a *App) runJobs(ctx context.Context) {
 // the jobs directly as the sole leader.
 func (a *App) runWithLeaderElection(ctx context.Context) error {
 	if !config.Bool("LEADER_ELECTION", false) {
-		a.log.Info("leader election disabled; running as sole scheduler")
+		a.log.InfoContext(ctx, "leader election disabled; running as sole scheduler")
 		a.runJobs(ctx)
 		return nil
 	}
 
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
+		a.log.ErrorContext(ctx, "in-cluster config failed", "err", err)
 		return fmt.Errorf("in-cluster config: %w", err)
 	}
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
+		a.log.ErrorContext(ctx, "k8s client init failed", "err", err)
 		return fmt.Errorf("k8s client: %w", err)
 	}
 
@@ -66,7 +68,7 @@ func (a *App) runWithLeaderElection(ctx context.Context) error {
 		LockConfig: resourcelock.ResourceLockConfig{Identity: id},
 	}
 
-	a.log.Info("starting leader election", "lease", leaseName, "namespace", ns, "identity", id)
+	a.log.InfoContext(ctx, "starting leader election", "lease", leaseName, "namespace", ns, "identity", id)
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		ReleaseOnCancel: true,
@@ -75,7 +77,7 @@ func (a *App) runWithLeaderElection(ctx context.Context) error {
 		RetryPeriod:     2 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(c context.Context) {
-				a.log.Info("acquired leadership; starting jobs", "identity", id)
+				a.log.InfoContext(c, "acquired leadership; starting jobs", "identity", id)
 				a.runJobs(c)
 			},
 			OnStoppedLeading: func() {

--- a/services/trading/cmd/trading/main.go
+++ b/services/trading/cmd/trading/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/app"
@@ -14,6 +15,10 @@ import (
 
 func main() {
 	if err := app.Run(); err != nil {
+		// app.Run installs the JSON logger as slog's default before any
+		// fallible init, so this lands as a structured record; the stderr
+		// line stays for bare `docker logs` ergonomics.
+		slog.Error("trading service exited", "err", err)
 		fmt.Fprintf(os.Stderr, "trading: %v\n", err)
 		os.Exit(1)
 	}

--- a/services/trading/internal/app/app.go
+++ b/services/trading/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
@@ -39,15 +40,23 @@ import (
 // first non-nil error from any subsystem.
 func Run() error {
 	log := logger.New("trading")
+	// Make the JSON logger the process default so logger.From(ctx)
+	// fallbacks and library slog calls emit structured records too.
+	slog.SetDefault(log)
 
 	ctx, cancel := shutdown.Context()
 	defer cancel()
 
 	prov, err := otelinit.Init(ctx, "trading")
 	if err != nil {
+		log.Error("otelinit failed", "err", err)
 		return fmt.Errorf("otelinit: %w", err)
 	}
-	defer func() { _ = prov.Shutdown(context.Background()) }()
+	defer func() {
+		if serr := prov.Shutdown(context.Background()); serr != nil {
+			log.Warn("otel provider shutdown failed", "err", serr)
+		}
+	}()
 
 	// OpenPair dials the primary (DATABASE_URL → banka-pg-pooler-rw) and,
 	// when set, a hot-standby read pool (DATABASE_READ_URL →
@@ -57,6 +66,7 @@ func Run() error {
 	// idempotency reads stay on the primary.
 	db, err := postgres.OpenPair(ctx, config.MustString("DATABASE_URL"), config.String("DATABASE_READ_URL", ""))
 	if err != nil {
+		log.Error("postgres connect failed", "err", err)
 		return fmt.Errorf("postgres: %w", err)
 	}
 	defer db.Close()
@@ -66,13 +76,18 @@ func Run() error {
 
 	rdb, err := pkgredis.Open(ctx, config.MustString("REDIS_ADDR"), config.String("REDIS_PASSWORD", ""))
 	if err != nil {
+		log.Error("redis connect failed", "err", err)
 		return fmt.Errorf("redis: %w", err)
 	}
-	defer rdb.Close()
+	defer func() {
+		if cerr := rdb.Close(); cerr != nil {
+			log.Warn("redis close failed", "err", cerr)
+		}
+	}()
 
 	belgrade, err := time.LoadLocation("Europe/Belgrade")
 	if err != nil {
-		log.Warn("Europe/Belgrade timezone unavailable, falling back to UTC", "error", err)
+		log.Warn("Europe/Belgrade timezone unavailable, falling back to UTC", "err", err)
 		belgrade = time.UTC
 	}
 
@@ -105,9 +120,14 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
+			log.Error("dial exchange grpc failed", "err", err, "addr", exAddr)
 			return fmt.Errorf("dial exchange: %w", err)
 		}
-		defer conn.Close()
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				log.Warn("close exchange grpc conn failed", "err", cerr)
+			}
+		}()
 		svc.Rates = &exchangeAdapter{c: exchangepb.NewExchangeServiceClient(conn)}
 	} else {
 		log.Warn("EXCHANGE_GRPC_ADDR not set; agent-limit math will use raw notional for foreign trades")
@@ -125,9 +145,14 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
+			log.Error("dial user grpc failed", "err", err, "addr", userAddr)
 			return fmt.Errorf("dial user: %w", err)
 		}
-		defer conn.Close()
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				log.Warn("close user grpc conn failed", "err", cerr)
+			}
+		}()
 		userClient = userpb.NewUserServiceClient(conn)
 		svc.Users = &userResolverAdapter{c: userClient}
 	} else {
@@ -145,9 +170,14 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
+			log.Error("dial notification grpc failed", "err", err, "addr", notifAddr)
 			return fmt.Errorf("dial notification: %w", err)
 		}
-		defer conn.Close()
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				log.Warn("close notification grpc conn failed", "err", cerr)
+			}
+		}()
 		notifClient := notifpb.NewNotificationServiceClient(conn)
 		emailSender = &notifEmailSender{c: notifClient}
 		// General-purpose fan-out (email + in-app) for C3 order/price-alert
@@ -175,9 +205,14 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
+			log.Error("dial bank grpc failed", "err", err, "addr", bankAddr)
 			return fmt.Errorf("dial bank: %w", err)
 		}
-		defer conn.Close()
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				log.Warn("close bank grpc conn failed", "err", cerr)
+			}
+		}()
 		adapter := &bankSettlerAdapter{c: bankpb.NewBankServiceClient(conn)}
 		svc.Settler = adapter
 		svc.TaxSettler = adapter
@@ -208,6 +243,8 @@ func Run() error {
 			svc.PartnerOTC = client
 			svc.PartnerPayer = client
 			log.Info("interbank client configured", "partners", len(routes))
+		} else {
+			log.Warn("INTERBANK_ROUTES set but no valid routes parsed; partner OTC disabled")
 		}
 	}
 
@@ -366,6 +403,7 @@ func Run() error {
 	log.Info("trading service ready", "grpc", grpcAddr)
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		log.Error("trading service exiting on subsystem failure", "err", err)
 		return err
 	}
 	return nil

--- a/services/trading/internal/app/bank_client.go
+++ b/services/trading/internal/app/bank_client.go
@@ -7,10 +7,12 @@ import (
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/auth"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/permissions"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/service"
+	"google.golang.org/grpc/status"
 )
 
 // bankSettlerAdapter wraps the bank-service gRPC client and satisfies
@@ -81,6 +83,9 @@ func (a *bankSettlerAdapter) Settle(ctx context.Context, in service.SettleInput)
 		Purpose:   in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: SettleTrade failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "account_id", in.AccountID, "direction", in.Direction)
 		return "", fmt.Errorf("bank.SettleTrade: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -100,6 +105,9 @@ func (a *bankSettlerAdapter) SettleForex(ctx context.Context, in service.SettleF
 		Purpose:       in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: SettleForexFill failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "direction", in.Direction)
 		return "", fmt.Errorf("bank.SettleForexFill: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -127,6 +135,9 @@ func (a *bankSettlerAdapter) SettleTax(ctx context.Context, in service.TaxSettle
 		Purpose:   in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: SettleCapitalGainsTax failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "account_id", in.AccountID)
 		return "", fmt.Errorf("bank.SettleCapitalGainsTax: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -155,6 +166,9 @@ func (a *bankSettlerAdapter) SettleDividend(ctx context.Context, in service.Divi
 		Purpose:   in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: SettleDividend failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "account_id", in.AccountID)
 		return "", fmt.Errorf("bank.SettleDividend: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -176,6 +190,8 @@ func (a *bankSettlerAdapter) ListClientAccounts(ctx context.Context, ownerID str
 	}
 	resp, err := a.c.ListAccounts(ctx, req)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: ListAccounts failed",
+			"err", err, "code", status.Code(err).String(), "owner_client_id", ownerID)
 		return nil, fmt.Errorf("bank.ListAccounts: %w", err)
 	}
 	out := make([]service.BankAccount, 0, len(resp.GetAccounts()))
@@ -196,6 +212,8 @@ func (a *bankSettlerAdapter) AccountAvailable(ctx context.Context, accountID str
 	ctx = withBankAdmin(ctx)
 	resp, err := a.c.GetAccount(ctx, &bankpb.GetAccountRequest{Id: accountID})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: GetAccount (available) failed",
+			"err", err, "code", status.Code(err).String(), "account_id", accountID)
 		return "", "", fmt.Errorf("bank.GetAccount: %w", err)
 	}
 	return currencyFromBankProto(resp.GetCurrency()), resp.GetAvailableBalance(), nil
@@ -209,6 +227,8 @@ func (a *bankSettlerAdapter) AccountNumber(ctx context.Context, accountID string
 	ctx = withBankAdmin(ctx)
 	resp, err := a.c.GetAccount(ctx, &bankpb.GetAccountRequest{Id: accountID})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: GetAccount (number) failed",
+			"err", err, "code", status.Code(err).String(), "account_id", accountID)
 		return "", fmt.Errorf("bank.GetAccount: %w", err)
 	}
 	return resp.GetNumber(), nil
@@ -226,6 +246,9 @@ func (a *bankSettlerAdapter) Reserve(ctx context.Context, in service.ReserveInpu
 		OpKind:    in.OpKind,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: ReserveFunds failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "account_id", in.AccountID, "op_kind", in.OpKind)
 		return "", fmt.Errorf("bank.ReserveFunds: %w", err)
 	}
 	return resp.GetReservationId(), nil
@@ -238,6 +261,8 @@ func (a *bankSettlerAdapter) Release(ctx context.Context, opID string) (bool, er
 	ctx = withBankAdmin(ctx)
 	resp, err := a.c.ReleaseFunds(ctx, &bankpb.ReleaseFundsRequest{OpId: opID})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: ReleaseFunds failed",
+			"err", err, "code", status.Code(err).String(), "op_id", opID)
 		return false, fmt.Errorf("bank.ReleaseFunds: %w", err)
 	}
 	return resp.GetReleased(), nil
@@ -255,6 +280,9 @@ func (a *bankSettlerAdapter) Commit(ctx context.Context, in service.CommitInput)
 		Purpose:       in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: CommitReservedFunds failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "dest_account_id", in.DestAccountID)
 		return "", fmt.Errorf("bank.CommitReservedFunds: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -269,6 +297,8 @@ func (a *bankSettlerAdapter) CreateFundAccount(ctx context.Context, name string,
 		Currency: currencyToBankProto(currency),
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: CreateFundAccount failed",
+			"err", err, "code", status.Code(err).String(), "name", name, "currency", string(currency))
 		return "", fmt.Errorf("bank.CreateFundAccount: %w", err)
 	}
 	return resp.GetId(), nil
@@ -288,6 +318,9 @@ func (a *bankSettlerAdapter) Transfer(ctx context.Context, in service.TransferIn
 		Purpose:       in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: TransferBetweenClients failed",
+			"err", err, "code", status.Code(err).String(),
+			"op_id", in.OpID, "from_account_id", in.FromAccountID, "to_account_id", in.ToAccountID)
 		return "", fmt.Errorf("bank.TransferBetweenClients: %w", err)
 	}
 	return resp.GetOpId(), nil
@@ -303,6 +336,8 @@ func (a *bankSettlerAdapter) ClientLargestActiveLoan(ctx context.Context, client
 		PageSize: 100,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank adapter: ListLoans failed",
+			"err", err, "code", status.Code(err).String(), "client_id", clientID)
 		return "", "", fmt.Errorf("bank.ListLoans: %w", err)
 	}
 	var bestCur domain.Currency
@@ -315,6 +350,8 @@ func (a *bankSettlerAdapter) ClientLargestActiveLoan(ctx context.Context, client
 		}
 		r, err := money.Parse(amt)
 		if err != nil {
+			logger.From(ctx).WarnContext(ctx, "largest-loan scan: unparsable remaining_principal, skipping loan",
+				"err", err, "loan_id", l.GetId(), "client_id", clientID)
 			continue
 		}
 		if bestRat == nil || r.Cmp(bestRat) > 0 {

--- a/services/trading/internal/app/exchange_client.go
+++ b/services/trading/internal/app/exchange_client.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	exchangepb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/exchange/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
+	"google.golang.org/grpc/status"
 )
 
 // exchangeAdapter implements service.RateProvider by dialing the
@@ -21,6 +23,8 @@ func (a *exchangeAdapter) Quote(ctx context.Context, from, to domain.Currency) (
 		To:   currencyToExchangeProto(to),
 	})
 	if err != nil {
+		logger.From(ctx).WarnContext(ctx, "exchange adapter: Quote failed",
+			"err", err, "code", status.Code(err).String(), "from", string(from), "to", string(to))
 		return "", "", fmt.Errorf("exchange quote: %w", err)
 	}
 	return resp.GetBid(), resp.GetAsk(), nil

--- a/services/trading/internal/app/interbank_client.go
+++ b/services/trading/internal/app/interbank_client.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 
 	bankpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/bank/v1"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/service"
+	"google.golang.org/grpc/status"
 )
 
 // interbankPayerAdapter wraps bank's InterbankProtocolService client
@@ -35,6 +37,9 @@ func (a *interbankPayerAdapter) PreparePayment(ctx context.Context, in service.P
 		Purpose:             in.Purpose,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "interbank 2pc: bank.PreparePayment failed",
+			"err", err, "code", status.Code(err).String(),
+			"transaction_id", in.TransactionID, "sender_routing", in.SenderRoutingNumber)
 		return service.PrepareInterbankResult{}, fmt.Errorf("bank.PreparePayment: %w", err)
 	}
 	return service.PrepareInterbankResult{
@@ -51,6 +56,9 @@ func (a *interbankPayerAdapter) CommitPayment(ctx context.Context, senderRouting
 		TransactionId:       txID,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "interbank 2pc: bank.CommitPayment failed",
+			"err", err, "code", status.Code(err).String(),
+			"transaction_id", txID, "sender_routing", senderRouting)
 		return service.CommitInterbankResult{}, fmt.Errorf("bank.CommitPayment: %w", err)
 	}
 	return service.CommitInterbankResult{
@@ -68,6 +76,9 @@ func (a *interbankPayerAdapter) RollbackPayment(ctx context.Context, senderRouti
 		Reason:              reason,
 	})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "interbank 2pc: bank.RollbackPayment failed",
+			"err", err, "code", status.Code(err).String(),
+			"transaction_id", txID, "sender_routing", senderRouting, "reason", reason)
 		return fmt.Errorf("bank.RollbackPayment: %w", err)
 	}
 	return nil

--- a/services/trading/internal/app/jobs.go
+++ b/services/trading/internal/app/jobs.go
@@ -29,9 +29,9 @@ func runDailyAt(ctx context.Context, log *slog.Logger, name string, loc *time.Lo
 			return nil
 		case <-t.C:
 			if err := fn(ctx); err != nil {
-				log.Warn("daily job failed", "job", name, "error", err)
+				log.ErrorContext(ctx, "daily job failed", "err", err, "job", name)
 			} else {
-				log.Info("daily job ran", "job", name)
+				log.InfoContext(ctx, "daily job ran", "job", name)
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func runMonthlyTaxCron(ctx context.Context, log *slog.Logger, svc *service.Servi
 			cronCtx := service.TaxCronContext(ctx)
 			res, err := svc.RunTax(cronCtx, service.RunTaxInput{})
 			if err != nil {
-				log.Warn("monthly tax cron failed", "err", err.Error())
+				log.ErrorContext(ctx, "monthly tax cron failed", "err", err)
 				continue
 			}
 			log.Info("monthly tax cron ran",
@@ -119,7 +119,7 @@ func runOptionsRefresh(ctx context.Context, log *slog.Logger, svc *service.Servi
 	once := func() {
 		res, err := svc.Options.RunOnce(ctx)
 		if err != nil {
-			log.Warn("options generator failed", "err", err.Error())
+			log.ErrorContext(ctx, "options generator failed", "err", err)
 			return
 		}
 		log.Info("options generator ran",
@@ -155,7 +155,7 @@ func runMarketDataRefresh(ctx context.Context, log *slog.Logger, svc *service.Se
 	once := func() {
 		res, err := svc.MarketData.RunOnce(ctx)
 		if err != nil {
-			log.Warn("market-data refresh failed", "err", err.Error())
+			log.ErrorContext(ctx, "market-data refresh failed", "err", err)
 			return
 		}
 		log.Info("market-data refresh ran",
@@ -190,7 +190,8 @@ func runStockHistoryBackfill(ctx context.Context, log *slog.Logger, svc *service
 	}
 	res, err := svc.MarketData.BackfillStockHistory(ctx)
 	if err != nil {
-		log.Warn("stock-history backfill failed", "err", err.Error())
+		// Swallowed by design — the seed history remains usable.
+		log.ErrorContext(ctx, "stock-history backfill failed", "err", err)
 		return nil
 	}
 	log.Info("stock-history backfill ran",
@@ -227,7 +228,7 @@ func runExecutionWorker(ctx context.Context, log *slog.Logger, svc *service.Serv
 		case <-t.C:
 			fired, err := svc.RunExecutionTick(ctx)
 			if err != nil {
-				log.Warn("execution tick failed", "err", err.Error())
+				log.ErrorContext(ctx, "execution tick failed", "err", err)
 				continue
 			}
 			if fired > 0 {
@@ -249,7 +250,7 @@ func runOTCExpirySweep(ctx context.Context, log *slog.Logger, svc *service.Servi
 	once := func() {
 		res, err := svc.SweepExpiredOTCContracts(ctx)
 		if err != nil {
-			log.Warn("otc expiry sweep failed", "err", err.Error())
+			log.ErrorContext(ctx, "otc expiry sweep failed", "err", err)
 			return
 		}
 		if res.ContractsExpired > 0 || res.OffersExpired > 0 || res.OffersWarned > 0 {
@@ -303,7 +304,7 @@ func runSagaRecoveryWorker(ctx context.Context, log *slog.Logger, svc *service.S
 			// so the scheduler service can drive the same logic.
 			n, err := svc.RunSagaRecoveryTick(ctx)
 			if err != nil {
-				log.Warn("saga recovery: tick failed", "err", err.Error())
+				log.ErrorContext(ctx, "saga recovery: tick failed", "err", err)
 				continue
 			}
 			if n > 0 {
@@ -330,7 +331,7 @@ func runFundPerformanceCron(ctx context.Context, log *slog.Logger, svc *service.
 		case <-t.C:
 			n, err := svc.SnapshotAllFunds(ctx, time.Now().In(loc))
 			if err != nil {
-				log.Warn("fund snapshot cron failed", "err", err.Error())
+				log.ErrorContext(ctx, "fund snapshot cron failed", "err", err)
 				continue
 			}
 			log.Info("fund snapshot cron ran", "funds", n)

--- a/services/trading/internal/app/otc_notifier.go
+++ b/services/trading/internal/app/otc_notifier.go
@@ -216,8 +216,10 @@ func (n *otcEmailNotifier) recipientEmail(ctx context.Context, userID string, ki
 
 func (n *otcEmailNotifier) dispatch(ctx context.Context, to, subject, body string) {
 	if err := n.sender.Send(ctx, email.Message{To: to, Subject: subject, Body: body}); err != nil {
-		n.log.Warn("otc email send failed", "to", to, "subject", subject, "err", err.Error())
+		n.log.WarnContext(ctx, "otc email send failed", "err", err, "to", to, "subject", subject)
+		return
 	}
+	n.log.InfoContext(ctx, "otc email sent", "to", to, "subject", subject)
 }
 
 func errString(err error) string {

--- a/services/trading/internal/external/alphavantage/client.go
+++ b/services/trading/internal/external/alphavantage/client.go
@@ -296,6 +296,18 @@ func (c *Client) FXQuote(ctx context.Context, from, to string) (*FXQuote, error)
 	return out, nil
 }
 
+// stripURLError unwraps a *url.Error to its transport cause. The
+// url.Error string embeds the full request URL — and with it the API
+// key in the query string — so it must never be logged or returned
+// upstream (callers log err.Error() too).
+func stripURLError(err error) error {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		return fmt.Errorf("alphavantage %s: %w", uerr.Op, uerr.Err)
+	}
+	return err
+}
+
 // do issues the GET, applies the API key, and rejects rate-limit and
 // error envelopes. Log lines deliberately carry the request function +
 // symbol rather than the URL — the URL embeds the API key.
@@ -308,6 +320,7 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"?"+q.Encode(), nil)
 	if err != nil {
+		err = stripURLError(err)
 		log.ErrorContext(ctx, "alphavantage request build failed", "err", err)
 		return nil, err
 	}
@@ -317,6 +330,7 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 	}
 	resp, err := httpc.Do(req)
 	if err != nil {
+		err = stripURLError(err)
 		log.ErrorContext(ctx, "alphavantage request failed", "err", err)
 		return nil, err
 	}

--- a/services/trading/internal/external/alphavantage/client.go
+++ b/services/trading/internal/external/alphavantage/client.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 )
 
 // ErrThrottled is returned when Alpha Vantage refuses with a quota note
@@ -117,6 +119,7 @@ func (c *Client) Quote(ctx context.Context, symbol string) (*StockQuote, error) 
 		GlobalQuote map[string]string `json:"Global Quote"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "alphavantage quote decode failed", "err", err, "symbol", symbol)
 		return nil, fmt.Errorf("alphavantage: decode quote: %w", err)
 	}
 	if len(env.GlobalQuote) == 0 {
@@ -134,12 +137,19 @@ func (c *Client) Quote(ctx context.Context, symbol string) (*StockQuote, error) 
 		ChangePercent: strings.TrimSpace(strings.TrimSuffix(q["10. change percent"], "%")),
 	}
 	if v := q["06. volume"]; v != "" {
-		n, _ := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		n, perr := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if perr != nil {
+			logger.From(ctx).WarnContext(ctx, "alphavantage quote volume unparsable, defaulting to 0",
+				"err", perr, "symbol", symbol, "volume", v)
+		}
 		out.Volume = n
 	}
 	if v := q["07. latest trading day"]; v != "" {
-		if t, err := time.Parse("2006-01-02", v); err == nil {
+		if t, perr := time.Parse("2006-01-02", v); perr == nil {
 			out.LatestDay = t
+		} else {
+			logger.From(ctx).WarnContext(ctx, "alphavantage quote latest trading day unparsable, dropped",
+				"err", perr, "symbol", symbol, "latest_day", v)
 		}
 	}
 	if out.Price == "" {
@@ -167,6 +177,7 @@ func (c *Client) TimeSeriesDaily(ctx context.Context, symbol string) ([]DailyBar
 		Series map[string]map[string]string `json:"Time Series (Daily)"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "alphavantage daily series decode failed", "err", err, "symbol", symbol)
 		return nil, fmt.Errorf("alphavantage: decode daily series: %w", err)
 	}
 	if len(env.Series) == 0 {
@@ -176,6 +187,8 @@ func (c *Client) TimeSeriesDaily(ctx context.Context, symbol string) ([]DailyBar
 	for day, cols := range env.Series {
 		d, perr := time.Parse("2006-01-02", day)
 		if perr != nil {
+			logger.From(ctx).WarnContext(ctx, "alphavantage daily bar date unparsable, row skipped",
+				"err", perr, "symbol", symbol, "day", day)
 			continue
 		}
 		closePx := strings.TrimSpace(cols["4. close"])
@@ -184,7 +197,12 @@ func (c *Client) TimeSeriesDaily(ctx context.Context, symbol string) ([]DailyBar
 		}
 		var vol int64
 		if v := strings.TrimSpace(cols["5. volume"]); v != "" {
-			vol, _ = strconv.ParseInt(v, 10, 64)
+			var verr error
+			vol, verr = strconv.ParseInt(v, 10, 64)
+			if verr != nil {
+				logger.From(ctx).WarnContext(ctx, "alphavantage daily bar volume unparsable, defaulting to 0",
+					"err", verr, "symbol", symbol, "day", day, "volume", v)
+			}
 		}
 		out = append(out, DailyBar{Date: d, Close: closePx, Volume: vol})
 	}
@@ -207,6 +225,7 @@ func (c *Client) Overview(ctx context.Context, symbol string) (*CompanyOverview,
 	// OVERVIEW returns a flat object; an unknown symbol returns "{}".
 	var raw map[string]string
 	if err := json.Unmarshal(body, &raw); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "alphavantage overview decode failed", "err", err, "symbol", symbol)
 		return nil, fmt.Errorf("alphavantage: decode overview: %w", err)
 	}
 	if len(raw) == 0 || raw["Symbol"] == "" {
@@ -220,7 +239,11 @@ func (c *Client) Overview(ctx context.Context, symbol string) (*CompanyOverview,
 		DividendYield: strings.TrimSpace(raw["DividendYield"]),
 	}
 	if v := raw["SharesOutstanding"]; v != "" {
-		n, _ := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		n, perr := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if perr != nil {
+			logger.From(ctx).WarnContext(ctx, "alphavantage overview shares outstanding unparsable, defaulting to 0",
+				"err", perr, "symbol", symbol, "shares_outstanding", v)
+		}
 		out.OutstandingShares = n
 	}
 	// Alpha Vantage occasionally emits "None" or "-" for dividend yield;
@@ -245,6 +268,7 @@ func (c *Client) FXQuote(ctx context.Context, from, to string) (*FXQuote, error)
 		Realtime map[string]string `json:"Realtime Currency Exchange Rate"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "alphavantage fx decode failed", "err", err, "from", from, "to", to)
 		return nil, fmt.Errorf("alphavantage: decode fx: %w", err)
 	}
 	if len(env.Realtime) == 0 {
@@ -259,8 +283,11 @@ func (c *Client) FXQuote(ctx context.Context, from, to string) (*FXQuote, error)
 		Ask:          strings.TrimSpace(r["9. Ask Price"]),
 	}
 	if v := r["6. Last Refreshed"]; v != "" {
-		if t, err := time.Parse("2006-01-02 15:04:05", v); err == nil {
+		if t, perr := time.Parse("2006-01-02 15:04:05", v); perr == nil {
 			out.UpdatedAt = t
+		} else {
+			logger.From(ctx).WarnContext(ctx, "alphavantage fx last refreshed unparsable, dropped",
+				"err", perr, "from", from, "to", to, "last_refreshed", v)
 		}
 	}
 	if out.ExchangeRate == "" {
@@ -270,8 +297,10 @@ func (c *Client) FXQuote(ctx context.Context, from, to string) (*FXQuote, error)
 }
 
 // do issues the GET, applies the API key, and rejects rate-limit and
-// error envelopes.
+// error envelopes. Log lines deliberately carry the request function +
+// symbol rather than the URL — the URL embeds the API key.
 func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
+	log := logger.From(ctx).With("function", q.Get("function"), "symbol", q.Get("symbol"))
 	q.Set("apikey", c.APIKey)
 	base := c.BaseURL
 	if base == "" {
@@ -279,6 +308,7 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"?"+q.Encode(), nil)
 	if err != nil {
+		log.ErrorContext(ctx, "alphavantage request build failed", "err", err)
 		return nil, err
 	}
 	httpc := c.HTTP
@@ -287,10 +317,12 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 	}
 	resp, err := httpc.Do(req)
 	if err != nil {
+		log.ErrorContext(ctx, "alphavantage request failed", "err", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		log.ErrorContext(ctx, "alphavantage request rejected", "status", resp.StatusCode)
 		return nil, fmt.Errorf("alphavantage: http %d", resp.StatusCode)
 	}
 	// Read first into a buffer so we can probe for the rate-limit
@@ -303,6 +335,7 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 		if n > 0 {
 			buf = append(buf, tmp[:n]...)
 			if len(buf) > maxBody {
+				log.ErrorContext(ctx, "alphavantage response too large", "max_bytes", maxBody)
 				return nil, fmt.Errorf("alphavantage: response too large")
 			}
 		}
@@ -318,14 +351,19 @@ func (c *Client) do(ctx context.Context, q url.Values) ([]byte, error) {
 	var env map[string]json.RawMessage
 	if err := json.Unmarshal(buf, &env); err == nil {
 		if v, ok := env["Note"]; ok {
-			return nil, wrapEnvelope(ErrThrottled, v)
+			werr := wrapEnvelope(ErrThrottled, v)
+			log.WarnContext(ctx, "alphavantage rate-limited", "err", werr)
+			return nil, werr
 		}
 		if v, ok := env["Information"]; ok {
-			return nil, wrapEnvelope(ErrThrottled, v)
+			werr := wrapEnvelope(ErrThrottled, v)
+			log.WarnContext(ctx, "alphavantage rate-limited", "err", werr)
+			return nil, werr
 		}
 		if v, ok := env["Error Message"]; ok {
 			var msg string
 			_ = json.Unmarshal(v, &msg)
+			log.WarnContext(ctx, "alphavantage error envelope", "message", msg)
 			return nil, fmt.Errorf("alphavantage: %s", msg)
 		}
 	}

--- a/services/trading/internal/external/influxmarket/influxmarket.go
+++ b/services/trading/internal/external/influxmarket/influxmarket.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 )
 
 const measurement = "listing_daily_price_info"
@@ -100,17 +102,21 @@ func (s *influxStore) WriteDaily(ctx context.Context, r Row) error {
 		s.baseURL, url.QueryEscape(s.org), url.QueryEscape(s.bucket))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(line))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "influx write request build failed", "err", err, "listing_id", r.ListingID)
 		return err
 	}
 	req.Header.Set("Authorization", "Token "+s.token)
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
 	resp, err := s.client.Do(req)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "influx write request failed", "err", err, "listing_id", r.ListingID)
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
 		body, _ := io.ReadAll(resp.Body)
+		logger.From(ctx).ErrorContext(ctx, "influx write rejected",
+			"status", resp.StatusCode, "listing_id", r.ListingID, "body", string(body))
 		return fmt.Errorf("influxmarket write: %d %s", resp.StatusCode, string(body))
 	}
 	return nil
@@ -163,6 +169,7 @@ func (s *influxStore) query(ctx context.Context, flux string) ([]Row, error) {
 	u := fmt.Sprintf("%s/api/v2/query?org=%s", s.baseURL, url.QueryEscape(s.org))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "influx query request build failed", "err", err)
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Token "+s.token)
@@ -170,14 +177,21 @@ func (s *influxStore) query(ctx context.Context, flux string) ([]Row, error) {
 	req.Header.Set("Accept", "application/csv")
 	resp, err := s.client.Do(req)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "influx query request failed", "err", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
 		raw, _ := io.ReadAll(resp.Body)
+		logger.From(ctx).ErrorContext(ctx, "influx query rejected", "status", resp.StatusCode, "body", string(raw))
 		return nil, fmt.Errorf("influxmarket query: %d %s", resp.StatusCode, string(raw))
 	}
-	return decodeCSV(resp.Body)
+	rows, err := decodeCSV(resp.Body)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "influx query csv decode failed", "err", err)
+		return nil, err
+	}
+	return rows, nil
 }
 
 func decodeCSV(r io.Reader) ([]Row, error) {

--- a/services/trading/internal/external/interbank/banka2.go
+++ b/services/trading/internal/external/interbank/banka2.go
@@ -87,6 +87,8 @@ func (c *Client) discoverBanka2(ctx context.Context, bankCode, tickerFilter stri
 	}
 	var parsed []banka2PublicStock
 	if err := jsonDecode(body, &parsed); err != nil {
+		c.log.ErrorContext(ctx, "banka2 public-stock decode failed",
+			"err", err.Error(), "bank_code", bankCode, "body", bodySnippet(body, 512))
 		return nil, fmt.Errorf("banka2 %s public-stock decode: %w", bankCode, err)
 	}
 	// Banka 2 returns one element per ticker carrying a list of sellers.
@@ -94,7 +96,11 @@ func (c *Client) discoverBanka2(ctx context.Context, bankCode, tickerFilter stri
 	out := make([]*service.PartnerHolding, 0)
 	for _, ps := range parsed {
 		for _, s := range ps.Sellers {
-			qty, _ := strconv.ParseInt(s.Amount.String(), 10, 32)
+			qty, qerr := strconv.ParseInt(s.Amount.String(), 10, 32)
+			if qerr != nil {
+				c.log.WarnContext(ctx, "banka2 public-stock seller amount unparsable, defaulting to 0",
+					"err", qerr.Error(), "bank_code", bankCode, "ticker", ps.Stock.Ticker, "amount", s.Amount.String())
+			}
 			rowBankCode := strconv.Itoa(s.Seller.RoutingNumber)
 			if rowBankCode == "" {
 				rowBankCode = bankCode
@@ -149,6 +155,9 @@ func (c *Client) createOfferBanka2(ctx context.Context, in service.PartnerCreate
 	// Banka 2 returns the ForeignBankId it minted — { routingNumber, id }.
 	var partnerID banka2ForeignID
 	if err := jsonDecode(respBody, &partnerID); err != nil {
+		c.log.ErrorContext(ctx, "banka2 create offer decode failed",
+			"err", err.Error(), "bank_code", in.RemoteBankCode, "thread_id", in.LocalThreadID,
+			"body", bodySnippet(respBody, 512))
 		return nil, fmt.Errorf("banka2 create offer decode: %w", err)
 	}
 	return &service.PartnerCreateOfferOutput{
@@ -230,5 +239,7 @@ func (c *Client) actionBanka2(ctx context.Context, in service.PartnerActionInput
 		}
 		return nil
 	}
+	c.log.ErrorContext(ctx, "banka2 unknown action verb",
+		"verb", verb, "bank_code", in.RemoteBankCode, "remote_thread_id", in.RemoteThreadID)
 	return fmt.Errorf("banka2: unknown action verb %q", verb)
 }

--- a/services/trading/internal/external/interbank/banka2_exercise.go
+++ b/services/trading/internal/external/interbank/banka2_exercise.go
@@ -138,6 +138,9 @@ func (c *Client) ExercisePartnerBanka2(ctx context.Context, in ExercisePartnerIn
 	}
 	var vote b2TransactionVote
 	if err := jsonDecode(body, &vote); err != nil {
+		c.log.ErrorContext(ctx, "banka2 exercise NEW_TX decode failed",
+			"err", err.Error(), "transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+			"body", bodySnippet(body, 512))
 		return fmt.Errorf("banka2 exercise NEW_TX decode: %w", err)
 	}
 	if vote.Vote != "YES" {
@@ -145,9 +148,23 @@ func (c *Client) ExercisePartnerBanka2(ctx context.Context, in ExercisePartnerIn
 		for _, rr := range vote.Reasons {
 			reasons = append(reasons, rr.Reason)
 		}
+		c.log.WarnContext(ctx, "banka2 exercise vote rejected",
+			"transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+			"contract_id", in.ContractID, "vote", vote.Vote, "reasons", reasons)
 		// Roll the partner's prepared state back before surfacing the refusal.
-		_ = c.rollbackPartnerBanka2(ctx, RollbackPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID})
+		if rerr := c.rollbackPartnerBanka2(ctx, RollbackPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID}); rerr != nil {
+			c.log.WarnContext(ctx, "banka2 exercise rollback after NO vote failed",
+				"err", rerr.Error(), "transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode)
+		}
 		return fmt.Errorf("banka2 exercise refused by %s: %v", in.RemoteBankCode, reasons)
 	}
-	return c.commitPartnerBanka2(ctx, CommitPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID})
+	if err := c.commitPartnerBanka2(ctx, CommitPartnerInput{RemoteBankCode: in.RemoteBankCode, TransactionID: in.TransactionID}); err != nil {
+		c.log.ErrorContext(ctx, "banka2 exercise commit failed",
+			"err", err.Error(), "transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode)
+		return err
+	}
+	c.log.InfoContext(ctx, "banka2 exercise committed",
+		"transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode, "contract_id", in.ContractID,
+		"ticker", in.Ticker, "quantity", in.Quantity)
+	return nil
 }

--- a/services/trading/internal/external/interbank/client.go
+++ b/services/trading/internal/external/interbank/client.go
@@ -142,8 +142,15 @@ func (c *Client) Protocol(ctx context.Context, bankCode string) Protocol {
 	}
 	p := c.probe(ctx, bankCode)
 	c.protocols.Store(bankCode, p)
-	c.log.Info("partner protocol detected",
-		"bank_code", bankCode, "protocol", string(p), "base_url", c.baseURL(bankCode))
+	if p == ProtocolUnknown {
+		// Sticky: the unknown result is cached, so this partner stays
+		// unreachable until the process restarts. Make that loud.
+		c.log.WarnContext(ctx, "partner protocol detection failed, partner disabled until restart",
+			"bank_code", bankCode, "base_url", c.baseURL(bankCode))
+	} else {
+		c.log.InfoContext(ctx, "partner protocol detected",
+			"bank_code", bankCode, "protocol", string(p), "base_url", c.baseURL(bankCode))
+	}
 	return p
 }
 
@@ -172,6 +179,7 @@ func (c *Client) probeOK(ctx context.Context, method, url string, withAPIKey boo
 	defer cancel()
 	req, err := http.NewRequestWithContext(probeCtx, method, url, nil)
 	if err != nil {
+		c.log.WarnContext(ctx, "interbank probe request build failed", "url", url, "err", err.Error())
 		return false
 	}
 	if withAPIKey {
@@ -181,11 +189,16 @@ func (c *Client) probeOK(ctx context.Context, method, url string, withAPIKey boo
 	}
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
+		c.log.WarnContext(ctx, "interbank probe failed", "method", method, "url", url, "err", err.Error())
 		return false
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		c.log.WarnContext(ctx, "interbank probe rejected", "method", method, "url", url, "status", resp.StatusCode)
+		return false
+	}
+	return true
 }
 
 // signRequest stamps the celina-5 digital-signature headers on an
@@ -222,12 +235,14 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any) (int,
 		var err error
 		buf, err = json.Marshal(body)
 		if err != nil {
+			c.log.ErrorContext(ctx, "interbank request marshal failed", "method", method, "url", url, "err", err.Error())
 			return 0, nil, fmt.Errorf("marshal: %w", err)
 		}
 		reader = bytes.NewReader(buf)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, reader)
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank request build failed", "method", method, "url", url, "err", err.Error())
 		return 0, nil, fmt.Errorf("new request: %w", err)
 	}
 	if body != nil {
@@ -237,16 +252,43 @@ func (c *Client) doJSON(ctx context.Context, method, url string, body any) (int,
 		req.Header.Set("X-Api-Key", k)
 	}
 	c.signRequest(req, buf)
+	start := time.Now()
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank request failed",
+			"method", method, "url", url, "dur", time.Since(start), "err", err.Error())
 		return 0, nil, fmt.Errorf("do request: %w", err)
 	}
 	defer resp.Body.Close()
 	out, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank response read failed",
+			"method", method, "url", url, "status", resp.StatusCode, "err", err.Error())
 		return resp.StatusCode, nil, fmt.Errorf("read body: %w", err)
 	}
+	logOutbound(ctx, c.log, method, url, resp.StatusCode, time.Since(start), out)
 	return resp.StatusCode, out, nil
+}
+
+// logOutbound is the shared access log for outbound interbank HTTP.
+// Non-2xx carries a snippet of the partner's response body — that text
+// is usually the only clue to why the partner rejected us.
+func logOutbound(ctx context.Context, log *slog.Logger, method, url string, status int, dur time.Duration, body []byte) {
+	if status < 200 || status >= 300 {
+		log.WarnContext(ctx, "interbank request rejected",
+			"method", method, "url", url, "status", status, "dur", dur, "body", bodySnippet(body, 512))
+		return
+	}
+	log.InfoContext(ctx, "interbank request ok",
+		"method", method, "url", url, "status", status, "dur", dur)
+}
+
+// bodySnippet returns up to n bytes of body as a string for log output.
+func bodySnippet(b []byte, n int) string {
+	if len(b) > n {
+		b = b[:n]
+	}
+	return string(b)
 }
 
 // errUnsupportedProtocol is returned when we'd need to speak a protocol

--- a/services/trading/internal/external/interbank/otc.go
+++ b/services/trading/internal/external/interbank/otc.go
@@ -88,6 +88,8 @@ func (c *Client) Discover(ctx context.Context, bankCode, tickerFilter string) ([
 	var targets []string
 	if bankCode != "" {
 		if c.baseURL(bankCode) == "" {
+			c.log.WarnContext(ctx, "discover requested for unconfigured partner bank",
+				"bank_code", bankCode, "configured_banks", c.cfg.Routes.BankCodes())
 			return nil, &errUnknownBank{bankCode: bankCode}
 		}
 		targets = []string{bankCode}
@@ -96,15 +98,19 @@ func (c *Client) Discover(ctx context.Context, bankCode, tickerFilter string) ([
 	}
 
 	var out []*service.PartnerHolding
+	failed := 0
 	for _, code := range targets {
 		rows, err := c.discoverOne(ctx, code, tickerFilter)
 		if err != nil {
-			c.log.Warn("partner discover failed",
-				"bank_code", code, "err", err.Error())
+			failed++
+			c.log.WarnContext(ctx, "partner discover failed",
+				"bank_code", code, "base_url", c.baseURL(code), "err", err.Error())
 			continue
 		}
 		out = append(out, rows...)
 	}
+	c.log.InfoContext(ctx, "partner discovery complete",
+		"targets", len(targets), "failed", failed, "holdings", len(out), "ticker_filter", tickerFilter)
 	return out, nil
 }
 
@@ -133,6 +139,8 @@ func (c *Client) discoverNative(ctx context.Context, bankCode, tickerFilter stri
 	}
 	var parsed nativePublicResponse
 	if err := jsonDecode(body, &parsed); err != nil {
+		c.log.ErrorContext(ctx, "native discover decode failed",
+			"err", err.Error(), "bank_code", bankCode, "body", bodySnippet(body, 512))
 		return nil, fmt.Errorf("partner %s discover decode: %w", bankCode, err)
 	}
 	out := make([]*service.PartnerHolding, 0, len(parsed.Items))
@@ -195,6 +203,9 @@ func (c *Client) createOfferNative(ctx context.Context, in service.PartnerCreate
 	}
 	var parsed nativeOfferResponse
 	if err := jsonDecode(respBody, &parsed); err != nil {
+		c.log.ErrorContext(ctx, "native create offer decode failed",
+			"err", err.Error(), "bank_code", in.RemoteBankCode, "thread_id", in.LocalThreadID,
+			"body", bodySnippet(respBody, 512))
 		return nil, fmt.Errorf("partner %s create offer decode: %w", in.RemoteBankCode, err)
 	}
 	return &service.PartnerCreateOfferOutput{

--- a/services/trading/internal/external/interbank/payments.go
+++ b/services/trading/internal/external/interbank/payments.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/service"
 )
@@ -177,9 +178,17 @@ func (c *Client) preparePartnerNative(ctx context.Context, in PreparePartnerInpu
 	}
 	var parsed nativePreparePaymentResponse
 	if err := jsonDecode(respBody, &parsed); err != nil {
+		c.log.ErrorContext(ctx, "native prepare decode failed",
+			"err", err.Error(), "transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+			"body", bodySnippet(respBody, 512))
 		return nil, fmt.Errorf("native prepare decode: %w", err)
 	}
 	accepted := strings.EqualFold(parsed.Status, "prepared")
+	if !accepted {
+		c.log.WarnContext(ctx, "native prepare not accepted",
+			"transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+			"partner_status", parsed.Status)
+	}
 	return &PreparePartnerResult{Accepted: accepted, RawStatus: status, RawBody: respBody}, nil
 }
 
@@ -313,15 +322,23 @@ func (c *Client) preparePartnerBanka2(ctx context.Context, in PreparePartnerInpu
 	}
 	var vote b2TransactionVote
 	if err := jsonDecode(respBody, &vote); err != nil {
+		c.log.ErrorContext(ctx, "banka2 NEW_TX decode failed",
+			"err", err.Error(), "transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+			"body", bodySnippet(respBody, 512))
 		return nil, fmt.Errorf("banka2 NEW_TX decode: %w", err)
 	}
 	if strings.EqualFold(vote.Vote, "YES") {
+		c.log.InfoContext(ctx, "banka2 prepare vote accepted",
+			"transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode)
 		return &PreparePartnerResult{Accepted: true, RawStatus: status, RawBody: respBody}, nil
 	}
 	reasons := make([]string, 0, len(vote.Reasons))
 	for _, r := range vote.Reasons {
 		reasons = append(reasons, r.Reason)
 	}
+	c.log.WarnContext(ctx, "banka2 vote rejected",
+		"transaction_id", in.TransactionID, "bank_code", in.RemoteBankCode,
+		"vote", vote.Vote, "reasons", reasons)
 	return &PreparePartnerResult{Accepted: false, NoReasons: reasons, RawStatus: status, RawBody: respBody}, nil
 }
 
@@ -410,10 +427,12 @@ func (c *Client) doJSONWithHeaders(ctx context.Context, method, url string, body
 	}
 	buf, err := json.Marshal(body)
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank request marshal failed", "err", err.Error(), "method", method, "url", url)
 		return 0, nil, fmt.Errorf("marshal: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(buf))
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank request build failed", "err", err.Error(), "method", method, "url", url)
 		return 0, nil, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -424,14 +443,20 @@ func (c *Client) doJSONWithHeaders(ctx context.Context, method, url string, body
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	start := time.Now()
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank request failed",
+			"method", method, "url", url, "dur", time.Since(start), "err", err.Error())
 		return 0, nil, fmt.Errorf("do request: %w", err)
 	}
 	defer resp.Body.Close()
 	out, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
+		c.log.ErrorContext(ctx, "interbank response read failed",
+			"method", method, "url", url, "status", resp.StatusCode, "err", err.Error())
 		return resp.StatusCode, nil, fmt.Errorf("read body: %w", err)
 	}
+	logOutbound(ctx, c.log, method, url, resp.StatusCode, time.Since(start), out)
 	return resp.StatusCode, out, nil
 }

--- a/services/trading/internal/external/interbank/routes.go
+++ b/services/trading/internal/external/interbank/routes.go
@@ -24,20 +24,22 @@ type Routes map[string]string
 // reachable; the caller surfaces "unknown partner bank" on first use).
 func ParseRoutes(raw string) Routes {
 	out := make(Routes)
-	for _, part := range strings.Split(raw, ",") {
+	for i, part := range strings.Split(raw, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}
 		key, value, ok := strings.Cut(part, ":")
 		if !ok {
-			slog.Default().Warn("interbank route entry malformed, dropped", "entry", part)
+			// Entry value deliberately not logged: a fat-fingered env
+			// paste could land key material in the value slot.
+			slog.Default().Warn("interbank route entry malformed, dropped", "position", i)
 			continue
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
 		if key == "" || value == "" {
-			slog.Default().Warn("interbank route entry malformed, dropped", "entry", part)
+			slog.Default().Warn("interbank route entry malformed, dropped", "position", i, "bank_code", key)
 			continue
 		}
 		out[key] = strings.TrimRight(value, "/")

--- a/services/trading/internal/external/interbank/routes.go
+++ b/services/trading/internal/external/interbank/routes.go
@@ -8,6 +8,7 @@
 package interbank
 
 import (
+	"log/slog"
 	"strings"
 )
 
@@ -30,11 +31,13 @@ func ParseRoutes(raw string) Routes {
 		}
 		key, value, ok := strings.Cut(part, ":")
 		if !ok {
+			slog.Default().Warn("interbank route entry malformed, dropped", "entry", part)
 			continue
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
 		if key == "" || value == "" {
+			slog.Default().Warn("interbank route entry malformed, dropped", "entry", part)
 			continue
 		}
 		out[key] = strings.TrimRight(value, "/")
@@ -58,11 +61,14 @@ func ParsePartnerKeys(raw string) map[string]string {
 		}
 		code, key, ok := strings.Cut(part, ":")
 		if !ok {
+			// Don't log the entry itself — the value side may be a secret key.
+			slog.Default().Warn("interbank code:value entry malformed, dropped")
 			continue
 		}
 		code = strings.TrimSpace(code)
 		key = strings.TrimSpace(key)
 		if code == "" || key == "" {
+			slog.Default().Warn("interbank code:value entry malformed, dropped", "bank_code", code)
 			continue
 		}
 		out[code] = key

--- a/services/trading/internal/saga/saga.go
+++ b/services/trading/internal/saga/saga.go
@@ -513,10 +513,12 @@ func (o *Orchestrator) runForward(ctx context.Context, row *Row, drv driver, log
 			row.Attempts = 0
 			row.NextAttemptAt = o.now()
 			if err := o.Store.Update(ctx, row); err != nil {
+				log.ErrorContext(ctx, "saga persist step failed", "err", err, "step", s.name)
 				return err
 			}
 			continue
 		}
+		log.DebugContext(ctx, "saga step start", "step", s.name, "step_no", i+1)
 		var err error
 		if ferr := forceForwardErr(ctx, s.name, i); ferr != nil {
 			log.Warn("saga: fault-injection forward fail",
@@ -533,16 +535,18 @@ func (o *Orchestrator) runForward(ctx context.Context, row *Row, drv driver, log
 			row.Attempts = 0
 			row.NextAttemptAt = o.now()
 			if err := o.Store.Update(ctx, row); err != nil {
+				log.ErrorContext(ctx, "saga persist step failed", "err", err, "step", s.name)
 				return err
 			}
+			log.InfoContext(ctx, "saga step completed", "step", s.name, "step_no", i+1)
 			continue
 		}
 		// Forward error. Record the attempt, then decide: roll back, or
 		// (for forward-recovery sagas) park the transient for retry.
 		row.appendLog("F", i, resultErr, err)
 		if isPermanent(err) || drv.compensateOnTransient {
-			log.Warn("saga: forward error → compensating",
-				"step", s.name, "permanent", isPermanent(err), "err", err.Error())
+			log.ErrorContext(ctx, "saga step forward failed, compensating",
+				"err", err.Error(), "step", s.name, "permanent", isPermanent(err))
 			row.LastError = err.Error()
 			row.Status = StatusCompensating
 			// Don't bump CurrentStep — the failed step never committed,
@@ -550,6 +554,7 @@ func (o *Orchestrator) runForward(ctx context.Context, row *Row, drv driver, log
 			row.NextAttemptAt = o.now()
 			row.Attempts = 0
 			if uerr := o.Store.Update(ctx, row); uerr != nil {
+				log.ErrorContext(ctx, "saga persist compensating flip failed", "err", uerr, "step", s.name)
 				return uerr
 			}
 			return o.runCompensations(ctx, row, drv, log)
@@ -570,6 +575,7 @@ func (o *Orchestrator) runForward(ctx context.Context, row *Row, drv driver, log
 				"err", err.Error())
 		}
 		if uerr := o.Store.Update(ctx, row); uerr != nil {
+			log.ErrorContext(ctx, "saga persist retry schedule failed", "err", uerr, "step", s.name)
 			return uerr
 		}
 		return err
@@ -580,7 +586,12 @@ func (o *Orchestrator) runForward(ctx context.Context, row *Row, drv driver, log
 	row.StepNo = len(drv.steps)
 	row.LastError = ""
 	row.NextAttemptAt = o.now()
-	return o.Store.Update(ctx, row)
+	if err := o.Store.Update(ctx, row); err != nil {
+		log.ErrorContext(ctx, "saga persist completion failed", "err", err)
+		return err
+	}
+	log.InfoContext(ctx, "saga completed", "steps", len(drv.steps))
+	return nil
 }
 
 // runCompensations walks the completed steps in reverse and runs each
@@ -597,7 +608,12 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 		// no side effects committed. This is a clean rollback.
 		row.Status = StatusCompensated
 		row.NextAttemptAt = o.now()
-		return o.Store.Update(ctx, row)
+		if err := o.Store.Update(ctx, row); err != nil {
+			log.ErrorContext(ctx, "saga persist compensated terminal failed", "err", err)
+			return err
+		}
+		log.InfoContext(ctx, "saga compensated", "last_error", row.LastError)
+		return nil
 	}
 	// Preserve the original forward-step error across compensation
 	// updates — it's the audit-trail "why did this saga roll back" line.
@@ -615,6 +631,7 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 			row.LastError = ""
 			row.Attempts = 0
 			if err := o.Store.Update(ctx, row); err != nil {
+				log.ErrorContext(ctx, "saga persist compensation step failed", "err", err, "step", s.name)
 				return err
 			}
 			continue
@@ -626,6 +643,7 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 			Log:           log.With("step", s.name, "phase", "compensate"),
 			StateRaw:      &row.State,
 		}
+		log.DebugContext(ctx, "saga compensation step start", "step", s.name, "step_no", i+1)
 		var err error
 		if ferr := forceCompensateErr(ctx, s.name, i, row.Attempts); ferr != nil {
 			log.Warn("saga: fault-injection compensate fail",
@@ -642,8 +660,10 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 			row.Attempts = 0
 			row.NextAttemptAt = o.now()
 			if uerr := o.Store.Update(ctx, row); uerr != nil {
+				log.ErrorContext(ctx, "saga persist compensation step failed", "err", uerr, "step", s.name)
 				return uerr
 			}
+			log.InfoContext(ctx, "saga compensation step completed", "step", s.name, "step_no", i+1)
 			continue
 		}
 		// Compensation failed. Record the attempt. A compensator must
@@ -660,6 +680,7 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 			row.LastError = err.Error()
 			row.NextAttemptAt = o.now()
 			if uerr := o.Store.Update(ctx, row); uerr != nil {
+				log.ErrorContext(ctx, "saga persist failed terminal failed", "err", uerr, "step", s.name)
 				return uerr
 			}
 			return err
@@ -672,11 +693,16 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 				"step", s.name, "attempts", row.Attempts, "err", err.Error())
 			row.Status = StatusFailed
 			if uerr := o.Store.Update(ctx, row); uerr != nil {
+				log.ErrorContext(ctx, "saga persist failed terminal failed", "err", uerr, "step", s.name)
 				return uerr
 			}
 			return err
 		}
+		log.WarnContext(ctx, "saga compensation transient error, will retry",
+			"err", err.Error(), "step", s.name, "attempts", row.Attempts,
+			"retry_after", row.NextAttemptAt.UTC().Format(time.RFC3339))
 		if uerr := o.Store.Update(ctx, row); uerr != nil {
+			log.ErrorContext(ctx, "saga persist retry schedule failed", "err", uerr, "step", s.name)
 			return uerr
 		}
 		return err
@@ -688,7 +714,12 @@ func (o *Orchestrator) runCompensations(ctx context.Context, row *Row, drv drive
 		row.LastError = origFailure
 	}
 	row.NextAttemptAt = o.now()
-	return o.Store.Update(ctx, row)
+	if err := o.Store.Update(ctx, row); err != nil {
+		log.ErrorContext(ctx, "saga persist compensated terminal failed", "err", err)
+		return err
+	}
+	log.InfoContext(ctx, "saga compensated", "last_error", row.LastError)
+	return nil
 }
 
 // =====================================================================

--- a/services/trading/internal/server/external_otc.go
+++ b/services/trading/internal/server/external_otc.go
@@ -20,6 +20,10 @@ import (
 func (s *Server) ListExternalPublicHoldings(ctx context.Context, in *tradingpb.ListExternalPublicHoldingsRequest) (*tradingpb.ListExternalPublicHoldingsResponse, error) {
 	rows, err := s.Svc.ListExternalPublicHoldings(ctx, in.GetBankCode(), in.GetTicker())
 	if err != nil {
+		// The interceptor logs method+code; the partner fan-out params are
+		// what disambiguate which discovery target broke.
+		s.Svc.Log.ErrorContext(ctx, "external otc: partner holdings discovery failed",
+			"err", err, "bank_code", in.GetBankCode(), "ticker", in.GetTicker())
 		return nil, err
 	}
 	out := &tradingpb.ListExternalPublicHoldingsResponse{
@@ -238,9 +242,21 @@ var settlementKindToString = map[tradingpb.ExternalOTCSettlementKind]string{
 }
 
 func (s *Server) SettleExternalOTCOption(ctx context.Context, in *tradingpb.SettleExternalOTCOptionRequest) (*tradingpb.SettleExternalOTCOptionResponse, error) {
+	phase, phaseOK := settlementPhaseToString[in.GetPhase()]
+	if !phaseOK {
+		s.Svc.Log.WarnContext(ctx, "external otc settle: unknown settlement phase in request",
+			"phase", in.GetPhase().String(),
+			"transaction_id", in.GetTransactionId(), "sender_bank_code", in.GetSenderBankCode())
+	}
+	kind, kindOK := settlementKindToString[in.GetKind()]
+	if !kindOK {
+		s.Svc.Log.WarnContext(ctx, "external otc settle: unknown settlement kind in request",
+			"kind", in.GetKind().String(),
+			"transaction_id", in.GetTransactionId(), "sender_bank_code", in.GetSenderBankCode())
+	}
 	res, err := s.Svc.SettleExternalOTCOption(ctx, service.SettleExternalOTCOptionInput{
-		Phase:          settlementPhaseToString[in.GetPhase()],
-		Kind:           settlementKindToString[in.GetKind()],
+		Phase:          phase,
+		Kind:           kind,
 		SenderBankCode: in.GetSenderBankCode(),
 		TransactionID:  in.GetTransactionId(),
 		OptionRef:      in.GetOptionRef(),
@@ -251,7 +267,19 @@ func (s *Server) SettleExternalOTCOption(ctx context.Context, in *tradingpb.Sett
 		Quantity:       in.GetQuantity(),
 	})
 	if err != nil {
+		// 2PC money leg — the transaction id is the cross-bank correlation
+		// key, which the boundary interceptor doesn't capture.
+		s.Svc.Log.ErrorContext(ctx, "external otc settle: 2pc phase failed",
+			"err", err, "phase", phase, "kind", kind,
+			"transaction_id", in.GetTransactionId(), "sender_bank_code", in.GetSenderBankCode())
 		return nil, err
+	}
+	if !res.Accepted {
+		// Rejection rides back as an OK gRPC response — without this log
+		// the boundary shows code=OK while the settlement actually refused.
+		s.Svc.Log.WarnContext(ctx, "external otc settle: phase rejected",
+			"reason", res.Reason, "phase", phase, "kind", kind,
+			"transaction_id", in.GetTransactionId(), "sender_bank_code", in.GetSenderBankCode())
 	}
 	return &tradingpb.SettleExternalOTCOptionResponse{
 		Accepted:            res.Accepted,

--- a/services/trading/internal/server/funds.go
+++ b/services/trading/internal/server/funds.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 
 	tradingpb "github.com/RAF-SI-2025/Banka-3-Backend/gen/proto/trading/v1"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/money"
@@ -359,10 +360,12 @@ func fundTxStatusToProto(s domain.FundTransactionStatus) tradingpb.FundTransacti
 func addDecimals(a, b string) string {
 	pa, ea := money.Parse(a)
 	if ea != nil {
+		slog.Warn("fund snapshot: unparsable liquid_rsd, defaulting to 0", "err", ea, "value", a)
 		pa = money.MustParse("0")
 	}
 	pb, eb := money.Parse(b)
 	if eb != nil {
+		slog.Warn("fund snapshot: unparsable holdings_value_rsd, defaulting to 0", "err", eb, "value", b)
 		pb = money.MustParse("0")
 	}
 	return money.FormatAmount(money.Add(pa, pb))

--- a/services/trading/internal/server/listings.go
+++ b/services/trading/internal/server/listings.go
@@ -79,10 +79,14 @@ func (s *Server) ListListings(ctx context.Context, in *tradingpb.ListListingsReq
 func (s *Server) GetListingDailyHistory(ctx context.Context, in *tradingpb.GetListingDailyHistoryRequest) (*tradingpb.GetListingDailyHistoryResponse, error) {
 	from, err := parseHistoryDate(in.GetFrom())
 	if err != nil {
+		s.Svc.Log.WarnContext(ctx, "listing history: bad 'from' date in request",
+			"err", err, "from", in.GetFrom(), "listing_id", in.GetListingId())
 		return nil, apperr.Validation("from: očekivan format YYYY-MM-DD")
 	}
 	to, err := parseHistoryDate(in.GetTo())
 	if err != nil {
+		s.Svc.Log.WarnContext(ctx, "listing history: bad 'to' date in request",
+			"err", err, "to", in.GetTo(), "listing_id", in.GetListingId())
 		return nil, apperr.Validation("to: očekivan format YYYY-MM-DD")
 	}
 	if !to.IsZero() {

--- a/services/trading/internal/server/otc.go
+++ b/services/trading/internal/server/otc.go
@@ -242,6 +242,9 @@ func otcOfferToProto(s *Server, ctx context.Context, o *domain.OTCOffer) *tradin
 	}
 	if sec, err := s.Svc.Store.GetSecurity(ctx, o.SecurityID); err == nil {
 		out.SecurityTicker = sec.Ticker
+	} else {
+		s.Svc.Log.WarnContext(ctx, "otc offer: security ticker lookup failed, leaving ticker empty",
+			"err", err, "security_id", o.SecurityID, "thread_id", o.ThreadID)
 	}
 	return out
 }
@@ -278,6 +281,9 @@ func otcContractToProto(s *Server, ctx context.Context, c *domain.OTCContract) *
 	}
 	if sec, err := s.Svc.Store.GetSecurity(ctx, c.SecurityID); err == nil {
 		out.SecurityTicker = sec.Ticker
+	} else {
+		s.Svc.Log.WarnContext(ctx, "otc contract: security ticker lookup failed, leaving ticker empty",
+			"err", err, "security_id", c.SecurityID, "contract_id", c.ID)
 	}
 	// Resolve the seller's human-readable name the same way the OTC
 	// discovery board does (service.ListPublicHoldings); without this
@@ -285,6 +291,9 @@ func otcContractToProto(s *Server, ctx context.Context, c *domain.OTCContract) *
 	if s.Svc.Users != nil {
 		if name, err := s.Svc.Users.DisplayName(ctx, c.SellerID, c.SellerKind); err == nil {
 			out.SellerDisplayName = name
+		} else {
+			s.Svc.Log.WarnContext(ctx, "otc contract: seller display-name lookup failed, leaving name empty",
+				"err", err, "seller_id", c.SellerID, "contract_id", c.ID)
 		}
 	}
 	return out

--- a/services/trading/internal/server/securities.go
+++ b/services/trading/internal/server/securities.go
@@ -88,11 +88,15 @@ func (s *Server) ListSecurities(ctx context.Context, in *tradingpb.ListSecuritie
 	}
 	minS, err := parseDatePtr(in.GetMinSettlement())
 	if err != nil {
+		s.Svc.Log.WarnContext(ctx, "list securities: bad min_settlement date in request",
+			"err", err, "min_settlement", in.GetMinSettlement())
 		return nil, apperr.Validation("min_settlement: očekivan format YYYY-MM-DD")
 	}
 	input.MinSettlement = minS
 	maxS, err := parseDatePtr(in.GetMaxSettlement())
 	if err != nil {
+		s.Svc.Log.WarnContext(ctx, "list securities: bad max_settlement date in request",
+			"err", err, "max_settlement", in.GetMaxSettlement())
 		return nil, apperr.Validation("max_settlement: očekivan format YYYY-MM-DD")
 	}
 	input.MaxSettlement = maxS

--- a/services/trading/internal/service/actuaries.go
+++ b/services/trading/internal/service/actuaries.go
@@ -54,12 +54,19 @@ func (s *Service) UpsertActuaryInfo(ctx context.Context, in UpsertActuaryInfoInp
 		}
 	}
 
-	return s.Store.UpsertActuaryInfo(ctx, &domain.ActuaryInfo{
+	out, err := s.Store.UpsertActuaryInfo(ctx, &domain.ActuaryInfo{
 		EmployeeID:   in.EmployeeID,
 		Type:         in.Type,
 		DailyLimit:   limit,
 		NeedApproval: need,
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "actuary info upserted",
+		"employee_id", in.EmployeeID, "type", string(in.Type),
+		"daily_limit", limit, "need_approval", need)
+	return out, nil
 }
 
 // GetActuaryInfo returns one actuary record. Visibility:
@@ -118,6 +125,8 @@ func (s *Service) UpdateActuaryLimit(ctx context.Context, employeeID, dailyLimit
 	newLimit, _ := money.Parse(dailyLimit)
 	usedLimit, err := money.Parse(cur.UsedLimit)
 	if err != nil {
+		s.log().ErrorContext(ctx, "actuary used_limit malformed",
+			"err", err, "employee_id", employeeID, "used_limit", cur.UsedLimit)
 		return nil, apperr.Validation("used_limit on actuary record is malformed")
 	}
 	if money.Cmp(newLimit, usedLimit) < 0 {
@@ -131,11 +140,17 @@ func (s *Service) UpdateActuaryLimit(ctx context.Context, employeeID, dailyLimit
 	// agent, with the old + new daily limit. Best-effort; never fails the op.
 	label := employeeID
 	if s.Users != nil {
-		if name, derr := s.Users.DisplayName(ctx, employeeID, domain.KindEmployee); derr == nil && name != "" {
+		name, derr := s.Users.DisplayName(ctx, employeeID, domain.KindEmployee)
+		if derr != nil {
+			s.log().WarnContext(ctx, "actuary display-name lookup failed",
+				"err", derr, "employee_id", employeeID)
+		} else if name != "" {
 			label = name
 		}
 	}
 	s.recordAudit(ctx, "limit.change", employeeID, label, cur.DailyLimit, dailyLimit, "")
+	s.log().InfoContext(ctx, "actuary limit updated",
+		"employee_id", employeeID, "old_limit", cur.DailyLimit, "new_limit", dailyLimit)
 	return out, nil
 }
 
@@ -144,7 +159,12 @@ func (s *Service) ResetActuaryUsedLimit(ctx context.Context, employeeID string) 
 	if _, err := s.requireSupervisor(ctx); err != nil {
 		return nil, err
 	}
-	return s.Store.ResetActuaryUsedLimit(ctx, employeeID)
+	out, err := s.Store.ResetActuaryUsedLimit(ctx, employeeID)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "actuary used limit reset", "employee_id", employeeID)
+	return out, nil
 }
 
 // SetActuaryNeedApproval toggles the per-actuary approval requirement.
@@ -160,7 +180,13 @@ func (s *Service) SetActuaryNeedApproval(ctx context.Context, employeeID string,
 	if cur.Type == domain.ActuarySupervisor {
 		return nil, apperr.FailedPrecondition("supervizor uvek ima need_approval=false")
 	}
-	return s.Store.SetActuaryNeedApproval(ctx, employeeID, need)
+	out, err := s.Store.SetActuaryNeedApproval(ctx, employeeID, need)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "actuary need-approval set",
+		"employee_id", employeeID, "need_approval", need)
+	return out, nil
 }
 
 // RunDailyResetActuaries zeroes used_limit across every actuary. The
@@ -178,7 +204,12 @@ func (s *Service) RunDailyResetActuaries(ctx context.Context) (int64, error) {
 			return 0, err
 		}
 	}
-	return s.Store.ResetAllUsedLimits(ctx)
+	n, err := s.Store.ResetAllUsedLimits(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.log().InfoContext(ctx, "daily actuary used-limit reset completed", "rows", n)
+	return n, nil
 }
 
 // validateNonNegativeAmount sanity-checks decimal-string amounts.

--- a/services/trading/internal/service/cross_bank_payment.go
+++ b/services/trading/internal/service/cross_bank_payment.go
@@ -111,13 +111,20 @@ func (s *Service) SubmitCrossBankPayment(ctx context.Context, in SubmitCrossBank
 	// Resolve source account: currency match + active.
 	srcCcy, _, err := s.Reservations.AccountAvailable(ctx, in.SourceAccountID)
 	if err != nil {
+		s.logOpErr(ctx, "cross-bank payment: source account lookup failed", err,
+			"source_account_id", in.SourceAccountID, "remote_bank_code", in.RemoteBankCode)
 		return nil, err
 	}
 	if srcCcy != in.Currency {
+		s.log().WarnContext(ctx, "cross-bank payment rejected: currency mismatch",
+			"source_account_id", in.SourceAccountID, "account_currency", string(srcCcy),
+			"requested_currency", string(in.Currency))
 		return nil, apperr.Validation("valuta računa se ne poklapa")
 	}
 	srcNumber, err := s.Reservations.AccountNumber(ctx, in.SourceAccountID)
 	if err != nil {
+		s.logOpErr(ctx, "cross-bank payment: source account number lookup failed", err,
+			"source_account_id", in.SourceAccountID)
 		return nil, err
 	}
 
@@ -142,8 +149,15 @@ func (s *Service) SubmitCrossBankPayment(ctx context.Context, in SubmitCrossBank
 		AttemptsMax:   8,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "cross-bank payment saga failed",
+			"err", err, "transaction_id", txID, "remote_bank_code", in.RemoteBankCode,
+			"amount", in.Amount, "currency", string(in.Currency))
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "cross-bank payment submitted",
+		"transaction_id", txID, "status", string(row.Status),
+		"remote_bank_code", in.RemoteBankCode, "amount", in.Amount,
+		"currency", string(in.Currency), "user_id", p.UserID)
 	// Retry queue (todoSpec): a saga left parked (status=running) means a
 	// transient failure — typically the partner bank being unavailable at
 	// prepare_partner. Enqueue a retry entry so the 5s/30s worker drives
@@ -180,6 +194,8 @@ func (s *Service) GetCrossBankPayment(ctx context.Context, txID string) (*CrossB
 	}
 	var payload crossBankPaymentPayload
 	if err := json.Unmarshal(row.State, &payload); err != nil {
+		s.log().ErrorContext(ctx, "cross-bank payment saga state decode failed",
+			"err", err, "transaction_id", txID)
 		return nil, apperr.Internal("decode saga state", err)
 	}
 	if payload.UserID != p.UserID && !permissions.Has(p.Permissions, permissions.Admin) {

--- a/services/trading/internal/service/cross_bank_payment_saga.go
+++ b/services/trading/internal/service/cross_bank_payment_saga.go
@@ -67,6 +67,9 @@ func registerCrossBankPaymentSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "prepare_local",
 				Forward: func(ctx context.Context, sc *saga.Context[crossBankPaymentPayload]) error {
+					sc.Log.DebugContext(ctx, "cross-bank payment: preparing local leg",
+						"remote_bank_code", sc.State.RemoteBankCode,
+						"amount", sc.State.Amount, "currency", sc.State.Currency)
 					_, err := svc.InterbankPayer.PreparePayment(ctx, PrepareInterbankInput{
 						SenderRoutingNumber: sc.State.SenderRoutingNumber,
 						TransactionID:       sc.TransactionID,
@@ -76,12 +79,24 @@ func registerCrossBankPaymentSaga(reg *saga.Registry, svc *Service) {
 						Amount:              sc.State.Amount,
 						Purpose:             sc.State.Purpose,
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: local prepare failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode,
+							"amount", sc.State.Amount, "currency", sc.State.Currency)
+					}
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[crossBankPaymentPayload]) error {
-					return svc.InterbankPayer.RollbackPayment(ctx,
+					if err := svc.InterbankPayer.RollbackPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID,
-						"cross-bank payment local rollback")
+						"cross-bank payment local rollback"); err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: local rollback compensation failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "cross-bank payment: local reservation rolled back",
+						"remote_bank_code", sc.State.RemoteBankCode)
+					return nil
 				},
 			},
 			{
@@ -97,6 +112,9 @@ func registerCrossBankPaymentSaga(reg *saga.Registry, svc *Service) {
 						Purpose:             sc.State.Purpose,
 					})
 					if err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: partner prepare failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode,
+							"amount", sc.State.Amount, "currency", sc.State.Currency)
 						return err
 					}
 					if !res.Accepted {
@@ -104,25 +122,42 @@ func registerCrossBankPaymentSaga(reg *saga.Registry, svc *Service) {
 						if len(res.NoReasons) > 0 {
 							reason = "partner refused: " + strings.Join(res.NoReasons, ",")
 						}
+						sc.Log.WarnContext(ctx, "cross-bank payment: partner voted no",
+							"remote_bank_code", sc.State.RemoteBankCode, "reason", reason)
 						// Wrap as InvalidArgument so the saga marks this as
 						// a permanent failure (not transient retry).
 						return status.Error(codes.InvalidArgument, reason)
 					}
+					sc.Log.InfoContext(ctx, "cross-bank payment: partner prepared",
+						"remote_bank_code", sc.State.RemoteBankCode,
+						"amount", sc.State.Amount, "currency", sc.State.Currency)
 					return nil
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[crossBankPaymentPayload]) error {
 					// Best-effort — if the partner never recorded the
 					// prepare row, this 404s and we swallow it.
-					return svc.PartnerPayer.RollbackPayment(ctx,
+					if err := svc.PartnerPayer.RollbackPayment(ctx,
 						sc.State.RemoteBankCode, sc.TransactionID,
-						"cross-bank payment partner rollback")
+						"cross-bank payment partner rollback"); err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: partner rollback compensation failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					return nil
 				},
 			},
 			{
 				Name: "commit_partner",
 				Forward: func(ctx context.Context, sc *saga.Context[crossBankPaymentPayload]) error {
-					return svc.PartnerPayer.CommitPayment(ctx,
-						sc.State.RemoteBankCode, sc.TransactionID)
+					if err := svc.PartnerPayer.CommitPayment(ctx,
+						sc.State.RemoteBankCode, sc.TransactionID); err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: partner commit failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "cross-bank payment: partner committed",
+						"remote_bank_code", sc.State.RemoteBankCode)
+					return nil
 				},
 				// Past the point of no return for the partner; no
 				// compensation defined. A failure here parks the saga
@@ -135,7 +170,15 @@ func registerCrossBankPaymentSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[crossBankPaymentPayload]) error {
 					_, err := svc.InterbankPayer.CommitPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID)
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "cross-bank payment: local commit failed",
+							"err", err, "remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "cross-bank payment: local leg committed",
+						"remote_bank_code", sc.State.RemoteBankCode,
+						"amount", sc.State.Amount, "currency", sc.State.Currency)
+					return nil
 				},
 				Compensate: nil,
 			},

--- a/services/trading/internal/service/dividends.go
+++ b/services/trading/internal/service/dividends.go
@@ -91,6 +91,7 @@ func (s *Service) RunDividendPayout(ctx context.Context) (*RunDividendPayoutResu
 
 	cands, err := s.Store.ListDividendCandidates(ctx)
 	if err != nil {
+		s.log().ErrorContext(ctx, "dividend payout: candidate scan failed", "err", err)
 		return nil, err
 	}
 
@@ -124,10 +125,18 @@ func (s *Service) RunDividendPayout(ctx context.Context) (*RunDividendPayoutResu
 func (s *Service) computeDividend(c *store.DividendCandidate) (*big.Rat, bool) {
 	price, err := money.Parse(c.Price)
 	if err != nil || price.Sign() <= 0 {
+		if err != nil {
+			s.log().Warn("dividend candidate price unparseable; skipping",
+				"err", err, "holding_id", c.HoldingID, "price", c.Price)
+		}
 		return nil, false
 	}
 	yield, err := money.Parse(c.DividendYield)
 	if err != nil || yield.Sign() <= 0 {
+		if err != nil {
+			s.log().Warn("dividend candidate yield unparseable; skipping",
+				"err", err, "holding_id", c.HoldingID, "yield", c.DividendYield)
+		}
 		return nil, false
 	}
 	gross := dividend.Quarterly(int64(c.Quantity), price, yield)

--- a/services/trading/internal/service/exchanges.go
+++ b/services/trading/internal/service/exchanges.go
@@ -25,7 +25,12 @@ func (s *Service) UpsertExchange(ctx context.Context, in *domain.Exchange) (*dom
 	if err := validateExchange(in); err != nil {
 		return nil, err
 	}
-	return s.Store.UpsertExchange(ctx, in)
+	e, err := s.Store.UpsertExchange(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "exchange upserted", "mic", e.MIC)
+	return e, nil
 }
 
 // SetExchangeOverride writes the four-state override (open / closed /
@@ -46,7 +51,16 @@ func (s *Service) SetExchangeOverride(ctx context.Context, mic string, state *do
 			return nil, apperr.Validation("invalid override state")
 		}
 	}
-	return s.Store.SetExchangeOverride(ctx, mic, state)
+	e, err := s.Store.SetExchangeOverride(ctx, mic, state)
+	if err != nil {
+		return nil, err
+	}
+	override := "cleared"
+	if state != nil {
+		override = string(*state)
+	}
+	s.log().InfoContext(ctx, "exchange override set", "mic", mic, "override", override)
+	return e, nil
 }
 
 // ListExchanges returns every exchange with the resolved is_open /
@@ -103,12 +117,17 @@ func (s *Service) resolveMarketState(e *domain.Exchange, now time.Time) *MarketS
 	}
 	loc, err := time.LoadLocation(e.Timezone)
 	if err != nil {
+		s.log().Warn("exchange timezone load failed; falling back to UTC",
+			"err", err, "mic", e.MIC, "timezone", e.Timezone)
 		loc = time.UTC
 	}
 	local := now.In(loc)
 	openT, err1 := parseHHMM(e.OpenLocal)
 	closeT, err2 := parseHHMM(e.CloseLocal)
 	if err1 != nil || err2 != nil {
+		s.log().Warn("exchange open/close hours unparseable; treating as closed",
+			"mic", e.MIC, "open", e.OpenLocal, "close", e.CloseLocal,
+			"open_err", err1, "close_err", err2)
 		return ms
 	}
 	openAt := time.Date(local.Year(), local.Month(), local.Day(), openT.h, openT.m, 0, 0, loc)

--- a/services/trading/internal/service/execution.go
+++ b/services/trading/internal/service/execution.go
@@ -719,6 +719,8 @@ func (s *Service) recordRealizedGain(
 func (s *Service) stopTriggered(o *domain.Order, listing *domain.Listing) bool {
 	stop, err := money.Parse(o.StopPrice)
 	if err != nil {
+		s.log().Warn("stop trigger: stop price parse failed, order will never trigger",
+			"err", err, "order_id", o.ID, "security_id", o.SecurityID, "stop_price", o.StopPrice)
 		return false
 	}
 	var quoteStr string
@@ -729,6 +731,8 @@ func (s *Service) stopTriggered(o *domain.Order, listing *domain.Listing) bool {
 	}
 	quote, err := money.Parse(quoteStr)
 	if err != nil {
+		s.log().Warn("stop trigger: listing quote parse failed, order will never trigger",
+			"err", err, "order_id", o.ID, "security_id", o.SecurityID, "quote", quoteStr)
 		return false
 	}
 	cmp := quote.Cmp(stop)
@@ -754,18 +758,24 @@ func (s *Service) stopTriggered(o *domain.Order, listing *domain.Listing) bool {
 func (s *Service) limitConditionMet(o *domain.Order, listing *domain.Listing) bool {
 	limit, err := money.Parse(o.LimitPrice)
 	if err != nil {
+		s.log().Warn("limit condition: limit price parse failed, order will never fill",
+			"err", err, "order_id", o.ID, "security_id", o.SecurityID, "limit_price", o.LimitPrice)
 		return false
 	}
 	switch o.Direction {
 	case domain.DirectionBuy:
 		ask, err := money.Parse(listing.Ask)
 		if err != nil {
+			s.log().Warn("limit condition: listing ask parse failed, order will never fill",
+				"err", err, "order_id", o.ID, "security_id", o.SecurityID, "ask", listing.Ask)
 			return false
 		}
 		return ask.Cmp(limit) <= 0
 	case domain.DirectionSell:
 		bid, err := money.Parse(listing.Bid)
 		if err != nil {
+			s.log().Warn("limit condition: listing bid parse failed, order will never fill",
+				"err", err, "order_id", o.ID, "security_id", o.SecurityID, "bid", listing.Bid)
 			return false
 		}
 		return bid.Cmp(limit) >= 0

--- a/services/trading/internal/service/execution.go
+++ b/services/trading/internal/service/execution.go
@@ -239,6 +239,11 @@ func (s *Service) ProcessOrderTick(ctx context.Context, o *domain.Order) (proces
 				res.NextEarliest = s.now().Add(s.tickRetryInterval())
 				return res, nil
 			}
+		} else if !isAppKind(exErr, apperr.KindNotFound) {
+			// Swallowed by design (fail-open to the fill path), but a
+			// real lookup failure deserves visibility.
+			s.log().WarnContext(ctx, "fill: exchange lookup failed; proceeding without market-state gate",
+				"err", exErr, "order_id", o.ID, "mic", listing.ExchangeMIC)
 		}
 	}
 
@@ -319,6 +324,7 @@ func (s *Service) ProcessOrderTick(ctx context.Context, o *domain.Order) (proces
 // legs; the booking tx is the only operation needed to converge.
 func (s *Service) executeFill(ctx context.Context, o *domain.Order, listing *domain.Listing, fillPrice string, qty int32) (*domain.OrderExecution, error) {
 	if s.Settler == nil {
+		s.log().ErrorContext(ctx, "fill: trade settler not wired", "order_id", o.ID)
 		return nil, apperr.Internal("trade settler not wired", nil)
 	}
 
@@ -332,10 +338,14 @@ func (s *Service) executeFill(ctx context.Context, o *domain.Order, listing *dom
 
 	csR, err := money.Parse(contractSize)
 	if err != nil {
+		s.log().ErrorContext(ctx, "fill: contract size unparseable",
+			"err", err, "order_id", o.ID, "contract_size", contractSize)
 		return nil, apperr.Internal("contract size unparseable", err)
 	}
 	priceR, err := money.Parse(fillPrice)
 	if err != nil {
+		s.log().ErrorContext(ctx, "fill: fill price unparseable",
+			"err", err, "order_id", o.ID, "fill_price", fillPrice)
 		return nil, apperr.Internal("fill price unparseable", err)
 	}
 	qtyR := new(big.Rat).SetInt64(int64(qty))
@@ -375,6 +385,8 @@ func (s *Service) executeFill(ctx context.Context, o *domain.Order, listing *dom
 		pending = row
 		return nil
 	}); err != nil {
+		s.log().ErrorContext(ctx, "fill: pending execution insert failed",
+			"err", err, "order_id", o.ID, "quantity", qty)
 		return nil, err
 	}
 
@@ -438,10 +450,14 @@ func (s *Service) completeFill(
 ) (*domain.OrderExecution, error) {
 	notional, err := money.Parse(pending.TotalAmount)
 	if err != nil {
+		s.log().ErrorContext(ctx, "fill: pending notional unparseable",
+			"err", err, "order_id", o.ID, "exec_id", pending.ID, "total_amount", pending.TotalAmount)
 		return nil, apperr.Internal("pending notional unparseable", err)
 	}
 	commission, err := money.Parse(pending.CommissionAmt)
 	if err != nil {
+		s.log().ErrorContext(ctx, "fill: pending commission unparseable",
+			"err", err, "order_id", o.ID, "exec_id", pending.ID, "commission", pending.CommissionAmt)
 		return nil, apperr.Internal("pending commission unparseable", err)
 	}
 
@@ -450,6 +466,9 @@ func (s *Service) completeFill(
 	// migration 0011), so a retry after a partial failure is a no-op.
 	settledOpID, err := s.settleCashLeg(ctx, o, sec, pending.PricePerUnit, pending.Quantity, notional, commission, pending.ID)
 	if err != nil {
+		s.log().ErrorContext(ctx, "fill: bank cash-leg settle failed",
+			"err", err, "order_id", o.ID, "exec_id", pending.ID,
+			"ticker", sec.Ticker, "quantity", pending.Quantity)
 		return nil, err
 	}
 
@@ -513,6 +532,10 @@ func (s *Service) completeFill(
 	pending.Status = "settled"
 	exec = pending
 	bizmetric.TradeCompleted(ctx, string(o.Direction), string(sec.Type), "ok")
+	s.log().InfoContext(ctx, "order fill settled",
+		"order_id", o.ID, "exec_id", pending.ID, "op_id", settledOpID,
+		"ticker", sec.Ticker, "quantity", pending.Quantity,
+		"price", pending.PricePerUnit, "remaining", remainingAfter)
 
 	// Order-fill notifications (todoSpec C3 S23/S24). Emitted after the
 	// booking tx commits so the row state matches what we announce.
@@ -1029,6 +1052,7 @@ func (s *Service) tickRetryInterval() time.Duration {
 func (s *Service) RunExecutionTick(ctx context.Context) (int, error) {
 	pendingIDs, err := s.Store.ListOrderIDsWithPendingExecutions(ctx, 200)
 	if err != nil {
+		s.log().ErrorContext(ctx, "execution tick: pending-execution scan failed", "err", err)
 		return 0, err
 	}
 	seen := make(map[string]struct{}, len(pendingIDs))
@@ -1052,6 +1076,7 @@ func (s *Service) RunExecutionTick(ctx context.Context) (int, error) {
 
 	orders, err := s.Store.GetActiveOrdersForExecution(ctx, 200)
 	if err != nil {
+		s.log().ErrorContext(ctx, "execution tick: active-order scan failed", "err", err)
 		return fired, err
 	}
 	for _, o := range orders {

--- a/services/trading/internal/service/exercise.go
+++ b/services/trading/internal/service/exercise.go
@@ -85,6 +85,8 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 		return nil, apperr.FailedPrecondition("opcija je istekla")
 	}
 	if option.UnderlyingSecurityID == "" {
+		s.log().ErrorContext(ctx, "option exercise: option has no underlying",
+			"holding_id", holding.ID, "security_id", option.ID, "ticker", option.Ticker)
 		return nil, apperr.Internal("opcija bez underlying-a", nil)
 	}
 
@@ -102,10 +104,14 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 	// exercising).
 	current, err := money.Parse(listing.Price)
 	if err != nil {
+		s.log().ErrorContext(ctx, "option exercise: underlying price unparseable",
+			"err", err, "ticker", option.Ticker, "price", listing.Price)
 		return nil, apperr.Internal("underlying price unparseable", err)
 	}
 	strike, err := money.Parse(option.StrikePrice)
 	if err != nil {
+		s.log().ErrorContext(ctx, "option exercise: strike unparseable",
+			"err", err, "ticker", option.Ticker, "strike_price", option.StrikePrice)
 		return nil, apperr.Internal("strike unparseable", err)
 	}
 	switch option.OptionType {
@@ -128,6 +134,8 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 	}
 	cs, err := money.Parse(contractSizeStr)
 	if err != nil {
+		s.log().ErrorContext(ctx, "option exercise: contract size unparseable",
+			"err", err, "ticker", option.Ticker, "contract_size", contractSizeStr)
 		return nil, apperr.Internal("contract size unparseable", err)
 	}
 	if cs.Sign() == 0 {
@@ -167,12 +175,16 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 		pending = row
 		return nil
 	}); err != nil {
+		s.log().ErrorContext(ctx, "option exercise: pending row insert failed",
+			"err", err, "holding_id", holding.ID, "ticker", option.Ticker)
 		return nil, err
 	}
 
 	// (2) Bank cash leg. CALL = debit user, PUT = credit user. The bank
 	// dedupes on op_id via migration 0011's unique (op_id, leg_index).
 	if s.Settler == nil {
+		s.log().ErrorContext(ctx, "option exercise: trade settler not wired",
+			"exercise_id", pending.ID)
 		return nil, apperr.Internal("trade settler not wired", nil)
 	}
 	direction := "debit"
@@ -189,6 +201,10 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 		Purpose:   "Exercise " + option.Ticker,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "option exercise: bank settle failed",
+			"err", err, "exercise_id", pending.ID, "ticker", option.Ticker,
+			"direction", direction, "amount", pending.NotionalAmt,
+			"currency", string(currency))
 		return nil, err
 	}
 
@@ -274,6 +290,10 @@ func (s *Service) ExerciseOption(ctx context.Context, in ExerciseOptionInput) (*
 			"exercise_id", pending.ID, "op_id", settledOpID, "err", err.Error())
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "option exercised",
+		"exercise_id", pending.ID, "op_id", settledOpID, "ticker", option.Ticker,
+		"option_type", string(option.OptionType), "quantity", in.Quantity,
+		"notional", pending.NotionalAmt, "currency", string(currency))
 	return res, nil
 }
 

--- a/services/trading/internal/service/external_otc.go
+++ b/services/trading/internal/service/external_otc.go
@@ -184,7 +184,13 @@ func (s *Service) ListExternalPublicHoldings(ctx context.Context, bankCode, tick
 	if s.PartnerOTC == nil {
 		return nil, apperr.FailedPrecondition("cross-bank discovery nije konfigurisana")
 	}
-	return s.PartnerOTC.Discover(ctx, bankCode, tickerFilter)
+	holdings, err := s.PartnerOTC.Discover(ctx, bankCode, tickerFilter)
+	if err != nil {
+		s.log().ErrorContext(ctx, "external otc discovery failed",
+			"err", err, "remote_bank_code", bankCode, "ticker", tickerFilter)
+		return nil, err
+	}
+	return holdings, nil
 }
 
 // CreateExternalOTCOfferInput captures the FE form payload.
@@ -239,9 +245,13 @@ func (s *Service) CreateExternalOTCOffer(ctx context.Context, in CreateExternalO
 	}
 	acctNum, err := s.Reservations.AccountNumber(ctx, in.BuyerAccountID)
 	if err != nil {
+		s.log().WarnContext(ctx, "external otc offer: buyer account lookup failed",
+			"err", err, "buyer_account_id", in.BuyerAccountID, "remote_bank_code", in.RemoteBankCode)
 		return nil, apperr.Validation("kupčev račun nije pronađen")
 	}
 	if len(acctNum) != 18 {
+		s.log().ErrorContext(ctx, "external otc offer: local account number not 18 digits",
+			"buyer_account_id", in.BuyerAccountID, "len", len(acctNum))
 		return nil, apperr.Internal("local account number nema 18 cifara", nil)
 	}
 
@@ -287,6 +297,9 @@ func (s *Service) CreateExternalOTCOffer(ctx context.Context, in CreateExternalO
 		live = t
 		return nil
 	}); err != nil {
+		s.log().ErrorContext(ctx, "external otc offer: local mirror insert failed",
+			"err", err, "remote_bank_code", in.RemoteBankCode, "ticker", in.SecurityTicker,
+			"quantity", in.Quantity)
 		return nil, err
 	}
 
@@ -310,13 +323,19 @@ func (s *Service) CreateExternalOTCOffer(ctx context.Context, in CreateExternalO
 		LocalAccountRef:  live.LocalAccountNumber,
 	})
 	if err != nil {
+		s.log().WarnContext(ctx, "external otc offer: partner rejected create",
+			"err", err, "thread_id", live.ID, "remote_bank_code", in.RemoteBankCode,
+			"ticker", in.SecurityTicker, "quantity", in.Quantity)
 		// Best-effort flip to 'rejected' so the FE can show a final
 		// state. Swallow the inner error — the user-facing 5xx is
 		// already informative.
-		_ = s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+		if errFlip := s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 			_, errRej := s.Store.SetExternalOTCThreadStatus(ctx, tx, live.ID, domain.ExternalOTCThreadRejected)
 			return errRej
-		})
+		}); errFlip != nil {
+			s.log().WarnContext(ctx, "external otc thread status flip to rejected failed",
+				"err", errFlip, "thread_id", live.ID, "remote_bank_code", in.RemoteBankCode)
+		}
 		return nil, apperr.FailedPrecondition("partner banka je odbila ponudu: " + err.Error())
 	}
 
@@ -330,9 +349,16 @@ func (s *Service) CreateExternalOTCOffer(ctx context.Context, in CreateExternalO
 			live = t
 			return nil
 		}); err != nil {
+			s.log().ErrorContext(ctx, "external otc offer: remote identity stamp failed after partner ack",
+				"err", err, "thread_id", live.ID, "remote_bank_code", in.RemoteBankCode,
+				"remote_thread_id", out.RemoteThreadID)
 			return nil, err
 		}
 	}
+	s.log().InfoContext(ctx, "external otc offer created; partner acked",
+		"thread_id", live.ID, "remote_bank_code", live.RemoteBankCode,
+		"remote_thread_id", live.RemoteThreadID, "ticker", live.SecurityTicker,
+		"quantity", live.Quantity)
 	return live, nil
 }
 
@@ -395,6 +421,11 @@ func (s *Service) GetExternalOTCThread(ctx context.Context, threadID, remoteBank
 	res := &GetExternalOTCThreadResult{Thread: t, Iterations: its}
 	if c, err := s.Store.GetExternalOTCContractByThread(ctx, t.ID); err == nil {
 		res.Contract = c
+	} else if !isAppKind(err, apperr.KindNotFound) {
+		// Best-effort decoration — absence is normal, anything else is
+		// a real lookup failure being swallowed.
+		s.log().WarnContext(ctx, "external otc thread contract lookup failed",
+			"err", err, "thread_id", t.ID, "remote_bank_code", t.RemoteBankCode)
 	}
 	return res, nil
 }
@@ -437,9 +468,13 @@ func (s *Service) CounterExternalOTCOffer(ctx context.Context, in CounterExterna
 			return err
 		}
 		if t.Status != domain.ExternalOTCThreadOpen {
+			s.log().WarnContext(ctx, "external otc counter rejected: thread not open",
+				"thread_id", t.ID, "status", string(t.Status))
 			return apperr.FailedPrecondition("nit više nije otvorena")
 		}
 		if t.ModifiedBySide == domain.ExternalOTCSideLocal {
+			s.log().WarnContext(ctx, "external otc counter rejected: not local side's turn",
+				"thread_id", t.ID)
 			return apperr.FailedPrecondition("druga strana je na potezu")
 		}
 		updated, err := s.Store.UpdateExternalOTCThreadTerms(ctx, tx, t.ID,
@@ -461,6 +496,7 @@ func (s *Service) CounterExternalOTCOffer(ctx context.Context, in CounterExterna
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc counter failed", err, "thread_id", in.ThreadID)
 		return nil, err
 	}
 
@@ -481,8 +517,14 @@ func (s *Service) CounterExternalOTCOffer(ctx context.Context, in CounterExterna
 		SecurityTicker:     live.SecurityTicker,
 		Currency:           string(live.Currency),
 	}); err != nil {
+		s.log().WarnContext(ctx, "external otc counter: partner rejected",
+			"err", err, "thread_id", live.ID, "remote_bank_code", live.RemoteBankCode,
+			"remote_thread_id", live.RemoteThreadID)
 		return nil, apperr.FailedPrecondition("partner banka je odbila kontraponudu: " + err.Error())
 	}
+	s.log().InfoContext(ctx, "external otc counter applied; partner acked",
+		"thread_id", live.ID, "remote_bank_code", live.RemoteBankCode,
+		"quantity", live.Quantity, "ticker", live.SecurityTicker)
 	return live, nil
 }
 
@@ -510,6 +552,8 @@ func (s *Service) WithdrawExternalOTCOffer(ctx context.Context, bankCode, thread
 			return err
 		}
 		if t.Status != domain.ExternalOTCThreadOpen {
+			s.log().WarnContext(ctx, "external otc withdraw rejected: thread not open",
+				"thread_id", t.ID, "status", string(t.Status))
 			return apperr.FailedPrecondition("nit više nije otvorena")
 		}
 		updated, err := s.Store.SetExternalOTCThreadStatus(ctx, tx, t.ID, domain.ExternalOTCThreadWithdrawn)
@@ -519,8 +563,11 @@ func (s *Service) WithdrawExternalOTCOffer(ctx context.Context, bankCode, thread
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc withdraw failed", err, "thread_id", threadID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc thread withdrawn",
+		"thread_id", live.ID, "remote_bank_code", live.RemoteBankCode)
 
 	// Best-effort partner notification — local state is already
 	// terminal. Partner reconciles on next poll if this fails.
@@ -634,10 +681,15 @@ func (s *Service) ReceiveExternalOTCOffer(ctx context.Context, in ReceiveExterna
 	// SellerHoldingRef is a uuid (we control the format on /otc/public).
 	holding, err := s.Store.GetHoldingByID(ctx, in.SellerHoldingRef)
 	if err != nil {
+		s.log().WarnContext(ctx, "external otc inbound offer: seller holding not found",
+			"err", err, "seller_holding_ref", in.SellerHoldingRef,
+			"remote_bank_code", in.SenderBankCode, "remote_thread_id", in.SenderThreadID)
 		return nil, apperr.Validation("hartija ne postoji ili nije javno objavljena")
 	}
 	sec, err := s.Store.GetSecurity(ctx, holding.SecurityID)
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc inbound offer: security lookup failed",
+			"err", err, "security_id", holding.SecurityID, "remote_bank_code", in.SenderBankCode)
 		return nil, apperr.Internal("get security", err)
 	}
 	acctNum, err := s.resolveSellerAccountNumber(ctx, holding)
@@ -688,8 +740,15 @@ func (s *Service) ReceiveExternalOTCOffer(ctx context.Context, in ReceiveExterna
 		live = t
 		return nil
 	}); err != nil {
+		s.log().ErrorContext(ctx, "external otc inbound offer: mirror insert failed",
+			"err", err, "remote_bank_code", in.SenderBankCode,
+			"remote_thread_id", in.SenderThreadID, "ticker", sec.Ticker)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc inbound offer mirrored",
+		"thread_id", live.ID, "remote_bank_code", in.SenderBankCode,
+		"remote_thread_id", in.SenderThreadID, "ticker", live.SecurityTicker,
+		"quantity", live.Quantity)
 	return live, nil
 }
 
@@ -716,6 +775,8 @@ func (s *Service) ReceiveExternalOTCCounter(ctx context.Context, in ReceiveExter
 			return err
 		}
 		if t.Status != domain.ExternalOTCThreadOpen {
+			s.log().WarnContext(ctx, "external otc inbound counter rejected: thread not open",
+				"thread_id", t.ID, "status", string(t.Status), "remote_bank_code", in.SenderBankCode)
 			return apperr.FailedPrecondition("nit više nije otvorena")
 		}
 		updated, err := s.Store.UpdateExternalOTCThreadTerms(ctx, tx, t.ID,
@@ -737,8 +798,13 @@ func (s *Service) ReceiveExternalOTCCounter(ctx context.Context, in ReceiveExter
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc inbound counter failed", err,
+			"remote_bank_code", in.SenderBankCode, "remote_thread_id", in.SenderThreadID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc inbound counter applied",
+		"thread_id", live.ID, "remote_bank_code", in.SenderBankCode,
+		"quantity", live.Quantity)
 	return live, nil
 }
 
@@ -771,6 +837,8 @@ func (s *Service) ReceiveExternalOTCAccept(ctx context.Context, in ReceiveExtern
 		// accepting a thread we initiated, the partner_otc.go inbound
 		// route should never have routed it here.)
 		if t.Direction != domain.ExternalOTCIncoming {
+			s.log().WarnContext(ctx, "external otc inbound accept rejected: thread not incoming",
+				"thread_id", t.ID, "direction", string(t.Direction), "remote_bank_code", in.SenderBankCode)
 			return apperr.FailedPrecondition("partner može prihvatiti samo dolaznu nit")
 		}
 		if t.Status == domain.ExternalOTCThreadAccepted {
@@ -779,6 +847,8 @@ func (s *Service) ReceiveExternalOTCAccept(ctx context.Context, in ReceiveExtern
 			return nil
 		}
 		if t.Status != domain.ExternalOTCThreadOpen {
+			s.log().WarnContext(ctx, "external otc inbound accept rejected: thread not open",
+				"thread_id", t.ID, "status", string(t.Status), "remote_bank_code", in.SenderBankCode)
 			return apperr.FailedPrecondition("nit nije otvorena")
 		}
 		updated, err := s.Store.SetExternalOTCThreadStatus(ctx, tx, t.ID, domain.ExternalOTCThreadAccepted)
@@ -817,8 +887,14 @@ func (s *Service) ReceiveExternalOTCAccept(ctx context.Context, in ReceiveExtern
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc inbound accept failed", err,
+			"remote_bank_code", in.SenderBankCode, "remote_thread_id", in.SenderThreadID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc inbound accept: thread accepted, contract minted",
+		"thread_id", live.ID, "remote_bank_code", in.SenderBankCode,
+		"remote_thread_id", in.SenderThreadID, "ticker", live.SecurityTicker,
+		"quantity", live.Quantity)
 	return live, nil
 }
 
@@ -865,6 +941,9 @@ func (s *Service) ReceiveExternalOTCExerciseNotice(ctx context.Context, in Recei
 			return nil
 		}
 		if contract.Status != domain.ExternalOTCContractActive {
+			s.log().WarnContext(ctx, "external otc inbound exercise rejected: contract not active",
+				"contract_id", contract.ID, "status", string(contract.Status),
+				"remote_bank_code", in.SenderBankCode)
 			return apperr.FailedPrecondition("ugovor nije aktivan")
 		}
 		updated, err := s.Store.SetExternalOTCContractExercised(ctx, tx, contract.ID, derivedOpID, s.now())
@@ -874,8 +953,13 @@ func (s *Service) ReceiveExternalOTCExerciseNotice(ctx context.Context, in Recei
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc inbound exercise notice failed", err,
+			"remote_bank_code", in.SenderBankCode, "remote_contract_id", in.SenderContractID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc contract exercised via inbound notice",
+		"contract_id", live.ID, "thread_id", live.ThreadID,
+		"remote_bank_code", in.SenderBankCode, "exercise_op_id", derivedOpID)
 	return live, nil
 }
 
@@ -907,8 +991,13 @@ func (s *Service) setRemoteThreadStatus(ctx context.Context, bankCode, remoteThr
 		live = updated
 		return nil
 	}); err != nil {
+		s.logOpErr(ctx, "external otc thread status flip failed", err,
+			"remote_bank_code", bankCode, "remote_thread_id", remoteThreadID,
+			"target_status", string(status))
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc thread status flipped",
+		"thread_id", live.ID, "remote_bank_code", bankCode, "status", string(status))
 	return live, nil
 }
 
@@ -945,9 +1034,13 @@ func (s *Service) resolveSellerAccountNumber(ctx context.Context, h *domain.Hold
 	}
 	num, err := s.Reservations.AccountNumber(ctx, h.AccountID)
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc: seller account number lookup failed",
+			"err", err, "account_id", h.AccountID, "holding_id", h.ID)
 		return "", apperr.Internal("resolve seller account number", err)
 	}
 	if len(num) != 18 {
+		s.log().ErrorContext(ctx, "external otc: seller account number not 18 digits",
+			"account_id", h.AccountID, "len", len(num))
 		return "", apperr.Internal("seller account number nema 18 cifara", nil)
 	}
 	return num, nil

--- a/services/trading/internal/service/external_otc.go
+++ b/services/trading/internal/service/external_otc.go
@@ -186,7 +186,9 @@ func (s *Service) ListExternalPublicHoldings(ctx context.Context, bankCode, tick
 	}
 	holdings, err := s.PartnerOTC.Discover(ctx, bankCode, tickerFilter)
 	if err != nil {
-		s.log().ErrorContext(ctx, "external otc discovery failed",
+		// Discover only errors on an unconfigured bank_code (per-partner
+		// failures are logged inside the client) — client input, so Warn.
+		s.log().WarnContext(ctx, "external otc discovery failed",
 			"err", err, "remote_bank_code", bankCode, "ticker", tickerFilter)
 		return nil, err
 	}

--- a/services/trading/internal/service/external_otc_accept_saga.go
+++ b/services/trading/internal/service/external_otc_accept_saga.go
@@ -96,12 +96,20 @@ func (s *Service) acceptExternalOutgoing(ctx context.Context, thread *domain.Ext
 	// (modified_by_side = remote). Otherwise the buyer's accepting their
 	// own iteration.
 	if thread.ModifiedBySide != domain.ExternalOTCSideRemote {
+		s.log().WarnContext(ctx, "external otc accept rejected: not remote side's turn",
+			"thread_id", thread.ID, "remote_bank_code", thread.RemoteBankCode)
 		return nil, apperr.FailedPrecondition("druga strana je na potezu")
 	}
 	if thread.Status != domain.ExternalOTCThreadOpen {
+		s.log().WarnContext(ctx, "external otc accept rejected: thread not open",
+			"thread_id", thread.ID, "status", string(thread.Status),
+			"remote_bank_code", thread.RemoteBankCode)
 		return nil, apperr.FailedPrecondition("nit nije otvorena")
 	}
 	if thread.LocalRole != domain.ExternalOTCRoleBuyer {
+		s.log().WarnContext(ctx, "external otc accept rejected: local side is not buyer",
+			"thread_id", thread.ID, "local_role", string(thread.LocalRole),
+			"remote_bank_code", thread.RemoteBankCode)
 		return nil, apperr.FailedPrecondition("samo kupac može prihvatiti eksternu ponudu (za prodavca se koristi Receive*)")
 	}
 
@@ -142,23 +150,41 @@ func (s *Service) acceptExternalOutgoing(ctx context.Context, thread *domain.Ext
 		AttemptsMax:   8,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc accept saga failed",
+			"err", err, "transaction_id", txID, "thread_id", thread.ID,
+			"remote_bank_code", thread.RemoteBankCode)
 		return nil, fmt.Errorf("external otc accept saga: %w", err)
 	}
 	if row.Status != saga.StatusCompleted {
 		if row.Status == saga.StatusRunning {
+			s.log().WarnContext(ctx, "external otc accept saga parked for retry",
+				"transaction_id", txID, "thread_id", thread.ID,
+				"remote_bank_code", thread.RemoteBankCode, "last_error", row.LastError)
 			return nil, status.Error(codes.Unavailable, "external otc accept saga parked for retry")
 		}
+		s.log().ErrorContext(ctx, "external otc accept saga did not complete",
+			"transaction_id", txID, "thread_id", thread.ID,
+			"remote_bank_code", thread.RemoteBankCode,
+			"saga_status", string(row.Status), "last_error", row.LastError)
 		return nil, apperr.Internal("external otc accept saga did not complete", nil)
 	}
 
 	tFresh, err := s.Store.GetExternalOTCThread(ctx, thread.ID)
 	if err != nil {
+		s.logOpErr(ctx, "external otc accept: thread refetch failed", err,
+			"thread_id", thread.ID, "transaction_id", txID)
 		return nil, err
 	}
 	contract, err := s.Store.GetExternalOTCContractByThread(ctx, thread.ID)
 	if err != nil {
+		s.logOpErr(ctx, "external otc accept: contract fetch after saga failed", err,
+			"thread_id", thread.ID, "transaction_id", txID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "external otc accept saga completed; contract minted",
+		"transaction_id", txID, "thread_id", thread.ID, "contract_id", contract.ID,
+		"remote_bank_code", thread.RemoteBankCode, "ticker", thread.SecurityTicker,
+		"quantity", thread.Quantity)
 	return &AcceptExternalOTCOfferResult{Thread: tFresh, Contract: contract}, nil
 }
 
@@ -175,8 +201,13 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						// Partner (si-tx-proto/Banka-2) debits our buyer via an
 						// inbound NEW_TX during notify_partner_accept; nothing to
 						// prepare on our side.
+						sc.Log.DebugContext(ctx, "external otc accept: premium prepare skipped (partner coordinates)",
+							"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode)
 						return nil
 					}
+					sc.Log.DebugContext(ctx, "external otc accept: preparing premium leg",
+						"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode,
+						"premium", sc.State.Premium, "currency", sc.State.Currency)
 					_, err := svc.InterbankPayer.PreparePayment(ctx, PrepareInterbankInput{
 						SenderRoutingNumber: sc.State.SenderRoutingNumber,
 						TransactionID:       sc.TransactionID,
@@ -186,15 +217,28 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						Amount:              sc.State.Premium,
 						Purpose:             "OTC premija (eksterno) — nit " + sc.State.ThreadID,
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: premium prepare failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+					}
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
 					if sc.State.PartnerCoordinatesAccept {
 						return nil
 					}
-					return svc.InterbankPayer.RollbackPayment(ctx,
+					if err := svc.InterbankPayer.RollbackPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID,
-						"external otc accept compensation")
+						"external otc accept compensation"); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: premium rollback compensation failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc accept: premium reservation rolled back",
+						"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode)
+					return nil
 				},
 			},
 			// 2. Tell the partner we're accepting. They mint a contract
@@ -205,9 +249,12 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
 					settle, perr := time.Parse("2006-01-02", sc.State.SettlementDate)
 					if perr != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: bad settlement_date in saga state",
+							"err", perr, "thread_id", sc.State.ThreadID,
+							"settlement_date", sc.State.SettlementDate)
 						return status.Error(codes.InvalidArgument, "bad settlement_date")
 					}
-					return svc.PartnerOTC.Accept(ctx, PartnerActionInput{
+					if err := svc.PartnerOTC.Accept(ctx, PartnerActionInput{
 						RemoteBankCode: sc.State.RemoteBankCode,
 						RemoteThreadID: sc.State.RemoteThreadID,
 						LocalThreadID:  sc.State.ThreadID,
@@ -215,7 +262,17 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						PricePerUnit:   sc.State.PricePerUnit,
 						Premium:        sc.State.Premium,
 						SettlementDate: settle,
-					})
+					}); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: partner accept notification failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"remote_bank_code", sc.State.RemoteBankCode,
+							"remote_thread_id", sc.State.RemoteThreadID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc accept: partner acked accept",
+						"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode,
+						"remote_thread_id", sc.State.RemoteThreadID)
+					return nil
 				},
 				// No partner-side compensation primitive — we'd have to
 				// re-counter with the prior terms or call Withdraw. For
@@ -236,7 +293,16 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 					}
 					_, err := svc.InterbankPayer.CommitPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID)
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: premium commit failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc accept: premium committed",
+						"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode,
+						"premium", sc.State.Premium, "currency", sc.State.Currency)
+					return nil
 				},
 				// Commit's already moved money; rollback isn't safe.
 				// Compensation here would need a refund-in-the-opposite-
@@ -249,9 +315,12 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCAcceptPayload]) error {
 					settle, perr := time.Parse("2006-01-02", sc.State.SettlementDate)
 					if perr != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: bad settlement_date in saga state",
+							"err", perr, "thread_id", sc.State.ThreadID,
+							"settlement_date", sc.State.SettlementDate)
 						return status.Error(codes.InvalidArgument, "bad settlement_date")
 					}
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					err := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						_, ierr := svc.Store.InsertExternalOTCContract(ctx, tx, &domain.ExternalOTCContract{
 							ThreadID:           sc.State.ThreadID,
 							Direction:          domain.ExternalOTCOutgoing,
@@ -284,6 +353,16 @@ func registerExternalOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 							domain.ExternalOTCThreadAccepted)
 						return err
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "external otc accept: local contract create failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc accept: local contract created, thread accepted",
+						"thread_id", sc.State.ThreadID, "remote_bank_code", sc.State.RemoteBankCode,
+						"ticker", sc.State.SecurityTicker, "quantity", sc.State.Quantity)
+					return nil
 				},
 				// Compensation: delete the contract; flip the thread back
 				// to open. The bank-side legs are already committed; not

--- a/services/trading/internal/service/external_otc_exercise_saga.go
+++ b/services/trading/internal/service/external_otc_exercise_saga.go
@@ -84,9 +84,15 @@ func (s *Service) exerciseExternalOutgoing(ctx context.Context, contract *domain
 		return nil, apperr.FailedPrecondition("cross-bank infrastructure nije konfigurisana")
 	}
 	if contract.LocalRole != domain.ExternalOTCRoleBuyer {
+		s.log().WarnContext(ctx, "external otc exercise rejected: local side is not buyer",
+			"contract_id", contract.ID, "local_role", string(contract.LocalRole),
+			"remote_bank_code", contract.RemoteBankCode)
 		return nil, apperr.FailedPrecondition("samo kupac može iskoristiti opciju")
 	}
 	if contract.Status != domain.ExternalOTCContractActive {
+		s.log().WarnContext(ctx, "external otc exercise rejected: contract not active",
+			"contract_id", contract.ID, "status", string(contract.Status),
+			"remote_bank_code", contract.RemoteBankCode)
 		return nil, apperr.FailedPrecondition("ugovor nije aktivan")
 	}
 
@@ -94,6 +100,8 @@ func (s *Service) exerciseExternalOutgoing(ctx context.Context, contract *domain
 	qty, _ := money.Parse(fmt.Sprintf("%d", contract.Quantity))
 	strike, err := money.Parse(contract.StrikePrice)
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc exercise: strike price unparseable",
+			"err", err, "contract_id", contract.ID, "strike_price", contract.StrikePrice)
 		return nil, apperr.Internal("strike price unparseable", err)
 	}
 	total := money.Mul(qty, strike)
@@ -128,14 +136,29 @@ func (s *Service) exerciseExternalOutgoing(ctx context.Context, contract *domain
 		AttemptsMax:   8,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc exercise saga failed",
+			"err", err, "transaction_id", txID, "contract_id", contract.ID,
+			"remote_bank_code", contract.RemoteBankCode)
 		return nil, fmt.Errorf("external otc exercise saga: %w", err)
 	}
 	if row.Status != saga.StatusCompleted {
 		if row.Status == saga.StatusRunning {
+			s.log().WarnContext(ctx, "external otc exercise saga parked for retry",
+				"transaction_id", txID, "contract_id", contract.ID,
+				"remote_bank_code", contract.RemoteBankCode, "last_error", row.LastError)
 			return nil, status.Error(codes.Unavailable, "external otc exercise saga parked for retry")
 		}
+		s.log().ErrorContext(ctx, "external otc exercise saga did not complete",
+			"transaction_id", txID, "contract_id", contract.ID,
+			"remote_bank_code", contract.RemoteBankCode,
+			"saga_status", string(row.Status), "last_error", row.LastError)
 		return nil, apperr.Internal("external otc exercise saga did not complete", nil)
 	}
+	s.log().InfoContext(ctx, "external otc contract exercised",
+		"transaction_id", txID, "contract_id", contract.ID,
+		"thread_id", contract.ThreadID, "remote_bank_code", contract.RemoteBankCode,
+		"ticker", contract.SecurityTicker, "quantity", contract.Quantity,
+		"strike_total", payload.TotalAmount, "currency", payload.Currency)
 	return s.Store.GetExternalOTCContract(ctx, contract.ID)
 }
 
@@ -147,6 +170,9 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "prepare_strike",
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
+					sc.Log.DebugContext(ctx, "external otc exercise: preparing strike leg",
+						"contract_id", sc.State.ContractID, "remote_bank_code", sc.State.RemoteBankCode,
+						"strike_total", sc.State.TotalAmount, "currency", sc.State.Currency)
 					_, err := svc.InterbankPayer.PreparePayment(ctx, PrepareInterbankInput{
 						SenderRoutingNumber: sc.State.SenderRoutingNumber,
 						TransactionID:       sc.TransactionID,
@@ -156,12 +182,25 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						Amount:              sc.State.TotalAmount,
 						Purpose:             "OTC izvršenje (eksterno) — ugovor " + sc.State.ContractID,
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: strike prepare failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+					}
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
-					return svc.InterbankPayer.RollbackPayment(ctx,
+					if err := svc.InterbankPayer.RollbackPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID,
-						"external otc exercise compensation")
+						"external otc exercise compensation"); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: strike rollback compensation failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc exercise: strike reservation rolled back",
+						"contract_id", sc.State.ContractID, "remote_bank_code", sc.State.RemoteBankCode)
+					return nil
 				},
 			},
 			// Partner notification — there's no dedicated "Exercise" verb
@@ -185,7 +224,7 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 					// (OPTION-account legs release the seller shares + credit the
 					// strike) and drive it to COMMIT. A partner NO surfaces as a
 					// permanent error -> compensate the local strike reservation.
-					return svc.PartnerOTC.ExerciseOption(ctx, PartnerExerciseInput{
+					if err := svc.PartnerOTC.ExerciseOption(ctx, PartnerExerciseInput{
 						RemoteBankCode: sc.State.RemoteBankCode,
 						ContractID:     sc.State.RemoteThreadID,
 						TransactionID:  sc.TransactionID,
@@ -194,7 +233,17 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						StrikeTotal:    sc.State.TotalAmount,
 						Currency:       sc.State.Currency,
 						Ticker:         sc.State.SecurityTicker,
-					})
+					}); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: partner exercise 2pc failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"remote_bank_code", sc.State.RemoteBankCode,
+							"remote_thread_id", sc.State.RemoteThreadID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc exercise: partner exercise 2pc committed",
+						"contract_id", sc.State.ContractID, "remote_bank_code", sc.State.RemoteBankCode,
+						"ticker", sc.State.SecurityTicker, "quantity", sc.State.Quantity)
+					return nil
 				},
 				Compensate: nil,
 			},
@@ -203,7 +252,16 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
 					_, err := svc.InterbankPayer.CommitPayment(ctx,
 						sc.State.SenderRoutingNumber, sc.TransactionID)
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: strike commit failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"remote_bank_code", sc.State.RemoteBankCode)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc exercise: strike committed",
+						"contract_id", sc.State.ContractID, "remote_bank_code", sc.State.RemoteBankCode,
+						"strike_total", sc.State.TotalAmount, "currency", sc.State.Currency)
+					return nil
 				},
 				Compensate: nil,
 			},
@@ -221,14 +279,26 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 					if err != nil {
 						// Unknown ticker locally — strike already settled + contract
 						// exercised; skip delivery rather than strand the saga.
+						sc.Log.WarnContext(ctx, "external otc exercise: ticker unknown locally, skipping share delivery",
+							"err", err, "contract_id", sc.State.ContractID,
+							"ticker", sc.State.SecurityTicker, "quantity", sc.State.Quantity)
 						return nil
 					}
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					if err := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						_, aerr := svc.Store.ApplyBuyFill(ctx, tx, sc.State.LocalUserID,
 							sc.State.LocalUserKind, sec.ID, sc.State.LocalAccountID,
 							sc.State.Quantity, sc.State.StrikePrice)
 						return aerr
-					})
+					}); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: local share delivery failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"ticker", sc.State.SecurityTicker, "quantity", sc.State.Quantity)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc exercise: shares delivered to buyer",
+						"contract_id", sc.State.ContractID, "ticker", sc.State.SecurityTicker,
+						"quantity", sc.State.Quantity)
+					return nil
 				},
 				Compensate: nil,
 			},
@@ -236,11 +306,18 @@ func registerExternalOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 				Name: "mark_exercised",
 				Forward: func(ctx context.Context, sc *saga.Context[externalOTCExercisePayload]) error {
 					opID := deriveExternalCommitOpID(sc.State.SenderRoutingNumber, sc.TransactionID)
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					if err := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						_, merr := svc.Store.SetExternalOTCContractExercised(ctx, tx,
 							sc.State.ContractID, opID, time.Now())
 						return merr
-					})
+					}); err != nil {
+						sc.Log.ErrorContext(ctx, "external otc exercise: mark exercised failed",
+							"err", err, "contract_id", sc.State.ContractID, "exercise_op_id", opID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "external otc exercise: contract marked exercised",
+						"contract_id", sc.State.ContractID, "exercise_op_id", opID)
+					return nil
 				},
 				Compensate: nil,
 			},

--- a/services/trading/internal/service/external_otc_settlement.go
+++ b/services/trading/internal/service/external_otc_settlement.go
@@ -57,7 +57,13 @@ type SettleExternalOTCOptionResult struct {
 }
 
 func (s *Service) SettleExternalOTCOption(ctx context.Context, in SettleExternalOTCOptionInput) (*SettleExternalOTCOptionResult, error) {
-	senderRouting, _ := strconv.Atoi(in.SenderBankCode)
+	senderRouting, aerr := strconv.Atoi(in.SenderBankCode)
+	if aerr != nil {
+		// Routing 0 makes the contract lookup miss and the system vote NO
+		// with "contract not found" — surface the real cause here.
+		s.log().WarnContext(ctx, "external otc settlement: malformed sender bank code, routing treated as 0",
+			"err", aerr, "sender_bank_code", in.SenderBankCode, "transaction_id", in.TransactionID)
+	}
 	switch strings.ToLower(in.Phase) {
 	case "prepare":
 		return s.settleOTCPrepare(ctx, senderRouting, in)

--- a/services/trading/internal/service/external_otc_settlement.go
+++ b/services/trading/internal/service/external_otc_settlement.go
@@ -66,6 +66,9 @@ func (s *Service) SettleExternalOTCOption(ctx context.Context, in SettleExternal
 	case "rollback":
 		return s.settleOTCRollback(ctx, senderRouting, in)
 	default:
+		s.log().WarnContext(ctx, "external otc settlement: unknown phase",
+			"phase", in.Phase, "transaction_id", in.TransactionID,
+			"remote_bank_code", in.SenderBankCode)
 		return nil, apperr.Validation("nepoznata settlement faza")
 	}
 }
@@ -81,8 +84,14 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 	contract, err := s.Store.GetExternalOTCContractByThread(ctx, in.OptionRef)
 	if err != nil {
 		if isAppKind(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "external otc settlement prepare: negotiation not found, voting no",
+				"transaction_id", in.TransactionID, "option_ref", in.OptionRef,
+				"remote_bank_code", in.SenderBankCode)
 			return no("OPTION_NEGOTIATION_NOT_FOUND"), nil
 		}
+		s.log().ErrorContext(ctx, "external otc settlement prepare: contract lookup failed",
+			"err", err, "transaction_id", in.TransactionID, "option_ref", in.OptionRef,
+			"remote_bank_code", in.SenderBankCode)
 		return nil, err
 	}
 	res.SellerAccountNumber = contract.LocalAccountNumber
@@ -106,6 +115,9 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 		switch kind {
 		case domain.ExternalOTCSettlementKindAccept:
 			if contract.Status != domain.ExternalOTCContractActive {
+				s.log().WarnContext(ctx, "external otc settlement prepare: contract not active, voting no",
+					"transaction_id", in.TransactionID, "contract_id", contract.ID,
+					"status", string(contract.Status), "remote_bank_code", in.SenderBankCode)
 				res.Accepted = false
 				res.Reason = "OPTION_USED_OR_EXPIRED"
 				return nil
@@ -113,6 +125,9 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 			// Reserve the seller's shares for the life of the contract.
 			if _, err := s.Store.IncrementReservedHolding(ctx, tx, contract.SellerHoldingRef, contract.Quantity); err != nil {
 				if isAppKind(err, apperr.KindFailedPrecondition) {
+					s.log().WarnContext(ctx, "external otc settlement prepare: insufficient asset, voting no",
+						"err", err, "transaction_id", in.TransactionID, "contract_id", contract.ID,
+						"quantity", contract.Quantity, "remote_bank_code", in.SenderBankCode)
 					res.Accepted = false
 					res.Reason = "INSUFFICIENT_ASSET"
 					return nil
@@ -121,6 +136,9 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 			}
 		case domain.ExternalOTCSettlementKindExercise:
 			if contract.Status != domain.ExternalOTCContractActive {
+				s.log().WarnContext(ctx, "external otc settlement prepare: contract not active, voting no",
+					"transaction_id", in.TransactionID, "contract_id", contract.ID,
+					"status", string(contract.Status), "remote_bank_code", in.SenderBankCode)
 				res.Accepted = false
 				res.Reason = "OPTION_USED_OR_EXPIRED"
 				return nil
@@ -130,6 +148,10 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 				return err
 			}
 			if h.ReservedCount < contract.Quantity || h.Quantity < contract.Quantity {
+				s.log().WarnContext(ctx, "external otc settlement prepare: holding no longer covers contract, voting no",
+					"transaction_id", in.TransactionID, "contract_id", contract.ID,
+					"quantity", contract.Quantity, "reserved", h.ReservedCount,
+					"held", h.Quantity, "remote_bank_code", in.SenderBankCode)
 				res.Accepted = false
 				res.Reason = "INSUFFICIENT_ASSET"
 				return nil
@@ -153,7 +175,15 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 		return nil
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc settlement prepare failed",
+			"err", err, "transaction_id", in.TransactionID, "contract_id", contract.ID,
+			"kind", in.Kind, "remote_bank_code", in.SenderBankCode)
 		return nil, err
+	}
+	if res.Accepted {
+		s.log().InfoContext(ctx, "external otc settlement prepared",
+			"transaction_id", in.TransactionID, "contract_id", contract.ID,
+			"kind", in.Kind, "remote_bank_code", in.SenderBankCode)
 	}
 	return res, nil
 }
@@ -163,6 +193,8 @@ func (s *Service) settleOTCPrepare(ctx context.Context, senderRouting int, in Se
 // marks the contract exercised. Idempotent.
 func (s *Service) settleOTCCommit(ctx context.Context, senderRouting int, in SettleExternalOTCOptionInput) (*SettleExternalOTCOptionResult, error) {
 	res := &SettleExternalOTCOptionResult{}
+	// Captured for the post-tx log lines.
+	var logContractID, logKind string
 	err := s.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 		st, err := s.Store.GetExternalOTCSettlement(ctx, tx, senderRouting, in.TransactionID)
 		if err != nil {
@@ -181,6 +213,7 @@ func (s *Service) settleOTCCommit(ctx context.Context, senderRouting int, in Set
 		if err != nil {
 			return err
 		}
+		logContractID, logKind = contract.ID, st.Kind
 
 		if st.Kind == domain.ExternalOTCSettlementKindExercise {
 			h, err := s.Store.GetHoldingByID(ctx, contract.SellerHoldingRef)
@@ -239,7 +272,15 @@ func (s *Service) settleOTCCommit(ctx context.Context, senderRouting int, in Set
 		return nil
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc settlement commit failed",
+			"err", err, "transaction_id", in.TransactionID, "contract_id", logContractID,
+			"kind", logKind, "remote_bank_code", in.SenderBankCode)
 		return nil, err
+	}
+	if res.Handled && res.Accepted {
+		s.log().InfoContext(ctx, "external otc settlement committed",
+			"transaction_id", in.TransactionID, "contract_id", logContractID,
+			"kind", logKind, "remote_bank_code", in.SenderBankCode)
 	}
 	return res, nil
 }
@@ -278,7 +319,14 @@ func (s *Service) settleOTCRollback(ctx context.Context, senderRouting int, in S
 		return nil
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "external otc settlement rollback failed",
+			"err", err, "transaction_id", in.TransactionID,
+			"remote_bank_code", in.SenderBankCode)
 		return nil, err
+	}
+	if res.Handled {
+		s.log().InfoContext(ctx, "external otc settlement rolled back",
+			"transaction_id", in.TransactionID, "remote_bank_code", in.SenderBankCode)
 	}
 	return res, nil
 }

--- a/services/trading/internal/service/fund_dividends.go
+++ b/services/trading/internal/service/fund_dividends.go
@@ -119,6 +119,9 @@ func (s *Service) payFundDividend(ctx context.Context, c *store.DividendCandidat
 		}
 	}
 
+	s.log().InfoContext(ctx, "fund dividend paid",
+		"fund_id", f.ID, "payout_id", payout.ID,
+		"gross", grossStr, "currency", string(c.Currency))
 	return rsd, nil
 }
 
@@ -130,6 +133,10 @@ func (s *Service) payFundDividend(ctx context.Context, c *store.DividendCandidat
 func (s *Service) distributeFundDividend(ctx context.Context, f *domain.Fund, payout *domain.DividendPayout, rsd *big.Rat) error {
 	totalUnits, err := money.Parse(f.TotalUnits)
 	if err != nil || totalUnits.Sign() <= 0 {
+		if err != nil {
+			s.log().WarnContext(ctx, "fund total_units unparseable; skipping dividend distribution",
+				"err", err, "fund_id", f.ID, "total_units", f.TotalUnits)
+		}
 		return nil
 	}
 	positions, err := s.Store.ListFundPositions(ctx, store.FundPositionFilter{
@@ -146,6 +153,10 @@ func (s *Service) distributeFundDividend(ctx context.Context, f *domain.Fund, pa
 		for _, pos := range positions {
 			units, err := money.Parse(pos.Units)
 			if err != nil || units.Sign() <= 0 {
+				if err != nil {
+					s.log().WarnContext(ctx, "fund position units unparseable; skipping slice",
+						"err", err, "fund_id", f.ID, "client_id", pos.ClientID, "units", pos.Units)
+				}
 				continue
 			}
 			slice := fundDividendSlice(rsd, units, totalUnits)
@@ -214,6 +225,10 @@ func reinvestQuantity(gross, price *big.Rat) int32 {
 func (s *Service) reinvestFundDividend(ctx context.Context, f *domain.Fund, c *store.DividendCandidate) error {
 	price, err := money.Parse(c.Price)
 	if err != nil || price.Sign() <= 0 {
+		if err != nil {
+			s.log().WarnContext(ctx, "fund reinvest price unparseable; skipping",
+				"err", err, "fund_id", f.ID, "security_id", c.SecurityID, "price", c.Price)
+		}
 		return nil
 	}
 	// Whole-share quantity affordable with the (security-currency)
@@ -236,5 +251,9 @@ func (s *Service) reinvestFundDividend(ctx context.Context, f *domain.Fund, c *s
 		OrderType:  domain.OrderMarket,
 		// InitiatorUser empty — the cron owns the call, not a supervisor.
 	})
+	if err == nil {
+		s.log().InfoContext(ctx, "fund dividend reinvested",
+			"fund_id", f.ID, "security_id", c.SecurityID, "quantity", qty)
+	}
 	return err
 }

--- a/services/trading/internal/service/fund_invest_saga.go
+++ b/services/trading/internal/service/fund_invest_saga.go
@@ -218,7 +218,12 @@ func (s *Service) InvestInFund(ctx context.Context, in InvestInFundInput) (*Inve
 		AttemptsMax:   8,
 	})
 	if err != nil {
-		_ = s.markFundTxFailed(ctx, auditID, err.Error())
+		s.log().ErrorContext(ctx, "fund invest saga failed",
+			"err", err, "transaction_id", txID, "fund_id", f.ID)
+		if mErr := s.markFundTxFailed(ctx, auditID, err.Error()); mErr != nil {
+			s.log().WarnContext(ctx, "fund invest: mark tx failed errored",
+				"err", mErr, "transaction_id", txID, "fund_tx_id", auditID)
+		}
 		return nil, fmt.Errorf("fund invest saga: %w", err)
 	}
 	if row.Status != saga.StatusCompleted {
@@ -227,8 +232,13 @@ func (s *Service) InvestInFund(ctx context.Context, in InvestInFundInput) (*Inve
 		// polls/backoffs; recovery worker will drive it forward.
 		// See [[reference_saga_park_status_mapping]] for the pattern.
 		if row.Status == saga.StatusRunning {
+			s.log().WarnContext(ctx, "fund invest saga parked for retry",
+				"transaction_id", txID, "fund_id", f.ID, "last_error", row.LastError)
 			return nil, status.Error(codes.Unavailable, "fund invest saga parked for retry")
 		}
+		s.log().ErrorContext(ctx, "fund invest saga did not complete",
+			"transaction_id", txID, "fund_id", f.ID,
+			"saga_status", string(row.Status), "last_error", row.LastError)
 		return nil, apperr.Internal("fund invest saga did not complete", nil)
 	}
 
@@ -236,6 +246,9 @@ func (s *Service) InvestInFund(ctx context.Context, in InvestInFundInput) (*Inve
 	if err != nil {
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "fund invest completed",
+		"transaction_id", txID, "fund_id", f.ID,
+		"amount_rsd", payload.AmountRSD, "units_delta", payload.UnitsDelta)
 	return &InvestInFundResult{Transaction: final, SagaID: txID, Pending: false}, nil
 }
 

--- a/services/trading/internal/service/fund_withdraw_saga.go
+++ b/services/trading/internal/service/fund_withdraw_saga.go
@@ -582,6 +582,8 @@ func (s *Service) placeAutoLiquidationOrders(ctx context.Context, sc *saga.Conte
 		}
 		sec, err := s.Store.GetSecurity(ctx, h.SecurityID)
 		if err != nil {
+			s.logOpErr(ctx, "auto-liquidation: security lookup failed, holding skipped in ranking", err,
+				"fund_id", sc.State.FundID, "holding_id", h.ID, "security_id", h.SecurityID)
 			continue
 		}
 		if sec.Type == domain.SecurityForex || sec.Type == domain.SecurityOption {
@@ -591,6 +593,8 @@ func (s *Service) placeAutoLiquidationOrders(ctx context.Context, sc *saga.Conte
 		}
 		listing, err := s.Store.GetListingBySecurityID(ctx, sec.ID)
 		if err != nil {
+			s.logOpErr(ctx, "auto-liquidation: listing lookup failed, holding skipped in ranking", err,
+				"fund_id", sc.State.FundID, "holding_id", h.ID, "security_id", sec.ID)
 			continue
 		}
 		price, _ := money.Parse(listing.Price)

--- a/services/trading/internal/service/fund_withdraw_saga.go
+++ b/services/trading/internal/service/fund_withdraw_saga.go
@@ -254,10 +254,29 @@ func (s *Service) WithdrawFromFund(ctx context.Context, in WithdrawFromFundInput
 		AttemptsMax:   8,
 	})
 	if err != nil {
-		_ = s.markFundTxFailed(ctx, auditID, err.Error())
+		s.log().ErrorContext(ctx, "fund withdraw saga failed",
+			"err", err, "transaction_id", txID, "fund_id", f.ID)
+		if mErr := s.markFundTxFailed(ctx, auditID, err.Error()); mErr != nil {
+			s.log().WarnContext(ctx, "fund withdraw: mark tx failed errored",
+				"err", mErr, "transaction_id", txID, "fund_tx_id", auditID)
+		}
 		return nil, fmt.Errorf("fund withdraw saga: %w", err)
 	}
-	final, _ := s.Store.GetFundTransaction(ctx, auditID)
+	if row.Status == saga.StatusRunning {
+		s.log().WarnContext(ctx, "fund withdraw saga parked (pending liquidation/retry)",
+			"transaction_id", txID, "fund_id", f.ID, "last_error", row.LastError)
+	} else {
+		s.log().InfoContext(ctx, "fund withdraw completed",
+			"transaction_id", txID, "fund_id", f.ID,
+			"amount_rsd", payload.AmountRSD, "units_removed", payload.UnitsRemoved)
+	}
+	final, ferr := s.Store.GetFundTransaction(ctx, auditID)
+	if ferr != nil {
+		// Best-effort echo — the saga outcome stands; only the audit-row
+		// decoration is lost.
+		s.log().WarnContext(ctx, "fund withdraw: audit row refetch failed",
+			"err", ferr, "transaction_id", txID, "fund_tx_id", auditID)
+	}
 	return &WithdrawFromFundResult{
 		Transaction: final,
 		SagaID:      txID,

--- a/services/trading/internal/service/funds.go
+++ b/services/trading/internal/service/funds.go
@@ -228,10 +228,13 @@ func (s *Service) CreateFund(ctx context.Context, in CreateFundInput) (*tdomain.
 		}
 	}
 	if s.Reservations == nil {
+		s.log().ErrorContext(ctx, "create fund: bank client not wired", "fund_name", name)
 		return nil, apperr.Internal("bank client not wired", nil)
 	}
 	accountID, err := s.Reservations.CreateFundAccount(ctx, name, tdomain.CurrencyRSD)
 	if err != nil {
+		s.log().ErrorContext(ctx, "create fund: bank fund-account create failed",
+			"err", err, "fund_name", name)
 		return nil, fmt.Errorf("bank.CreateFundAccount: %w", err)
 	}
 	f := &tdomain.Fund{
@@ -243,7 +246,16 @@ func (s *Service) CreateFund(ctx context.Context, in CreateFundInput) (*tdomain.
 		TotalUnits:          "0",
 		Status:              tdomain.FundActive,
 	}
-	return s.Store.InsertFund(ctx, f)
+	out, err := s.Store.InsertFund(ctx, f)
+	if err != nil {
+		s.logOpErr(ctx, "fund create failed", err,
+			"fund_name", name, "bank_account_id", accountID)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "fund created",
+		"fund_id", out.ID, "fund_name", out.Name, "manager_user_id", out.ManagerUserID,
+		"bank_account_id", out.BankAccountID)
+	return out, nil
 }
 
 // SetFundReinvestDividends toggles the fund's dividend-reinvestment flag
@@ -265,7 +277,15 @@ func (s *Service) SetFundReinvestDividends(ctx context.Context, fundID string, e
 	if err := requireFundManager(p, f); err != nil {
 		return nil, err
 	}
-	return s.Store.SetFundReinvestDividends(ctx, fundID, enabled)
+	out, err := s.Store.SetFundReinvestDividends(ctx, fundID, enabled)
+	if err != nil {
+		s.logOpErr(ctx, "fund reinvest-dividends flip failed", err,
+			"fund_id", fundID, "enabled", enabled)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "fund reinvest-dividends flag set",
+		"fund_id", fundID, "enabled", enabled)
+	return out, nil
 }
 
 // ListFundDividends returns the per-client distribution history for a

--- a/services/trading/internal/service/funds.go
+++ b/services/trading/internal/service/funds.go
@@ -378,14 +378,20 @@ func (s *Service) fundHoldingsValueRSD(ctx context.Context, fundID string) (stri
 	for _, h := range holdings {
 		sec, err := s.Store.GetSecurity(ctx, h.SecurityID)
 		if err != nil {
+			s.logOpErr(ctx, "fund value: security lookup failed, holding dropped from total", err,
+				"fund_id", fundID, "holding_id", h.ID, "security_id", h.SecurityID)
 			continue
 		}
 		listing, err := s.Store.GetListingBySecurityID(ctx, sec.ID)
 		if err != nil {
+			s.logOpErr(ctx, "fund value: listing lookup failed, holding dropped from total", err,
+				"fund_id", fundID, "holding_id", h.ID, "security_id", sec.ID)
 			continue
 		}
 		price, err := money.Parse(listing.Price)
 		if err != nil {
+			s.log().ErrorContext(ctx, "fund value: listing price parse failed, holding dropped from total",
+				"err", err, "fund_id", fundID, "holding_id", h.ID, "security_id", sec.ID, "price", listing.Price)
 			continue
 		}
 		cs, err := money.Parse(listing.ContractSize)
@@ -398,9 +404,15 @@ func (s *Service) fundHoldingsValueRSD(ctx context.Context, fundID string) (stri
 		if sec.Currency != tdomain.CurrencyRSD && sec.Currency != "" && s.Rates != nil {
 			_, ask, err := s.Rates.Quote(ctx, sec.Currency, tdomain.CurrencyRSD)
 			if err == nil {
-				if r, err := money.Parse(ask); err == nil {
+				if r, perr := money.Parse(ask); perr == nil {
 					notional = money.Mul(notional, r)
+				} else {
+					s.log().ErrorContext(ctx, "fund value: rate ask parse failed, amount counted unconverted",
+						"err", perr, "currency", sec.Currency, "security_id", sec.ID, "fund_id", fundID, "ask", ask)
 				}
+			} else {
+				s.log().ErrorContext(ctx, "fund value: fx quote failed, amount counted unconverted",
+					"err", err, "currency", sec.Currency, "security_id", sec.ID, "fund_id", fundID)
 			}
 		}
 		total = money.Add(total, notional)
@@ -585,6 +597,8 @@ func (s *Service) ListFundPositions(ctx context.Context, in ListFundPositionsInp
 	for _, pos := range rows {
 		f, err := s.Store.GetFund(ctx, pos.FundID)
 		if err != nil {
+			s.log().WarnContext(ctx, "fund positions: fund lookup failed, row dropped",
+				"err", err, "fund_id", pos.FundID, "position_id", pos.ID)
 			continue
 		}
 		dec := s.decorateFund(ctx, f)

--- a/services/trading/internal/service/interbank_retry.go
+++ b/services/trading/internal/service/interbank_retry.go
@@ -82,6 +82,7 @@ func (s *Service) RunInterbankRetryTick(ctx context.Context) (int, error) {
 	now := s.now()
 	entries, err := s.Store.ListDueInterbankRetries(ctx, now)
 	if err != nil {
+		s.log().ErrorContext(ctx, "interbank retry: due-entry scan failed", "err", err)
 		return 0, err
 	}
 	settled := 0
@@ -206,7 +207,14 @@ func (s *Service) releaseLocalReservation(ctx context.Context, txID string) {
 		return
 	}
 	row, err := s.SagaStore.Get(ctx, txID)
-	if err != nil || row == nil {
+	if err != nil {
+		s.log().WarnContext(ctx, "interbank retry: saga load for rollback failed",
+			"err", err, "transaction_id", txID)
+		return
+	}
+	if row == nil {
+		s.log().WarnContext(ctx, "interbank retry: saga not found for rollback",
+			"transaction_id", txID)
 		return
 	}
 	var payload crossBankPaymentPayload

--- a/services/trading/internal/service/listings.go
+++ b/services/trading/internal/service/listings.go
@@ -31,9 +31,16 @@ func (s *Service) UpsertListing(ctx context.Context, in *domain.Listing) (*domai
 		in.ChangeAmt = "0"
 	}
 	if _, err := s.Store.GetSecurity(ctx, in.SecurityID); err != nil {
+		s.log().WarnContext(ctx, "upsert listing security lookup failed",
+			"err", err, "security_id", in.SecurityID)
 		return nil, err
 	}
-	return s.Store.UpsertListing(ctx, in)
+	l, err := s.Store.UpsertListing(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "listing upserted", "listing_id", l.ID, "security_id", l.SecurityID)
+	return l, nil
 }
 
 // GetListing returns one listing.

--- a/services/trading/internal/service/marketdata.go
+++ b/services/trading/internal/service/marketdata.go
@@ -195,6 +195,8 @@ func (m *MarketData) BackfillStockHistory(ctx context.Context) (*StockHistoryBac
 		for _, b := range bars {
 			bid, ask, serr := stockSpread(b.Close, m.StockSpread)
 			if serr != nil {
+				m.Log.WarnContext(ctx, "stock-history backfill: spread compute failed, bar dropped",
+					"err", serr, "symbol", sym, "date", b.Date, "close", b.Close)
 				continue
 			}
 			change, cerr := changeAmt(prev, b.Close)

--- a/services/trading/internal/service/orders.go
+++ b/services/trading/internal/service/orders.go
@@ -249,8 +249,15 @@ func (s *Service) CreateOrder(ctx context.Context, in CreateOrderInput) (*Create
 	}
 	out, err := s.Store.CreateOrder(ctx, o)
 	if err != nil {
+		s.logOpErr(ctx, "order create failed", err,
+			"security_id", in.SecurityID, "direction", string(in.Direction),
+			"order_type", string(in.OrderType), "quantity", in.Quantity)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "order created",
+		"order_id", out.ID, "security_id", out.SecurityID, "ticker", sec.Ticker,
+		"direction", string(out.Direction), "order_type", string(out.OrderType),
+		"quantity", out.Quantity, "status", string(out.Status))
 	// Charge the agent's used_limit on auto-approved trades so the cap
 	// holds even when no supervisor approval was needed.
 	if status == domain.OrderStatusApproved && permissions.Has(p.Permissions, permissions.ActuaryAgent) {
@@ -363,8 +370,11 @@ func (s *Service) ApproveOrder(ctx context.Context, id string) (*domain.Order, e
 	}
 	out, err := s.Store.ApproveOrder(ctx, id, p.UserID)
 	if err != nil {
+		s.logOpErr(ctx, "order approve failed", err, "order_id", id)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "order approved",
+		"order_id", id, "approved_by", p.UserID)
 	// If the order belongs to an agent, charge the limit. We do this
 	// after the row-update so the audit stays clean even if the limit
 	// math fails — the supervisor can still see the order as approved.
@@ -390,8 +400,11 @@ func (s *Service) DeclineOrder(ctx context.Context, id, reason string) (*domain.
 	}
 	out, err := s.Store.DeclineOrder(ctx, id, p.UserID)
 	if err != nil {
+		s.logOpErr(ctx, "order decline failed", err, "order_id", id)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "order declined",
+		"order_id", id, "declined_by", p.UserID)
 	// S22: supervisor declined the order.
 	s.notifyOrderDeclined(ctx, out)
 	// S41 "odbijanje ordera": record the decline against the order id;
@@ -442,16 +455,21 @@ func (s *Service) CancelOrder(ctx context.Context, id string, partialQty int32) 
 	if fullCancel {
 		out, err = s.Store.CancelOrder(ctx, id)
 		if err != nil {
+			s.logOpErr(ctx, "order cancel failed", err, "order_id", id)
 			return nil, err
 		}
 		cancelledQty = cur.RemainingQuantity
 	} else {
 		out, err = s.Store.PartialCancelOrder(ctx, id, partialQty)
 		if err != nil {
+			s.logOpErr(ctx, "order partial cancel failed", err,
+				"order_id", id, "partial_qty", partialQty)
 			return nil, err
 		}
 		cancelledQty = partialQty
 	}
+	s.log().InfoContext(ctx, "order cancelled",
+		"order_id", id, "cancelled_qty", cancelledQty, "full_cancel", fullCancel)
 	if cur.Status == domain.OrderStatusApproved && cur.UserKind == domain.KindEmployee && cur.IsActuary {
 		s.maybeRefundAgentLimitQty(ctx, cur, cancelledQty)
 	}
@@ -692,10 +710,14 @@ func (s *Service) agentNeedsApproval(
 	}
 	limit, err := money.Parse(info.DailyLimit)
 	if err != nil {
+		s.log().ErrorContext(ctx, "agent daily_limit unparseable",
+			"err", err, "employee_id", employeeID, "daily_limit", info.DailyLimit)
 		return false, false, apperr.Internal("agent daily_limit unparseable", err)
 	}
 	used, err := money.Parse(info.UsedLimit)
 	if err != nil {
+		s.log().ErrorContext(ctx, "agent used_limit unparseable",
+			"err", err, "employee_id", employeeID, "used_limit", info.UsedLimit)
 		return false, false, apperr.Internal("agent used_limit unparseable", err)
 	}
 	// Spec p.38 reserves daily_limit=0 for supervisors (who have no cap).
@@ -1017,5 +1039,15 @@ func (s *Service) createFundActorOrder(ctx context.Context, in fundActorOrderInp
 		AfterHours:       afterHours,
 		ApprovedBy:       in.InitiatorUser,
 	}
-	return s.Store.CreateOrder(ctx, o)
+	out, err := s.Store.CreateOrder(ctx, o)
+	if err != nil {
+		s.logOpErr(ctx, "fund actor order create failed", err,
+			"fund_id", in.FundID, "security_id", in.SecurityID,
+			"direction", string(in.Direction), "quantity", in.Quantity)
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "fund actor order created",
+		"order_id", out.ID, "fund_id", in.FundID, "ticker", sec.Ticker,
+		"direction", string(out.Direction), "quantity", out.Quantity)
+	return out, nil
 }

--- a/services/trading/internal/service/otc.go
+++ b/services/trading/internal/service/otc.go
@@ -117,6 +117,9 @@ func (s *Service) ListPublicHoldings(ctx context.Context, tickerFilter string) (
 		}
 		if listing, err := s.Store.GetListingBySecurityID(ctx, sec.ID); err == nil {
 			row.CurrentPrice = listing.Price
+		} else if !isAppKind(err, apperr.KindNotFound) {
+			s.log().WarnContext(ctx, "public holding listing lookup failed",
+				"err", err, "security_id", sec.ID, "holding_id", h.ID)
 		}
 		// Spec p.67: an actuary's holding is held "in the name of the
 		// bank", so on the supervisor-side board the Owner column shows
@@ -229,6 +232,10 @@ func (s *Service) SuggestOTCMatches(ctx context.Context, in SuggestOTCMatchInput
 		}
 		listing, err := s.Store.GetListingBySecurityID(ctx, sec.ID)
 		if err != nil {
+			if !isAppKind(err, apperr.KindNotFound) {
+				s.log().WarnContext(ctx, "otc suggestion listing lookup failed",
+					"err", err, "security_id", sec.ID, "holding_id", h.ID)
+			}
 			continue // no priceable listing → can't band-match
 		}
 		unit, err := money.Parse(listing.Price)
@@ -388,9 +395,14 @@ func (s *Service) CreateOTCOffer(ctx context.Context, in CreateOTCOfferInput) (*
 		}
 		available := locked.PublicCount - locked.ReservedCount
 		if available <= 0 {
+			s.log().WarnContext(ctx, "otc offer rejected: holding no longer available",
+				"seller_holding_id", locked.ID, "ticker", sec.Ticker)
 			return apperr.FailedPrecondition("hartija više nije dostupna na OTC")
 		}
 		if in.Quantity > available {
+			s.log().WarnContext(ctx, "otc offer rejected: insufficient available shares",
+				"seller_holding_id", locked.ID, "ticker", sec.Ticker,
+				"requested", in.Quantity, "available", available)
 			return apperr.FailedPrecondition("nedovoljno raspoloživih akcija")
 		}
 		if _, err := s.Store.IncrementReservedHolding(ctx, tx, locked.ID, in.Quantity); err != nil {
@@ -421,8 +433,15 @@ func (s *Service) CreateOTCOffer(ctx context.Context, in CreateOTCOfferInput) (*
 		return nil
 	})
 	if err != nil {
+		s.logOpErr(ctx, "otc offer create failed", err,
+			"seller_holding_id", in.SellerHoldingID, "ticker", sec.Ticker,
+			"quantity", in.Quantity)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "otc offer created",
+		"thread_id", out.ThreadID, "offer_id", out.ID,
+		"seller_holding_id", out.SellerHoldingID, "ticker", sec.Ticker,
+		"quantity", out.Quantity)
 	if s.OTCNotifier != nil {
 		s.OTCNotifier.OnOTCCounterOffer(ctx, out, out.SellerID, out.SellerKind)
 	}
@@ -471,6 +490,8 @@ func (s *Service) CounterOfferOTC(ctx context.Context, in CounterOfferOTCInput) 
 			return apperr.PermissionDenied("niste strana u ovoj pregovaračkoj niti")
 		}
 		if open.ModifiedBy == p.UserID {
+			s.log().WarnContext(ctx, "otc counter rejected: not caller's turn",
+				"thread_id", in.ThreadID, "offer_id", open.ID)
 			return apperr.FailedPrecondition("čeka se odgovor druge strane")
 		}
 
@@ -515,8 +536,12 @@ func (s *Service) CounterOfferOTC(ctx context.Context, in CounterOfferOTCInput) 
 		return nil
 	})
 	if err != nil {
+		s.logOpErr(ctx, "otc counter failed", err,
+			"thread_id", in.ThreadID, "quantity", in.Quantity)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "otc counter applied",
+		"thread_id", out.ThreadID, "offer_id", out.ID, "quantity", out.Quantity)
 	if s.OTCNotifier != nil {
 		recipient, kind := otherParty(out, p.UserID)
 		s.OTCNotifier.OnOTCCounterOffer(ctx, out, recipient, kind)
@@ -559,8 +584,11 @@ func (s *Service) WithdrawOTCOffer(ctx context.Context, threadID string) (*domai
 		return nil
 	})
 	if err != nil {
+		s.logOpErr(ctx, "otc withdraw failed", err, "thread_id", threadID)
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "otc offer withdrawn",
+		"thread_id", out.ThreadID, "offer_id", out.ID)
 	if s.OTCNotifier != nil {
 		recipient, kind := otherParty(out, p.UserID)
 		s.OTCNotifier.OnOTCWithdrawn(ctx, out, recipient, kind)
@@ -630,8 +658,12 @@ func (s *Service) terminateOTCOffer(ctx context.Context, threadID string, target
 		return nil
 	})
 	if err != nil {
+		s.logOpErr(ctx, "otc offer termination failed", err,
+			"thread_id", threadID, "target_status", string(target))
 		return nil, err
 	}
+	s.log().InfoContext(ctx, "otc offer terminated",
+		"thread_id", out.ThreadID, "offer_id", out.ID, "status", string(target))
 	if s.OTCNotifier != nil {
 		recipient, kind := otherParty(out, p.UserID)
 		s.OTCNotifier.OnOTCOfferStateChanged(ctx, out, recipient, kind)
@@ -725,6 +757,11 @@ func (s *Service) GetOTCThread(ctx context.Context, threadID string) (*GetOTCThr
 	res := &GetOTCThreadResult{Iterations: iters}
 	if c, err := s.Store.GetOTCContractByThread(ctx, threadID); err == nil {
 		res.Contract = c
+	} else if !isAppKind(err, apperr.KindNotFound) {
+		// Best-effort decoration — absence is normal, anything else is
+		// a real lookup failure being swallowed.
+		s.log().WarnContext(ctx, "otc thread contract lookup failed",
+			"err", err, "thread_id", threadID)
 	}
 	return res, nil
 }

--- a/services/trading/internal/service/otc_accept_saga.go
+++ b/services/trading/internal/service/otc_accept_saga.go
@@ -107,6 +107,8 @@ func (s *Service) AcceptOTCOffer(ctx context.Context, in AcceptOTCOfferInput) (*
 		return nil, apperr.PermissionDenied("niste strana u niti")
 	}
 	if open.ModifiedBy == p.UserID {
+		s.log().WarnContext(ctx, "otc accept rejected: caller cannot accept own iteration",
+			"thread_id", in.ThreadID, "offer_id", open.ID)
 		return nil, apperr.FailedPrecondition("ne možete da prihvatite sopstvenu iteraciju")
 	}
 
@@ -147,6 +149,9 @@ func (s *Service) AcceptOTCOffer(ctx context.Context, in AcceptOTCOfferInput) (*
 		AttemptsMax:   8,
 	})
 	if err != nil {
+		s.log().ErrorContext(ctx, "otc accept saga failed",
+			"err", err, "transaction_id", txID, "thread_id", open.ThreadID,
+			"offer_id", open.ID)
 		return nil, fmt.Errorf("otc accept saga: %w", err)
 	}
 	if row.Status != saga.StatusCompleted {
@@ -155,16 +160,28 @@ func (s *Service) AcceptOTCOffer(ctx context.Context, in AcceptOTCOfferInput) (*
 		// polls/backoffs; recovery worker will drive it forward.
 		// See [[reference_saga_park_status_mapping]] for the pattern.
 		if row.Status == saga.StatusRunning {
+			s.log().WarnContext(ctx, "otc accept saga parked for retry",
+				"transaction_id", txID, "thread_id", open.ThreadID,
+				"last_error", row.LastError)
 			return nil, status.Error(codes.Unavailable, "otc accept saga parked for retry")
 		}
+		s.log().ErrorContext(ctx, "otc accept saga did not complete",
+			"transaction_id", txID, "thread_id", open.ThreadID,
+			"saga_status", string(row.Status), "last_error", row.LastError)
 		return nil, apperr.Internal("otc accept saga did not complete", nil)
 	}
 
 	contract, err := s.Store.GetOTCContractByThread(ctx, open.ThreadID)
 	if err != nil {
+		s.logOpErr(ctx, "otc accept: contract fetch after saga failed", err,
+			"thread_id", open.ThreadID, "transaction_id", txID)
 		return nil, err
 	}
 	premiumOp := saga.DeriveOpID(txID, "transfer_premium")
+	s.log().InfoContext(ctx, "otc offer accepted; contract minted",
+		"transaction_id", txID, "thread_id", open.ThreadID,
+		"contract_id", contract.ID, "quantity", contract.Quantity,
+		"premium", contract.PremiumPaid, "currency", string(contract.Currency))
 	if s.OTCNotifier != nil {
 		recipient, kind := otherContractParty(contract, p.UserID)
 		s.OTCNotifier.OnOTCAccepted(ctx, contract, recipient, kind)
@@ -182,6 +199,9 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "reserve_buyer_premium",
 				Forward: func(ctx context.Context, sc *saga.Context[otcAcceptSagaPayload]) error {
+					sc.Log.DebugContext(ctx, "otc accept: reserving buyer premium",
+						"thread_id", sc.State.ThreadID, "premium", sc.State.Premium,
+						"currency", sc.State.Currency)
 					_, err := svc.Reservations.Reserve(ctx, ReserveInput{
 						AccountID: sc.State.BuyerAccountID,
 						Amount:    sc.State.Premium,
@@ -189,11 +209,24 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						OpID:      sc.OpID,
 						OpKind:    "otc_premium",
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: buyer premium reserve failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"buyer_account_id", sc.State.BuyerAccountID,
+							"premium", sc.State.Premium)
+					}
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[otcAcceptSagaPayload]) error {
 					_, err := svc.Reservations.Release(ctx, sc.OpID)
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: premium reservation release compensation failed",
+							"err", err, "thread_id", sc.State.ThreadID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc accept: premium reservation released",
+						"thread_id", sc.State.ThreadID)
+					return nil
 				},
 			},
 			// Step 2: verify the seller's holding still reserves at
@@ -205,9 +238,16 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[otcAcceptSagaPayload]) error {
 					h, err := svc.Store.GetHoldingByID(ctx, sc.State.SellerHoldingID)
 					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: seller holding lookup failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"seller_holding_id", sc.State.SellerHoldingID)
 						return err
 					}
 					if h.ReservedCount < sc.State.Quantity {
+						sc.Log.WarnContext(ctx, "otc accept: seller holding reservation insufficient",
+							"thread_id", sc.State.ThreadID,
+							"seller_holding_id", sc.State.SellerHoldingID,
+							"reserved", h.ReservedCount, "quantity", sc.State.Quantity)
 						return status.Error(codes.FailedPrecondition,
 							"seller holding reservation insufficient")
 					}
@@ -229,7 +269,16 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						IsActuary:     sc.State.IsActuary,
 						Purpose:       "OTC premija — nit " + sc.State.ThreadID,
 					})
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: premium transfer failed",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"premium", sc.State.Premium, "currency", sc.State.Currency)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc accept: premium transferred to seller",
+						"thread_id", sc.State.ThreadID, "premium", sc.State.Premium,
+						"currency", sc.State.Currency)
+					return nil
 				},
 				// Best-effort compensation: re-release. Once a commit
 				// has succeeded, the bank's reservation row is
@@ -243,6 +292,10 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 				Compensate: func(ctx context.Context, sc *saga.Context[otcAcceptSagaPayload]) error {
 					reserveOp := saga.DeriveOpID(sc.TransactionID, "reserve_buyer_premium")
 					_, err := svc.Reservations.Release(ctx, reserveOp)
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: premium transfer compensation failed",
+							"err", err, "thread_id", sc.State.ThreadID)
+					}
 					return err
 				},
 			},
@@ -253,9 +306,12 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 					premiumOp := saga.DeriveOpID(sc.TransactionID, "transfer_premium")
 					settlement, err := time.Parse("2006-01-02", sc.State.SettlementDate)
 					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: bad settlement_date in saga state",
+							"err", err, "thread_id", sc.State.ThreadID,
+							"settlement_date", sc.State.SettlementDate)
 						return status.Error(codes.InvalidArgument, "bad settlement_date")
 					}
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					txErr := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						_, err := svc.Store.InsertOTCContract(ctx, tx, &domain.OTCContract{
 							ThreadID:        sc.State.ThreadID,
 							SecurityID:      sc.State.SecurityID,
@@ -279,9 +335,18 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						}
 						return svc.Store.MarkAllOTCOffersAcceptedInThread(ctx, tx, sc.State.ThreadID, sc.State.OfferID)
 					})
+					if txErr != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: contract create failed",
+							"err", txErr, "thread_id", sc.State.ThreadID, "offer_id", sc.State.OfferID)
+						return txErr
+					}
+					sc.Log.InfoContext(ctx, "otc accept: contract created, thread accepted",
+						"thread_id", sc.State.ThreadID, "offer_id", sc.State.OfferID,
+						"quantity", sc.State.Quantity)
+					return nil
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[otcAcceptSagaPayload]) error {
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					err := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						if err := svc.Store.DeleteOTCContractByThread(ctx, tx, sc.State.ThreadID); err != nil {
 							return err
 						}
@@ -290,6 +355,11 @@ func registerOTCAcceptSaga(reg *saga.Registry, svc *Service) {
 						_, err := svc.Store.MarkOTCOfferStatus(ctx, tx, sc.State.OfferID, domain.OTCStatusOpen)
 						return err
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc accept: contract create compensation failed",
+							"err", err, "thread_id", sc.State.ThreadID, "offer_id", sc.State.OfferID)
+					}
+					return err
 				},
 			},
 		},

--- a/services/trading/internal/service/otc_exercise_saga.go
+++ b/services/trading/internal/service/otc_exercise_saga.go
@@ -119,9 +119,13 @@ func (s *Service) ExerciseOTCContract(ctx context.Context, in ExerciseOTCContrac
 		}
 	}
 	if c.Status != domain.OTCContractActive {
+		s.log().WarnContext(ctx, "otc exercise rejected: contract not active",
+			"contract_id", c.ID, "status", string(c.Status))
 		return nil, apperr.FailedPrecondition("ugovor nije aktivan")
 	}
 	if !c.SettlementDate.After(s.now()) {
+		s.log().WarnContext(ctx, "otc exercise rejected: contract expired",
+			"contract_id", c.ID, "settlement_date", c.SettlementDate)
 		return nil, apperr.FailedPrecondition("ugovor je istekao")
 	}
 
@@ -129,6 +133,8 @@ func (s *Service) ExerciseOTCContract(ctx context.Context, in ExerciseOTCContrac
 	q := new(big.Rat).SetInt64(int64(c.Quantity))
 	strike, err := money.Parse(c.StrikePrice)
 	if err != nil {
+		s.log().ErrorContext(ctx, "otc exercise: strike price unparseable",
+			"err", err, "contract_id", c.ID, "strike_price", c.StrikePrice)
 		return nil, apperr.Internal("strike parse", err)
 	}
 	total := money.Mul(q, strike)
@@ -166,6 +172,9 @@ func (s *Service) ExerciseOTCContract(ctx context.Context, in ExerciseOTCContrac
 		// "internal error". The saga rolled forward+compensated
 		// already; this is a business-rule failure, not a system
 		// fault, so map it to FailedPrecondition.
+		s.log().WarnContext(ctx, "otc exercise saga rolled back",
+			"err", err, "transaction_id", txID, "contract_id", c.ID,
+			"thread_id", c.ThreadID, "last_error", sagaFailureMessage(row, err))
 		return nil, apperr.FailedPrecondition(sagaFailureMessage(row, err))
 	}
 	if row.Status != saga.StatusCompleted {
@@ -176,25 +185,44 @@ func (s *Service) ExerciseOTCContract(ctx context.Context, in ExerciseOTCContrac
 		// caller knows to poll/backoff rather than treating this as
 		// a permanent failure (c4-aggressive W4 expects 503 here).
 		if row.Status == saga.StatusRunning {
+			s.log().WarnContext(ctx, "otc exercise saga parked for retry",
+				"transaction_id", txID, "contract_id", c.ID,
+				"last_error", row.LastError)
 			return nil, status.Error(codes.Unavailable, sagaFailureMessage(row, nil))
 		}
+		s.log().WarnContext(ctx, "otc exercise saga did not complete",
+			"transaction_id", txID, "contract_id", c.ID,
+			"saga_status", string(row.Status), "last_error", row.LastError)
 		return nil, apperr.FailedPrecondition(sagaFailureMessage(row, nil))
 	}
 
 	// Reload + return final state.
 	finalRow, err := s.SagaStore.Get(ctx, txID)
 	if err != nil {
+		s.logOpErr(ctx, "otc exercise: saga row reload failed", err,
+			"transaction_id", txID, "contract_id", c.ID)
 		return nil, err
 	}
 	var finalPayload otcExerciseSagaPayload
 	if finalRow != nil && len(finalRow.State) > 0 {
-		_ = json.Unmarshal(finalRow.State, &finalPayload)
+		if uerr := json.Unmarshal(finalRow.State, &finalPayload); uerr != nil {
+			// Best-effort decoration — the contract is already exercised;
+			// only the realized-gain echo is lost.
+			s.log().WarnContext(ctx, "otc exercise: final saga state decode failed",
+				"err", uerr, "transaction_id", txID, "contract_id", c.ID)
+		}
 	}
 	updated, err := s.Store.GetOTCContract(ctx, c.ID)
 	if err != nil {
+		s.logOpErr(ctx, "otc exercise: contract refetch failed", err,
+			"contract_id", c.ID, "transaction_id", txID)
 		return nil, err
 	}
 	strikeOp := saga.DeriveOpID(txID, "transfer_strike")
+	s.log().InfoContext(ctx, "otc contract exercised",
+		"transaction_id", txID, "contract_id", c.ID, "thread_id", c.ThreadID,
+		"quantity", c.Quantity, "strike_total", payload.TotalAmount,
+		"currency", payload.Currency, "seller_gain_native", finalPayload.RealizedGainNative)
 	return &ExerciseOTCContractResult{
 		Contract:                 updated,
 		StrikeOpID:               strikeOp,
@@ -216,6 +244,9 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 			{
 				Name: "reserve_buyer_strike",
 				Forward: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
+					sc.Log.DebugContext(ctx, "otc exercise: reserving buyer strike",
+						"contract_id", sc.State.ContractID, "strike_total", sc.State.TotalAmount,
+						"currency", sc.State.Currency)
 					_, err := svc.Reservations.Reserve(ctx, ReserveInput{
 						AccountID: sc.State.BuyerAccountID,
 						Amount:    sc.State.TotalAmount,
@@ -223,11 +254,24 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						OpID:      sc.OpID,
 						OpKind:    "otc_exercise",
 					})
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: buyer strike reserve failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"buyer_account_id", sc.State.BuyerAccountID,
+							"strike_total", sc.State.TotalAmount)
+					}
 					return err
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
 					_, err := svc.Reservations.Release(ctx, sc.OpID)
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: strike reservation release compensation failed",
+							"err", err, "contract_id", sc.State.ContractID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc exercise: strike reservation released",
+						"contract_id", sc.State.ContractID)
+					return nil
 				},
 			},
 			{
@@ -235,9 +279,17 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
 					h, err := svc.Store.GetHoldingByID(ctx, sc.State.SellerHoldingID)
 					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: seller holding lookup failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"seller_holding_id", sc.State.SellerHoldingID)
 						return err
 					}
 					if h.Quantity < sc.State.Quantity || h.ReservedCount < sc.State.Quantity {
+						sc.Log.WarnContext(ctx, "otc exercise: seller holding no longer covers contract",
+							"contract_id", sc.State.ContractID,
+							"seller_holding_id", sc.State.SellerHoldingID,
+							"held", h.Quantity, "reserved", h.ReservedCount,
+							"quantity", sc.State.Quantity)
 						return status.Error(codes.FailedPrecondition,
 							"seller holding no longer covers contract quantity")
 					}
@@ -257,7 +309,16 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						IsActuary:     sc.State.IsActuary,
 						Purpose:       "OTC izvršenje — ugovor " + sc.State.ContractID,
 					})
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: strike transfer failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"strike_total", sc.State.TotalAmount, "currency", sc.State.Currency)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc exercise: strike transferred to seller",
+						"contract_id", sc.State.ContractID,
+						"strike_total", sc.State.TotalAmount, "currency", sc.State.Currency)
+					return nil
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
 					// Forward Commit already moved real money seller-ward
@@ -275,13 +336,21 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						IsActuary:     sc.State.IsActuary,
 						Purpose:       "Rollback OTC izvršenja — ugovor " + sc.State.ContractID,
 					})
-					return err
+					if err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: strike reverse-transfer compensation failed",
+							"err", err, "contract_id", sc.State.ContractID,
+							"strike_total", sc.State.TotalAmount)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc exercise: strike returned to buyer (compensation)",
+						"contract_id", sc.State.ContractID, "strike_total", sc.State.TotalAmount)
+					return nil
 				},
 			},
 			{
 				Name: "transfer_shares",
 				Forward: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					txErr := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						// 1. Sell side: capture pre-fill cost basis,
 						//    then decrement reserved_count BEFORE quantity.
 						//    The CHECK constraint reserved_count <= quantity
@@ -357,9 +426,20 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						sc.State.RealizedGainRSD = rg.GainRSD
 						return nil
 					})
+					if txErr != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: share transfer failed",
+							"err", txErr, "contract_id", sc.State.ContractID,
+							"seller_holding_id", sc.State.SellerHoldingID,
+							"quantity", sc.State.Quantity)
+						return txErr
+					}
+					sc.Log.InfoContext(ctx, "otc exercise: shares transferred to buyer",
+						"contract_id", sc.State.ContractID, "quantity", sc.State.Quantity,
+						"seller_gain_native", sc.State.RealizedGainNative)
+					return nil
 				},
 				Compensate: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					compErr := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						// Reverse the seller decrement: add back qty.
 						sellerHolding, err := svc.Store.GetHoldingByID(ctx, sc.State.SellerHoldingID)
 						if err != nil {
@@ -400,6 +480,13 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 						}
 						return nil
 					})
+					if compErr != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: share transfer compensation failed",
+							"err", compErr, "contract_id", sc.State.ContractID,
+							"seller_holding_id", sc.State.SellerHoldingID,
+							"quantity", sc.State.Quantity)
+					}
+					return compErr
 				},
 			},
 			{
@@ -407,14 +494,21 @@ func registerOTCExerciseSaga(reg *saga.Registry, svc *Service) {
 				Forward: func(ctx context.Context, sc *saga.Context[otcExerciseSagaPayload]) error {
 					strikeOp := saga.DeriveOpID(sc.TransactionID, "transfer_strike")
 					now := time.Now()
-					return svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
+					if err := svc.Store.ExecuteAtomic(ctx, func(tx pgx.Tx) error {
 						_, err := svc.Store.MarkOTCContractStatus(ctx, tx,
 							sc.State.ContractID,
 							domain.OTCContractExercised,
 							strikeOp, sc.TransactionID, &now,
 						)
 						return err
-					})
+					}); err != nil {
+						sc.Log.ErrorContext(ctx, "otc exercise: contract finalize failed",
+							"err", err, "contract_id", sc.State.ContractID)
+						return err
+					}
+					sc.Log.InfoContext(ctx, "otc exercise: contract marked exercised",
+						"contract_id", sc.State.ContractID, "thread_id", sc.State.ThreadID)
+					return nil
 				},
 				Compensate: nil, // last step
 			},

--- a/services/trading/internal/service/otc_expiry.go
+++ b/services/trading/internal/service/otc_expiry.go
@@ -129,6 +129,8 @@ func (s *Service) SweepExpiredOTCContracts(ctx context.Context) (*SweepExpiredOT
 		}
 		out.ContractsExpired++
 		out.SharesReleased += c.Quantity
+		s.log().InfoContext(ctx, "otc contract expired",
+			"contract_id", c.ID, "quantity", c.Quantity, "buyer_id", c.BuyerID)
 		if s.OTCNotifier != nil {
 			s.OTCNotifier.OnOTCContractExpired(ctx, c, c.BuyerID, c.BuyerKind)
 		}
@@ -190,6 +192,8 @@ func (s *Service) sweepExpiredOTCOffers(ctx context.Context, now time.Time, loc 
 			continue
 		}
 		out.OffersExpired++
+		s.log().InfoContext(ctx, "otc offer auto-expired",
+			"offer_id", o.ID, "thread_id", o.ThreadID)
 		if s.OTCNotifier != nil {
 			// Notify the party whose turn it was (modified_by is the other
 			// side); the offer aged out waiting on them.

--- a/services/trading/internal/service/portfolio.go
+++ b/services/trading/internal/service/portfolio.go
@@ -84,6 +84,12 @@ func (s *Service) ListHoldings(ctx context.Context, in ListHoldingsInput) ([]*Ho
 		}
 		dec := &HoldingDecorated{Holding: h, Security: sec}
 		listing, err := s.Store.GetListingBySecurityID(ctx, h.SecurityID)
+		if err != nil && !isAppKind(err, apperr.KindNotFound) {
+			// NotFound is expected (e.g. options without a listing); other
+			// failures silently render the holding without a market value.
+			s.log().WarnContext(ctx, "holding listing lookup failed, market value omitted",
+				"err", err, "holding_id", h.ID, "security_id", h.SecurityID)
+		}
 		if err == nil {
 			dec.CurrentPrice = listing.Price
 			price, _ := money.Parse(listing.Price)

--- a/services/trading/internal/service/portfolio.go
+++ b/services/trading/internal/service/portfolio.go
@@ -127,7 +127,15 @@ func (s *Service) SetPublicCount(ctx context.Context, holdingID string, count in
 		}
 	}
 	if count > h.Quantity {
+		s.log().WarnContext(ctx, "set public count rejected: exceeds quantity",
+			"holding_id", holdingID, "count", count, "quantity", h.Quantity)
 		return nil, apperr.Validation("public_count ne može da bude veći od quantity")
 	}
-	return s.Store.SetPublicCount(ctx, holdingID, count)
+	out, err := s.Store.SetPublicCount(ctx, holdingID, count)
+	if err != nil {
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "holding public count set",
+		"holding_id", holdingID, "count", count)
+	return out, nil
 }

--- a/services/trading/internal/service/price_alerts.go
+++ b/services/trading/internal/service/price_alerts.go
@@ -124,7 +124,14 @@ func (s *Service) RunPriceAlertSweep(ctx context.Context) (int, error) {
 			s.Log.Warn("price alert: deactivate failed", "alert_id", a.ID, "err", err.Error())
 			continue
 		}
+		s.log().InfoContext(ctx, "price alert triggered",
+			"alert_id", a.ID, "user_id", a.UserID,
+			"security_id", a.SecurityID, "price", listing.Price)
 		triggered++
+	}
+	if triggered > 0 {
+		s.log().InfoContext(ctx, "price alert sweep completed",
+			"triggered", triggered, "active", len(alerts))
 	}
 	return triggered, nil
 }
@@ -151,6 +158,9 @@ func (s *Service) firePriceAlert(ctx context.Context, a *domain.PriceAlert, curr
 	ticker := a.SecurityID
 	if sec, err := s.Store.GetSecurity(ctx, a.SecurityID); err == nil && sec.Ticker != "" {
 		ticker = sec.Ticker
+	} else if err != nil {
+		s.log().WarnContext(ctx, "price alert security lookup failed",
+			"err", err, "alert_id", a.ID, "security_id", a.SecurityID)
 	}
 	dir := "prešla iznad"
 	if a.Condition == domain.PriceAlertBelow {

--- a/services/trading/internal/service/profit.go
+++ b/services/trading/internal/service/profit.go
@@ -248,6 +248,8 @@ func (s *Service) ListBankFundPositions(ctx context.Context) ([]*BankFundPositio
 	for _, pos := range rows {
 		f, err := s.Store.GetFund(ctx, pos.FundID)
 		if err != nil {
+			s.log().WarnContext(ctx, "bank fund positions: fund lookup failed, row dropped",
+				"err", err, "fund_id", pos.FundID, "position_id", pos.ID)
 			continue
 		}
 		dec := s.decorateFund(ctx, f)

--- a/services/trading/internal/service/recurring_order.go
+++ b/services/trading/internal/service/recurring_order.go
@@ -108,7 +108,7 @@ func (s *Service) CreateRecurringOrder(ctx context.Context, in CreateRecurringOr
 		nextRun = start
 	}
 
-	return s.Store.InsertRecurringOrder(ctx, &domain.RecurringOrder{
+	out, err := s.Store.InsertRecurringOrder(ctx, &domain.RecurringOrder{
 		UserID:     p.UserID,
 		UserKind:   domain.UserKind(p.UserKind),
 		SecurityID: in.SecurityID,
@@ -120,6 +120,15 @@ func (s *Service) CreateRecurringOrder(ctx context.Context, in CreateRecurringOr
 		Cadence:    string(in.Cadence),
 		NextRun:    nextRun,
 	})
+	if err != nil {
+		s.logOpErr(ctx, "recurring order create failed", err,
+			"security_id", in.SecurityID, "cadence", string(in.Cadence))
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "recurring order created",
+		"recurring_order_id", out.ID, "security_id", out.SecurityID,
+		"mode", string(out.Mode), "cadence", out.Cadence, "next_run", out.NextRun)
+	return out, nil
 }
 
 // ListRecurringOrders returns the caller's own recurring orders (active
@@ -157,9 +166,13 @@ func (s *Service) setRecurringActive(ctx context.Context, id string, active bool
 		return nil, apperr.PermissionDenied("nedovoljne permisije")
 	}
 	if err := s.Store.SetRecurringOrderActive(ctx, id, active); err != nil {
+		s.logOpErr(ctx, "recurring order active flip failed", err,
+			"recurring_order_id", id, "active", active)
 		return nil, err
 	}
 	r.Active = active
+	s.log().InfoContext(ctx, "recurring order active flag set",
+		"recurring_order_id", id, "active", active)
 	return r, nil
 }
 
@@ -178,7 +191,12 @@ func (s *Service) CancelRecurringOrder(ctx context.Context, id string) error {
 	if r.UserID != p.UserID && !permissions.Has(p.Permissions, permissions.Admin) {
 		return apperr.PermissionDenied("nedovoljne permisije")
 	}
-	return s.Store.DeleteRecurringOrder(ctx, id)
+	if err := s.Store.DeleteRecurringOrder(ctx, id); err != nil {
+		s.logOpErr(ctx, "recurring order cancel failed", err, "recurring_order_id", id)
+		return err
+	}
+	s.log().InfoContext(ctx, "recurring order cancelled", "recurring_order_id", id)
+	return nil
 }
 
 // RunRecurringOrders is the DCA cron entrypoint (S49). For each due +
@@ -197,6 +215,7 @@ func (s *Service) RunRecurringOrders(ctx context.Context) (int, error) {
 	now := s.now()
 	rows, err := s.Store.ListDueRecurringOrders(ctx, now)
 	if err != nil {
+		s.log().ErrorContext(ctx, "recurring orders: due-row scan failed", "err", err)
 		return 0, err
 	}
 	created := 0
@@ -251,6 +270,8 @@ func (s *Service) runOneRecurringOrder(ctx context.Context, r *domain.RecurringO
 	if err != nil {
 		if isInsufficientFunds(err) {
 			// S50: skip + notify, still advance (handled by caller).
+			s.log().WarnContext(ctx, "recurring order: insufficient funds; skipping cycle",
+				"recurring_order_id", r.ID, "security_id", r.SecurityID)
 			s.notifyRecurringSkip(ctx, r, "nedovoljno sredstava na računu — kupovina je preskočena")
 			return false
 		}

--- a/services/trading/internal/service/saga_recovery.go
+++ b/services/trading/internal/service/saga_recovery.go
@@ -15,6 +15,7 @@ func (s *Service) RunSagaRecoveryTick(ctx context.Context) (int, error) {
 	}
 	due, err := s.SagaStore.DueForRecovery(ctx, 100)
 	if err != nil {
+		s.log().ErrorContext(ctx, "saga recovery: due-row scan failed", "err", err)
 		return 0, err
 	}
 	for _, row := range due {

--- a/services/trading/internal/service/scheduled_interbank.go
+++ b/services/trading/internal/service/scheduled_interbank.go
@@ -104,7 +104,7 @@ func (s *Service) CreateScheduledInterbankPayment(ctx context.Context, in Create
 		nextRun = schedule.Advance(now, in.Cadence)
 	}
 
-	return s.Store.InsertScheduledInterbankPayment(ctx, &domain.ScheduledInterbankPayment{
+	row, err := s.Store.InsertScheduledInterbankPayment(ctx, &domain.ScheduledInterbankPayment{
 		UserID:            p.UserID,
 		UserKind:          domain.UserKind(p.UserKind),
 		SourceAccountID:   in.SourceAccountID,
@@ -116,6 +116,16 @@ func (s *Service) CreateScheduledInterbankPayment(ctx context.Context, in Create
 		Cadence:           string(in.Cadence),
 		NextRun:           nextRun,
 	})
+	if err != nil {
+		s.logOpErr(ctx, "scheduled interbank payment create failed", err,
+			"remote_bank_code", in.DestBankCode, "cadence", string(in.Cadence))
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "scheduled interbank payment created",
+		"scheduled_interbank_id", row.ID, "remote_bank_code", row.DestBankCode,
+		"amount", row.Amount, "currency", string(row.Currency),
+		"cadence", row.Cadence, "next_run", row.NextRun)
+	return row, nil
 }
 
 // ListScheduledInterbankPayments returns the caller's own scheduled
@@ -152,9 +162,13 @@ func (s *Service) setScheduledInterbankActive(ctx context.Context, id string, ac
 		return nil, apperr.PermissionDenied("nedovoljne permisije")
 	}
 	if err := s.Store.SetScheduledInterbankPaymentActive(ctx, id, active); err != nil {
+		s.logOpErr(ctx, "scheduled interbank payment active flip failed", err,
+			"scheduled_interbank_id", id, "active", active)
 		return nil, err
 	}
 	row.Active = active
+	s.log().InfoContext(ctx, "scheduled interbank payment active flag set",
+		"scheduled_interbank_id", id, "active", active)
 	return row, nil
 }
 
@@ -171,7 +185,14 @@ func (s *Service) CancelScheduledInterbankPayment(ctx context.Context, id string
 	if row.UserID != p.UserID && !permissions.Has(p.Permissions, permissions.Admin) {
 		return apperr.PermissionDenied("nedovoljne permisije")
 	}
-	return s.Store.DeleteScheduledInterbankPayment(ctx, id)
+	if err := s.Store.DeleteScheduledInterbankPayment(ctx, id); err != nil {
+		s.logOpErr(ctx, "scheduled interbank payment cancel failed", err,
+			"scheduled_interbank_id", id)
+		return err
+	}
+	s.log().InfoContext(ctx, "scheduled interbank payment cancelled",
+		"scheduled_interbank_id", id, "remote_bank_code", row.DestBankCode)
+	return nil
 }
 
 // RunDueInterbankPayments is the sweep entrypoint. For each due + active
@@ -184,6 +205,7 @@ func (s *Service) RunDueInterbankPayments(ctx context.Context) (int, error) {
 	now := s.now()
 	rows, err := s.Store.ListDueScheduledInterbankPayments(ctx, now)
 	if err != nil {
+		s.log().ErrorContext(ctx, "scheduled interbank: due-row scan failed", "err", err)
 		return 0, err
 	}
 	submitted := 0
@@ -238,6 +260,10 @@ func (s *Service) runOneScheduledInterbank(ctx context.Context, r *domain.Schedu
 	// A 'running' status means the partner was unavailable and the retry
 	// queue is now driving it — that's a successful submit from the
 	// sweep's POV (the retry worker owns the outcome + client notice).
+	s.log().InfoContext(ctx, "scheduled interbank payment submitted",
+		"scheduled_interbank_id", r.ID, "transaction_id", res.TransactionID,
+		"remote_bank_code", r.DestBankCode, "amount", r.Amount,
+		"currency", string(r.Currency), "saga_status", res.Status)
 	return res.Status, ""
 }
 

--- a/services/trading/internal/service/securities.go
+++ b/services/trading/internal/service/securities.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/big"
 	"strings"
 	"time"
@@ -283,6 +284,15 @@ func filterStrikeWindow(rows []*OptionChainRow, shared *big.Rat, window int) []*
 	for _, r := range rows {
 		strike, err := money.Parse(r.StrikePrice)
 		if err != nil {
+			// No ctx in this helper — package-level slog.
+			attrs := []any{"err", err, "strike", r.StrikePrice}
+			if r.Call != nil {
+				attrs = append(attrs, "call_security_id", r.Call.ID)
+			}
+			if r.Put != nil {
+				attrs = append(attrs, "put_security_id", r.Put.ID)
+			}
+			slog.Warn("option chain: strike parse failed, row dropped", attrs...)
 			continue
 		}
 		diff := money.Sub(strike, shared)
@@ -384,10 +394,15 @@ func computeMaintenanceMargin(sec *domain.Security, l *domain.Listing) (*big.Rat
 	}
 	price, err := money.Parse(priceStr)
 	if err != nil {
+		// No ctx in this helper — package-level slog.
+		slog.Warn("maintenance margin: price parse failed, margin omitted",
+			"err", err, "security_id", sec.ID, "ticker", sec.Ticker, "price", priceStr)
 		return nil, false
 	}
 	contract, err := money.Parse(contrStr)
 	if err != nil {
+		slog.Warn("maintenance margin: contract size parse failed, margin omitted",
+			"err", err, "security_id", sec.ID, "ticker", sec.Ticker, "contract_size", contrStr)
 		return nil, false
 	}
 	switch sec.Type {

--- a/services/trading/internal/service/securities.go
+++ b/services/trading/internal/service/securities.go
@@ -33,7 +33,15 @@ func (s *Service) UpsertSecurity(ctx context.Context, in *domain.Security) (*dom
 	if err := validateSecurity(in); err != nil {
 		return nil, err
 	}
-	return s.Store.UpsertSecurity(ctx, in)
+	out, err := s.Store.UpsertSecurity(ctx, in)
+	if err != nil {
+		s.logOpErr(ctx, "security upsert failed", err,
+			"ticker", in.Ticker, "type", string(in.Type))
+		return nil, err
+	}
+	s.log().InfoContext(ctx, "security upserted",
+		"security_id", out.ID, "ticker", out.Ticker, "type", string(out.Type))
+	return out, nil
 }
 
 // GetSecurity returns one security joined with its listing and the

--- a/services/trading/internal/service/service.go
+++ b/services/trading/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -409,6 +410,37 @@ func New(st *store.Store, cfg Config, log *slog.Logger) *Service {
 		cfg.BankName = "Banka 3"
 	}
 	return &Service{Store: st, Cfg: cfg, Log: log}
+}
+
+// log returns the service logger, falling back to slog.Default so log
+// sites stay nil-safe when a test constructs a bare &Service{}.
+func (s *Service) log() *slog.Logger {
+	if s != nil && s.Log != nil {
+		return s.Log
+	}
+	return slog.Default()
+}
+
+// logOpErr records a failed operation, choosing the level by error
+// class: expected client-class apperr kinds (validation, not-found,
+// conflict, permission, precondition, unauthenticated) log at Warn;
+// everything else (internal, unavailable, non-apperr) logs at Error.
+// Logging-only helper — never alters err. attrs follow the "err" key.
+func (s *Service) logOpErr(ctx context.Context, msg string, err error, attrs ...any) {
+	if err == nil {
+		return
+	}
+	level := slog.LevelError
+	var ae *apperr.Error
+	if errors.As(err, &ae) {
+		switch ae.Kind {
+		case apperr.KindInternal, apperr.KindUnavailable:
+			// stay at Error
+		default:
+			level = slog.LevelWarn
+		}
+	}
+	s.log().Log(ctx, level, msg, append([]any{"err", err}, attrs...)...)
 }
 
 func (s *Service) now() time.Time {

--- a/services/trading/internal/service/tax.go
+++ b/services/trading/internal/service/tax.go
@@ -241,6 +241,9 @@ func (s *Service) RunTax(ctx context.Context, in RunTaxInput) (*RunTaxResult, er
 		UsersTaxed:        taxed,
 		TotalCollectedRSD: money.FormatAmount(total),
 	}
+	s.log().InfoContext(ctx, "tax run completed",
+		"users_taxed", result.UsersTaxed, "total_collected_rsd", result.TotalCollectedRSD,
+		"manual", isManual)
 	if isManual {
 		// note: users taxed / total collected (RSD). Best-effort.
 		note := "korisnika oporezovano: " + strconv.Itoa(int(result.UsersTaxed)) +
@@ -309,6 +312,9 @@ func (s *Service) runTaxForUser(ctx context.Context, userID string, kind domain.
 				InitiatorClientKind: kind,
 			})
 			if err != nil {
+				s.log().ErrorContext(ctx, "tax run: bank settle failed",
+					"err", err, "user_id", userID, "account_id", g.accountID,
+					"op_id", opID, "amount_rsd", money.FormatAmount(taxAmt))
 				return nil, err
 			}
 			if settledOpID != "" {
@@ -321,6 +327,8 @@ func (s *Service) runTaxForUser(ctx context.Context, userID string, kind domain.
 			return s.Store.MarkRealizedGainsTaxed(ctx, tx, g.ids, opID)
 		})
 		if err != nil {
+			s.log().ErrorContext(ctx, "tax run: mark gains taxed failed after bank settle",
+				"err", err, "user_id", userID, "account_id", g.accountID, "op_id", opID)
 			return nil, err
 		}
 	}

--- a/services/trading/internal/service/watchlist.go
+++ b/services/trading/internal/service/watchlist.go
@@ -141,9 +141,15 @@ func (s *Service) decorateWatchlistItem(ctx context.Context, it *domain.Watchlis
 		it.Name = sec.Name
 		it.SecurityType = sec.Type
 		it.Currency = sec.Currency
+	} else if err != nil {
+		s.log().WarnContext(ctx, "watchlist item security lookup failed",
+			"err", err, "item_id", it.ID, "security_id", it.SecurityID)
 	}
 	if listing, err := s.Store.GetListingBySecurityID(ctx, it.SecurityID); err == nil && listing != nil {
 		it.Price = listing.Price
 		it.DailyChange = listing.ChangeAmt
+	} else if err != nil {
+		s.log().WarnContext(ctx, "watchlist item listing lookup failed",
+			"err", err, "item_id", it.ID, "security_id", it.SecurityID)
 	}
 }

--- a/services/trading/internal/store/actuaries.go
+++ b/services/trading/internal/store/actuaries.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -25,6 +26,7 @@ func (s *Store) UpsertActuaryInfo(ctx context.Context, in *domain.ActuaryInfo) (
 	row := s.DB.QueryRow(ctx, q, in.EmployeeID, string(in.Type), in.DailyLimit, in.NeedApproval)
 	out, err := scanActuary(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert actuary failed", "err", err)
 		return nil, apperr.Internal("upsert actuary", err)
 	}
 	return out, nil
@@ -41,6 +43,7 @@ func (s *Store) GetActuaryInfo(ctx context.Context, employeeID string) (*domain.
 		if noRows(err) {
 			return nil, apperr.NotFound("actuary not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get actuary failed", "err", err, "employee_id", employeeID)
 		return nil, apperr.Internal("get actuary", err)
 	}
 	return out, nil
@@ -58,6 +61,7 @@ func (s *Store) UpdateActuaryLimit(ctx context.Context, employeeID, dailyLimit s
 		if noRows(err) {
 			return nil, apperr.NotFound("actuary not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update actuary limit failed", "err", err, "employee_id", employeeID)
 		return nil, apperr.Internal("update actuary limit", err)
 	}
 	return out, nil
@@ -75,6 +79,7 @@ func (s *Store) ResetActuaryUsedLimit(ctx context.Context, employeeID string) (*
 		if noRows(err) {
 			return nil, apperr.NotFound("actuary not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "reset used limit failed", "err", err, "employee_id", employeeID)
 		return nil, apperr.Internal("reset used limit", err)
 	}
 	return out, nil
@@ -86,6 +91,7 @@ func (s *Store) ResetAllUsedLimits(ctx context.Context) (int64, error) {
 	const q = `update "trading".actuary_info set used_limit = 0, updated_at = now() where used_limit <> 0`
 	tag, err := s.DB.Exec(ctx, q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset all used limits failed", "err", err)
 		return 0, apperr.Internal("reset all used limits", err)
 	}
 	return tag.RowsAffected(), nil
@@ -103,6 +109,7 @@ func (s *Store) SetActuaryNeedApproval(ctx context.Context, employeeID string, n
 		if noRows(err) {
 			return nil, apperr.NotFound("actuary not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set need approval failed", "err", err, "employee_id", employeeID)
 		return nil, apperr.Internal("set need approval", err)
 	}
 	return out, nil
@@ -114,6 +121,7 @@ func (s *Store) AddUsedLimit(ctx context.Context, tx pgx.Tx, employeeID, deltaRS
 	const q = `update "trading".actuary_info set used_limit = used_limit + $2, updated_at = now() where employee_id = $1`
 	_, err := tx.Exec(ctx, q, employeeID, deltaRSD)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "add used limit failed", "err", err, "employee_id", employeeID)
 		return apperr.Internal("add used limit", err)
 	}
 	return nil
@@ -131,6 +139,7 @@ func (s *Store) RefundUsedLimit(ctx context.Context, tx pgx.Tx, employeeID, delt
 	           where employee_id = $1`
 	_, err := tx.Exec(ctx, q, employeeID, deltaRSD)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "refund used limit failed", "err", err, "employee_id", employeeID)
 		return apperr.Internal("refund used limit", err)
 	}
 	return nil
@@ -174,6 +183,7 @@ func (s *Store) ListActuaries(ctx context.Context, t domain.ActuaryType, page, p
 	countQ := "select count(*) from \"trading\".actuary_info" + where
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), countQ, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count actuaries failed", "err", err)
 		return nil, 0, apperr.Internal("count actuaries", err)
 	}
 
@@ -185,6 +195,7 @@ func (s *Store) ListActuaries(ctx context.Context, t domain.ActuaryType, page, p
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list actuaries failed", "err", err)
 		return nil, 0, apperr.Internal("list actuaries", err)
 	}
 	defer rows.Close()
@@ -193,11 +204,16 @@ func (s *Store) ListActuaries(ctx context.Context, t domain.ActuaryType, page, p
 	for rows.Next() {
 		a, err := scanActuary(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan actuary failed", "err", err)
 			return nil, 0, apperr.Internal("scan actuary", err)
 		}
 		out = append(out, a)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list actuaries rows failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // scanActuary reads one ActuaryInfo row.

--- a/services/trading/internal/store/dividends.go
+++ b/services/trading/internal/store/dividends.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -36,6 +37,7 @@ func (s *Store) InsertDividendPayout(ctx context.Context, d *domain.DividendPayo
 			// Lost the op_id conflict — fetch the winning row.
 			return s.GetDividendPayoutByOpID(ctx, d.OpID)
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert dividend payout failed", "err", err)
 		return nil, apperr.Internal("insert dividend payout", err)
 	}
 	return out, nil
@@ -50,6 +52,7 @@ func (s *Store) GetDividendPayoutByOpID(ctx context.Context, opID string) (*doma
 		if noRows(err) {
 			return nil, apperr.NotFound("dividend payout ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get dividend payout by op_id failed", "err", err, "op_id", opID)
 		return nil, apperr.Internal("get dividend payout by op_id", err)
 	}
 	return out, nil
@@ -62,10 +65,15 @@ func (s *Store) ListDividendPayoutsByUser(ctx context.Context, userID string, ki
 	      where user_id = $1 and user_kind = $2 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID, string(kind))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend payouts failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list dividend payouts", err)
 	}
 	defer rows.Close()
-	return scanDividendPayouts(rows)
+	out, err := scanDividendPayouts(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend payouts by user failed", "err", err, "user_id", userID)
+	}
+	return out, err
 }
 
 // ListDividendPayoutsByPosition returns payouts for one holder's single
@@ -76,10 +84,15 @@ func (s *Store) ListDividendPayoutsByPosition(ctx context.Context, userID string
 	      order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID, string(kind), securityID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend payouts by position failed", "err", err, "user_id", userID, "security_id", securityID)
 		return nil, apperr.Internal("list dividend payouts by position", err)
 	}
 	defer rows.Close()
-	return scanDividendPayouts(rows)
+	out, err := scanDividendPayouts(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend payouts by position failed", "err", err, "user_id", userID, "security_id", securityID)
+	}
+	return out, err
 }
 
 // DividendCandidate is one stock holding eligible for a quarterly
@@ -116,6 +129,7 @@ func (s *Store) ListDividendCandidates(ctx context.Context) ([]*DividendCandidat
         order by h.user_id, h.security_id`
 	rows, err := s.DB.Query(ctx, q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend candidates failed", "err", err)
 		return nil, apperr.Internal("list dividend candidates", err)
 	}
 	defer rows.Close()
@@ -128,13 +142,18 @@ func (s *Store) ListDividendCandidates(ctx context.Context) ([]*DividendCandidat
 		)
 		if err := rows.Scan(&c.HoldingID, &c.UserID, &k, &c.SecurityID, &c.AccountID,
 			&c.Quantity, &c2, &c.DividendYield, &c.Price); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan dividend candidate failed", "err", err)
 			return nil, apperr.Internal("scan dividend candidate", err)
 		}
 		c.UserKind = domain.UserKind(k)
 		c.Currency = domain.Currency(c2)
 		out = append(out, &c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list dividend candidates rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanDividendPayout(row pgx.Row) (*domain.DividendPayout, error) {

--- a/services/trading/internal/store/exchanges.go
+++ b/services/trading/internal/store/exchanges.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -34,6 +35,7 @@ func (s *Store) UpsertExchange(ctx context.Context, e *domain.Exchange) (*domain
 	)
 	out, err := scanExchange(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert exchange failed", "err", err)
 		return nil, apperr.Internal("upsert exchange", err)
 	}
 	return out, nil
@@ -47,11 +49,17 @@ func (s *Store) SetExchangeOverride(ctx context.Context, mic string, state *doma
 		q := `update "trading".exchanges set override_state = NULL, updated_at = now() where mic = $1
 		      returning ` + exchangeCols
 		out, err := scanExchange(s.DB.QueryRow(ctx, q, mic))
+		if err != nil && !noRows(err) {
+			logger.From(ctx).ErrorContext(ctx, "clear exchange override failed", "err", err, "mic", mic)
+		}
 		return wrapExchange(out, err)
 	}
 	q := `update "trading".exchanges set override_state = $2, updated_at = now() where mic = $1
 	      returning ` + exchangeCols
 	out, err := scanExchange(s.DB.QueryRow(ctx, q, mic, string(*state)))
+	if err != nil && !noRows(err) {
+		logger.From(ctx).ErrorContext(ctx, "set exchange override failed", "err", err, "mic", mic)
+	}
 	return wrapExchange(out, err)
 }
 
@@ -69,6 +77,9 @@ func wrapExchange(out *domain.Exchange, err error) (*domain.Exchange, error) {
 func (s *Store) GetExchange(ctx context.Context, mic string) (*domain.Exchange, error) {
 	const q = `select ` + exchangeCols + ` from "trading".exchanges where mic = $1`
 	out, err := scanExchange(s.DB.QueryRow(ctx, q, mic))
+	if err != nil && !noRows(err) {
+		logger.From(ctx).ErrorContext(ctx, "get exchange failed", "err", err, "mic", mic)
+	}
 	return wrapExchange(out, err)
 }
 
@@ -77,6 +88,7 @@ func (s *Store) ListExchanges(ctx context.Context) ([]*domain.Exchange, error) {
 	const q = `select ` + exchangeCols + ` from "trading".exchanges order by mic`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list exchanges failed", "err", err)
 		return nil, apperr.Internal("list exchanges", err)
 	}
 	defer rows.Close()
@@ -84,11 +96,16 @@ func (s *Store) ListExchanges(ctx context.Context) ([]*domain.Exchange, error) {
 	for rows.Next() {
 		e, err := scanExchange(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan exchange failed", "err", err)
 			return nil, apperr.Internal("scan exchange", err)
 		}
 		out = append(out, e)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list exchanges rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanExchange(row pgx.Row) (*domain.Exchange, error) {

--- a/services/trading/internal/store/executions.go
+++ b/services/trading/internal/store/executions.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -32,6 +33,7 @@ func (s *Store) InsertPendingExecution(ctx context.Context, tx pgx.Tx, e *domain
 	)
 	out, err := scanExecution(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert pending execution failed", "err", err)
 		return nil, apperr.Internal("insert pending execution", err)
 	}
 	return out, nil
@@ -47,6 +49,7 @@ func (s *Store) MarkExecutionSettled(ctx context.Context, tx pgx.Tx, execID, ban
             bank_op_id = nullif($2, '')::uuid
         where id = $1`
 	if _, err := tx.Exec(ctx, q, execID, bankOpID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark execution settled failed", "err", err, "exec_id", execID, "bank_op_id", bankOpID)
 		return apperr.Internal("mark execution settled", err)
 	}
 	return nil
@@ -66,6 +69,7 @@ func (s *Store) RecordResumeFailure(ctx context.Context, execID, errMsg string) 
         returning attempts`
 	var attempts int32
 	if err := s.DB.QueryRow(ctx, q, execID, errMsg).Scan(&attempts); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "record resume failure failed", "err", err, "exec_id", execID)
 		return 0, apperr.Internal("record resume failure", err)
 	}
 	return attempts, nil
@@ -84,6 +88,7 @@ func (s *Store) MarkPendingAbandoned(ctx context.Context, tx pgx.Tx, execID, err
             last_error = $2
         where id = $1 and status = 'pending'`
 	if _, err := tx.Exec(ctx, q, execID, errMsg); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "abandon pending execution failed", "err", err, "exec_id", execID)
 		return apperr.Internal("abandon pending execution", err)
 	}
 	return nil
@@ -104,6 +109,7 @@ func (s *Store) GetPendingExecutionForOrder(ctx context.Context, orderID string)
 		if noRows(err) {
 			return nil, nil
 		}
+		logger.From(ctx).ErrorContext(ctx, "get pending execution failed", "err", err, "order_id", orderID)
 		return nil, apperr.Internal("get pending execution", err)
 	}
 	return out, nil
@@ -128,6 +134,7 @@ func (s *Store) ListOrderIDsWithPendingExecutions(ctx context.Context, limit int
         limit $1`
 	rows, err := s.DB.Query(ctx, q, limit)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list pending exec orders failed", "err", err)
 		return nil, apperr.Internal("list pending exec orders", err)
 	}
 	defer rows.Close()
@@ -135,11 +142,16 @@ func (s *Store) ListOrderIDsWithPendingExecutions(ctx context.Context, limit int
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan pending exec order id failed", "err", err)
 			return nil, apperr.Internal("scan pending exec order id", err)
 		}
 		out = append(out, id)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list order i ds with pending executions rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // AdvanceOrderProgress decrements remaining_quantity by `delta` inside
@@ -172,6 +184,7 @@ func (s *Store) AdvanceOrderProgress(ctx context.Context, tx pgx.Tx, orderID str
 		if noRows(err) {
 			return 0, apperr.FailedPrecondition("nalog nije aktivan ili nedovoljno preostale količine")
 		}
+		logger.From(ctx).ErrorContext(ctx, "advance order failed", "err", err, "order_id", orderID)
 		return 0, apperr.Internal("advance order", err)
 	}
 	return remaining, nil
@@ -182,6 +195,7 @@ func (s *Store) AdvanceOrderProgress(ctx context.Context, tx pgx.Tx, orderID str
 func (s *Store) SetOrderTriggered(ctx context.Context, tx pgx.Tx, orderID string) error {
 	const q = `update "trading".orders set triggered = true, last_modification = now() where id = $1`
 	if _, err := tx.Exec(ctx, q, orderID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set triggered failed", "err", err, "order_id", orderID)
 		return apperr.Internal("set triggered", err)
 	}
 	return nil
@@ -196,6 +210,7 @@ func (s *Store) ListExecutions(ctx context.Context, orderID string) ([]*domain.O
 	      order by executed_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, orderID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list executions failed", "err", err, "order_id", orderID)
 		return nil, apperr.Internal("list executions", err)
 	}
 	defer rows.Close()
@@ -203,11 +218,16 @@ func (s *Store) ListExecutions(ctx context.Context, orderID string) ([]*domain.O
 	for rows.Next() {
 		e, err := scanExecution(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan execution failed", "err", err, "order_id", orderID)
 			return nil, apperr.Internal("scan execution", err)
 		}
 		out = append(out, e)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list executions rows failed", "err", err, "order_id", orderID)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanExecution(row pgx.Row) (*domain.OrderExecution, error) {
@@ -233,6 +253,7 @@ func (s *Store) LatestExecutionAt(ctx context.Context, orderID string) (time.Tim
         where order_id = $1 and status = 'settled'`
 	var t *time.Time
 	if err := s.DB.QueryRow(ctx, q, orderID).Scan(&t); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "latest execution failed", "err", err, "order_id", orderID)
 		return time.Time{}, false, apperr.Internal("latest execution", err)
 	}
 	if t == nil {

--- a/services/trading/internal/store/external_otc.go
+++ b/services/trading/internal/store/external_otc.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -91,6 +92,7 @@ func (s *Store) InsertExternalOTCThread(ctx context.Context, tx pgx.Tx, t *domai
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("nit sa istom partner-bankom već postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert external otc thread failed", "err", err)
 		return nil, apperr.Internal("insert external otc thread", err)
 	}
 	return out, nil
@@ -104,6 +106,7 @@ func (s *Store) GetExternalOTCThread(ctx context.Context, id string) (*domain.Ex
 		if noRows(err) {
 			return nil, apperr.NotFound("eksterna ponuda ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get external otc thread failed", "err", err, "id", id)
 		return nil, apperr.Internal("get external otc thread", err)
 	}
 	return out, nil
@@ -131,6 +134,7 @@ func (s *Store) GetExternalOTCThreadByRemote(ctx context.Context, tx pgx.Tx, ban
 		if noRows(err) {
 			return nil, apperr.NotFound("eksterna nit ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get external otc thread by remote failed", "err", err, "remote_thread_id", remoteThreadID)
 		return nil, apperr.Internal("get external otc thread by remote", err)
 	}
 	return out, nil
@@ -169,6 +173,7 @@ func (s *Store) ListExternalOTCThreads(ctx context.Context, f ExternalOTCThreadF
 	      order by updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc threads failed", "err", err)
 		return nil, apperr.Internal("list external otc threads", err)
 	}
 	defer rows.Close()
@@ -176,11 +181,16 @@ func (s *Store) ListExternalOTCThreads(ctx context.Context, f ExternalOTCThreadF
 	for rows.Next() {
 		t, err := scanExternalOTCThread(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan external otc thread failed", "err", err)
 			return nil, apperr.Internal("scan external otc thread", err)
 		}
 		out = append(out, t)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc threads rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // UpdateExternalOTCThreadTerms applies a counter-offer to an existing
@@ -207,6 +217,7 @@ func (s *Store) UpdateExternalOTCThreadTerms(
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nit više nije otvorena")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update external otc thread terms failed", "err", err, "id", id)
 		return nil, apperr.Internal("update external otc thread terms", err)
 	}
 	return out, nil
@@ -226,6 +237,7 @@ func (s *Store) SetExternalOTCThreadStatus(
 		if noRows(err) {
 			return nil, apperr.NotFound("nit ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc thread status failed", "err", err, "id", id)
 		return nil, apperr.Internal("set external otc thread status", err)
 	}
 	return out, nil
@@ -248,6 +260,7 @@ func (s *Store) SetExternalOTCThreadRemoteThreadID(
 			// Already stamped — return the live row.
 			return s.GetExternalOTCThread(ctx, id)
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc thread remote id failed", "err", err, "remote_thread_id", remoteThreadID, "id", id)
 		return nil, apperr.Internal("set external otc thread remote id", err)
 	}
 	return out, nil
@@ -274,6 +287,7 @@ func (s *Store) SetExternalOTCThreadRemoteIdentity(
 		if noRows(err) {
 			return s.GetExternalOTCThread(ctx, id)
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc thread remote identity failed", "err", err, "remote_thread_id", remoteThreadID, "id", id)
 		return nil, apperr.Internal("set external otc thread remote identity", err)
 	}
 	return out, nil
@@ -314,6 +328,7 @@ func (s *Store) InsertExternalOTCIteration(ctx context.Context, tx pgx.Tx, it *d
 	)
 	out, err := scanExternalOTCIteration(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert external otc iteration failed", "err", err)
 		return nil, apperr.Internal("insert external otc iteration", err)
 	}
 	return out, nil
@@ -327,6 +342,7 @@ func (s *Store) ListExternalOTCIterations(ctx context.Context, threadID string) 
 	           where thread_id = $1 order by created_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, threadID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc iterations failed", "err", err, "thread_id", threadID)
 		return nil, apperr.Internal("list external otc iterations", err)
 	}
 	defer rows.Close()
@@ -334,11 +350,16 @@ func (s *Store) ListExternalOTCIterations(ctx context.Context, threadID string) 
 	for rows.Next() {
 		it, err := scanExternalOTCIteration(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan external otc iteration failed", "err", err, "thread_id", threadID)
 			return nil, apperr.Internal("scan external otc iteration", err)
 		}
 		out = append(out, it)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc iterations rows failed", "err", err, "thread_id", threadID)
+		return out, err
+	}
+	return out, nil
 }
 
 // =====================================================================
@@ -429,6 +450,7 @@ func (s *Store) InsertExternalOTCContract(ctx context.Context, tx pgx.Tx, c *dom
 	)
 	out, err := scanExternalOTCContract(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert external otc contract failed", "err", err)
 		return nil, apperr.Internal("insert external otc contract", err)
 	}
 	return out, nil
@@ -442,6 +464,7 @@ func (s *Store) GetExternalOTCContract(ctx context.Context, id string) (*domain.
 		if noRows(err) {
 			return nil, apperr.NotFound("eksterni ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get external otc contract failed", "err", err, "id", id)
 		return nil, apperr.Internal("get external otc contract", err)
 	}
 	return out, nil
@@ -457,6 +480,7 @@ func (s *Store) GetExternalOTCContractByThread(ctx context.Context, threadID str
 		if noRows(err) {
 			return nil, apperr.NotFound("ugovor nije sklopljen")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get external otc contract by thread failed", "err", err, "thread_id", threadID)
 		return nil, apperr.Internal("get external otc contract by thread", err)
 	}
 	return out, nil
@@ -486,6 +510,7 @@ func (s *Store) ListExternalOTCContracts(ctx context.Context, localUserID, statu
 	      order by updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc contracts failed", "err", err, "local_user_id", localUserID)
 		return nil, apperr.Internal("list external otc contracts", err)
 	}
 	defer rows.Close()
@@ -493,11 +518,16 @@ func (s *Store) ListExternalOTCContracts(ctx context.Context, localUserID, statu
 	for rows.Next() {
 		c, err := scanExternalOTCContract(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan external otc contract failed", "err", err, "local_user_id", localUserID)
 			return nil, apperr.Internal("scan external otc contract", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list external otc contracts rows failed", "err", err, "local_user_id", localUserID)
+		return out, err
+	}
+	return out, nil
 }
 
 // SetExternalOTCContractStatus flips status (active → settling → exercised
@@ -516,6 +546,7 @@ func (s *Store) SetExternalOTCContractStatus(
 		if noRows(err) {
 			return nil, apperr.NotFound("ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc contract status failed", "err", err, "id", id)
 		return nil, apperr.Internal("set external otc contract status", err)
 	}
 	return out, nil
@@ -541,6 +572,7 @@ func (s *Store) SetExternalOTCContractExercised(
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("ugovor je već iskorišćen drugim op_id-om")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc contract exercised failed", "err", err, "exercise_op_id", exerciseOpID, "id", id)
 		return nil, apperr.Internal("set external otc contract exercised", err)
 	}
 	return out, nil

--- a/services/trading/internal/store/external_otc_settlement.go
+++ b/services/trading/internal/store/external_otc_settlement.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
 )
@@ -51,6 +52,7 @@ func (s *Store) InsertExternalOTCSettlement(ctx context.Context, tx pgx.Tx, m *d
 			// Conflict — the row already existed; return it unchanged.
 			return s.GetExternalOTCSettlement(ctx, tx, m.SenderRoutingNumber, m.TransactionID)
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert external otc settlement failed", "err", err)
 		return nil, apperr.Internal("insert external otc settlement", err)
 	}
 	return out, nil
@@ -68,6 +70,7 @@ func (s *Store) GetExternalOTCSettlement(ctx context.Context, tx pgx.Tx, senderR
 		if noRows(err) {
 			return nil, nil
 		}
+		logger.From(ctx).ErrorContext(ctx, "get external otc settlement failed", "err", err, "tx_id", txID)
 		return nil, apperr.Internal("get external otc settlement", err)
 	}
 	return out, nil
@@ -91,6 +94,7 @@ func (s *Store) SetExternalOTCSettlementStatus(ctx context.Context, tx pgx.Tx, s
 		if noRows(err) {
 			return apperr.NotFound("settlement ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set external otc settlement status failed", "err", err, "tx_id", txID, "contract_id", contractID)
 		return apperr.Internal("set external otc settlement status", err)
 	}
 	return nil

--- a/services/trading/internal/store/funds.go
+++ b/services/trading/internal/store/funds.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -56,6 +57,7 @@ func (s *Store) InsertFund(ctx context.Context, f *domain.Fund) (*domain.Fund, e
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("fond sa istim imenom već postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert fund failed", "err", err)
 		return nil, apperr.Internal("insert fund", err)
 	}
 	return out, nil
@@ -69,6 +71,7 @@ func (s *Store) GetFund(ctx context.Context, id string) (*domain.Fund, error) {
 		if noRows(err) {
 			return nil, apperr.NotFound("fond ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fund failed", "err", err, "id", id)
 		return nil, apperr.Internal("get fund", err)
 	}
 	return out, nil
@@ -84,6 +87,7 @@ func (s *Store) GetFundTx(ctx context.Context, tx pgx.Tx, id string) (*domain.Fu
 		if noRows(err) {
 			return nil, apperr.NotFound("fond ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fund (tx) failed", "err", err, "id", id)
 		return nil, apperr.Internal("get fund (tx)", err)
 	}
 	return out, nil
@@ -128,6 +132,7 @@ func (s *Store) ListFunds(ctx context.Context, f FundFilter) ([]*domain.Fund, er
 		strings.Join(conds, " and ") + ` order by name`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list funds failed", "err", err)
 		return nil, apperr.Internal("list funds", err)
 	}
 	defer rows.Close()
@@ -135,11 +140,16 @@ func (s *Store) ListFunds(ctx context.Context, f FundFilter) ([]*domain.Fund, er
 	for rows.Next() {
 		fnd, err := scanFund(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fund failed", "err", err)
 			return nil, apperr.Internal("scan fund", err)
 		}
 		out = append(out, fnd)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list funds rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // SetFundManager flips manager_user_id on a fund (manager-demotion
@@ -149,6 +159,7 @@ func (s *Store) SetFundManager(ctx context.Context, tx pgx.Tx, fundID, managerID
 	           set manager_user_id = $2, updated_at = now()
 	           where id = $1`
 	if _, err := tx.Exec(ctx, q, fundID, managerID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set fund manager failed", "err", err, "fund_id", fundID, "manager_id", managerID)
 		return apperr.Internal("set fund manager", err)
 	}
 	return nil
@@ -165,6 +176,7 @@ func (s *Store) ReassignFundManager(ctx context.Context, fromID, toID string) (i
 	             and status = 'active'`
 	tag, err := s.DB.Exec(ctx, q, fromID, toID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reassign fund manager failed", "err", err, "from_id", fromID, "to_id", toID)
 		return 0, apperr.Internal("reassign fund manager", err)
 	}
 	return tag.RowsAffected(), nil
@@ -182,6 +194,7 @@ func (s *Store) AdjustFundUnits(ctx context.Context, tx pgx.Tx, fundID, delta st
 		if isCheckViolation(err) {
 			return apperr.FailedPrecondition("nedovoljno jedinica fonda")
 		}
+		logger.From(ctx).ErrorContext(ctx, "adjust fund units failed", "err", err, "fund_id", fundID)
 		return apperr.Internal("adjust fund units", err)
 	}
 	return nil
@@ -216,6 +229,7 @@ func (s *Store) GetFundPosition(ctx context.Context, fundID, clientID string) (*
 		if noRows(err) {
 			return nil, apperr.NotFound("pozicija ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fund position failed", "err", err, "fund_id", fundID, "client_id", clientID)
 		return nil, apperr.Internal("get fund position", err)
 	}
 	return out, nil
@@ -240,6 +254,7 @@ func (s *Store) UpsertFundPositionInvest(
         returning ` + fundPositionCols
 	out, err := scanFundPosition(tx.QueryRow(ctx, q, fundID, clientID, unitsDelta, amountRSD))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert fund position invest failed", "err", err, "fund_id", fundID, "client_id", clientID)
 		return nil, apperr.Internal("upsert fund position invest", err)
 	}
 	return out, nil
@@ -272,6 +287,7 @@ func (s *Store) DecrementFundPositionWithdraw(
 		if isCheckViolation(err) {
 			return nil, apperr.FailedPrecondition("nedovoljno jedinica u poziciji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "decrement fund position failed", "err", err, "fund_id", fundID, "client_id", clientID)
 		return nil, apperr.Internal("decrement fund position", err)
 	}
 	return out, nil
@@ -308,6 +324,7 @@ func (s *Store) ListFundPositions(ctx context.Context, f FundPositionFilter) ([]
 		strings.Join(conds, " and ") + ` order by updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund positions failed", "err", err)
 		return nil, apperr.Internal("list fund positions", err)
 	}
 	defer rows.Close()
@@ -315,11 +332,16 @@ func (s *Store) ListFundPositions(ctx context.Context, f FundPositionFilter) ([]
 	for rows.Next() {
 		p, err := scanFundPosition(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fund position failed", "err", err)
 			return nil, apperr.Internal("scan fund position", err)
 		}
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund positions rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // SumPositionsInvestedRSD totals total_invested_rsd across all
@@ -330,6 +352,7 @@ func (s *Store) SumPositionsInvestedRSD(ctx context.Context, fundID string) (str
 	           from "trading".client_fund_positions where fund_id = $1`
 	var out string
 	if err := s.DB.QueryRow(ctx, q, fundID).Scan(&out); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "sum fund positions invested failed", "err", err, "fund_id", fundID)
 		return "", apperr.Internal("sum fund positions invested", err)
 	}
 	return out, nil
@@ -347,6 +370,7 @@ func (s *Store) SetFundReinvestDividends(ctx context.Context, fundID string, ena
 		if noRows(err) {
 			return nil, apperr.NotFound("fond ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set fund reinvest dividends failed", "err", err, "fund_id", fundID)
 		return nil, apperr.Internal("set fund reinvest dividends", err)
 	}
 	return out, nil
@@ -394,10 +418,12 @@ func (s *Store) InsertFundDividendDistribution(ctx context.Context, tx pgx.Tx, d
 			             where dividend_payout_id = $1 and client_id = $2`
 			out, gerr := scanFundDividendDistribution(tx.QueryRow(ctx, sel, d.DividendPayoutID, d.ClientID))
 			if gerr != nil {
+				logger.From(ctx).ErrorContext(ctx, "get fund dividend distribution failed", "err", gerr)
 				return nil, apperr.Internal("get fund dividend distribution", gerr)
 			}
 			return out, nil
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert fund dividend distribution failed", "err", err)
 		return nil, apperr.Internal("insert fund dividend distribution", err)
 	}
 	return out, nil
@@ -411,6 +437,7 @@ func (s *Store) ListFundDividendDistributions(ctx context.Context, fundID string
 	           where fund_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, fundID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund dividend distributions failed", "err", err, "fund_id", fundID)
 		return nil, apperr.Internal("list fund dividend distributions", err)
 	}
 	defer rows.Close()
@@ -418,11 +445,16 @@ func (s *Store) ListFundDividendDistributions(ctx context.Context, fundID string
 	for rows.Next() {
 		d, err := scanFundDividendDistribution(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fund dividend distribution failed", "err", err, "fund_id", fundID)
 			return nil, apperr.Internal("scan fund dividend distribution", err)
 		}
 		out = append(out, d)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund dividend distributions rows failed", "err", err, "fund_id", fundID)
+		return out, err
+	}
+	return out, nil
 }
 
 // =====================================================================
@@ -478,6 +510,7 @@ func (s *Store) InsertFundTransaction(ctx context.Context, tx pgx.Tx, t *domain.
 	)
 	out, err := scanFundTx(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert fund tx failed", "err", err)
 		return nil, apperr.Internal("insert fund tx", err)
 	}
 	return out, nil
@@ -508,6 +541,7 @@ func (s *Store) MarkFundTransactionStatus(
 		if noRows(err) {
 			return nil, apperr.NotFound("fund transaction ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "mark fund tx status failed", "err", err, "saga_id", sagaID)
 		return nil, apperr.Internal("mark fund tx status", err)
 	}
 	return out, nil
@@ -521,6 +555,7 @@ func (s *Store) GetFundTransaction(ctx context.Context, id string) (*domain.Fund
 		if noRows(err) {
 			return nil, apperr.NotFound("fund transaction ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fund transaction failed", "err", err, "id", id)
 		return nil, apperr.Internal("get fund transaction", err)
 	}
 	return out, nil
@@ -536,6 +571,7 @@ func (s *Store) GetFundTransactionBySagaID(ctx context.Context, sagaID string) (
 		if noRows(err) {
 			return nil, apperr.NotFound("fund transaction za saga ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get fund transaction by saga failed", "err", err, "saga_id", sagaID)
 		return nil, apperr.Internal("get fund transaction by saga", err)
 	}
 	return out, nil
@@ -579,6 +615,7 @@ func (s *Store) ListFundTransactions(ctx context.Context, f FundTransactionFilte
 	countSQL := `select count(*) from "trading".client_fund_transactions` + where
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), countSQL, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count fund transactions failed", "err", err)
 		return nil, 0, apperr.Internal("count fund transactions", err)
 	}
 	args = append(args, pageSize, (page-1)*pageSize)
@@ -586,6 +623,7 @@ func (s *Store) ListFundTransactions(ctx context.Context, f FundTransactionFilte
 		` order by created_at desc limit ` + intArg(len(args)-1) + ` offset ` + intArg(len(args))
 	rows, err := s.DB.Query(postgres.WithRead(ctx), pageSQL, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund transactions failed", "err", err)
 		return nil, 0, apperr.Internal("list fund transactions", err)
 	}
 	defer rows.Close()
@@ -593,11 +631,16 @@ func (s *Store) ListFundTransactions(ctx context.Context, f FundTransactionFilte
 	for rows.Next() {
 		t, err := scanFundTx(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fund tx failed", "err", err)
 			return nil, 0, apperr.Internal("scan fund tx", err)
 		}
 		out = append(out, t)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund transactions rows failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // =====================================================================
@@ -613,6 +656,7 @@ func (s *Store) InsertFundPerformanceSnapshot(ctx context.Context, snap *domain.
         values ($1, $2, $3::numeric, $4::numeric)
         on conflict (fund_id, snapshot_at) do nothing`
 	if _, err := s.DB.Exec(ctx, q, snap.FundID, snap.SnapshotAt, snap.LiquidRSD, snap.HoldingsValueRSD); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert fund snapshot failed", "err", err)
 		return apperr.Internal("insert fund snapshot", err)
 	}
 	return nil
@@ -632,6 +676,7 @@ func (s *Store) ListFundPerformanceSnapshots(ctx context.Context, fundID string,
         order by snapshot_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, fundID, since)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund snapshots failed", "err", err, "fund_id", fundID)
 		return nil, apperr.Internal("list fund snapshots", err)
 	}
 	defer rows.Close()
@@ -639,9 +684,14 @@ func (s *Store) ListFundPerformanceSnapshots(ctx context.Context, fundID string,
 	for rows.Next() {
 		var snap domain.FundPerformanceSnapshot
 		if err := rows.Scan(&snap.FundID, &snap.SnapshotAt, &snap.LiquidRSD, &snap.HoldingsValueRSD); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan fund snapshot failed", "err", err, "fund_id", fundID)
 			return nil, apperr.Internal("scan fund snapshot", err)
 		}
 		out = append(out, &snap)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list fund performance snapshots rows failed", "err", err, "fund_id", fundID)
+		return out, err
+	}
+	return out, nil
 }

--- a/services/trading/internal/store/interbank_retry.go
+++ b/services/trading/internal/store/interbank_retry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
 )
@@ -36,6 +37,7 @@ func (s *Store) EnqueueInterbankRetry(ctx context.Context, e *domain.InterbankRe
 		string(e.UserKind), e.NextRetryAt, e.DeadlineAt)
 	out, err := scanInterbankRetry(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "enqueue interbank retry failed", "err", err)
 		return nil, apperr.Internal("enqueue interbank retry", err)
 	}
 	return out, nil
@@ -48,10 +50,15 @@ func (s *Store) ListDueInterbankRetries(ctx context.Context, now time.Time) ([]*
 	      where status = 'pending' and next_retry_at <= $1 order by next_retry_at asc`
 	rows, err := s.DB.Query(ctx, q, now)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due interbank retries failed", "err", err)
 		return nil, apperr.Internal("list due interbank retries", err)
 	}
 	defer rows.Close()
-	return scanInterbankRetries(rows)
+	out, err := scanInterbankRetries(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due interbank retries failed", "err", err)
+	}
+	return out, err
 }
 
 // ListInterbankRetriesByUser returns every retry entry (any status) for
@@ -61,10 +68,15 @@ func (s *Store) ListInterbankRetriesByUser(ctx context.Context, userID string) (
 	      where user_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(ctx, q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list interbank retries failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list interbank retries", err)
 	}
 	defer rows.Close()
-	return scanInterbankRetries(rows)
+	out, err := scanInterbankRetries(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list interbank retries by user failed", "err", err, "user_id", userID)
+	}
+	return out, err
 }
 
 // MarkInterbankRetrySucceeded flips an entry to succeeded.
@@ -72,6 +84,7 @@ func (s *Store) MarkInterbankRetrySucceeded(ctx context.Context, id string) erro
 	const q = `update "trading".interbank_retry_queue
 	           set status = 'succeeded', updated_at = now() where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark interbank retry succeeded failed", "err", err, "id", id)
 		return apperr.Internal("mark interbank retry succeeded", err)
 	}
 	return nil
@@ -82,6 +95,7 @@ func (s *Store) MarkInterbankRetryFailed(ctx context.Context, id, lastErr string
 	const q = `update "trading".interbank_retry_queue
 	           set status = 'failed', last_error = $2, updated_at = now() where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, lastErr); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark interbank retry failed failed", "err", err, "id", id)
 		return apperr.Internal("mark interbank retry failed", err)
 	}
 	return nil
@@ -97,6 +111,7 @@ func (s *Store) RescheduleInterbankRetry(ctx context.Context, id string, nextRet
 	               updated_at = now()
 	           where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, nextRetryAt, lastErr); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reschedule interbank retry failed", "err", err, "id", id)
 		return apperr.Internal("reschedule interbank retry", err)
 	}
 	return nil

--- a/services/trading/internal/store/listings.go
+++ b/services/trading/internal/store/listings.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -47,6 +48,7 @@ func (s *Store) UpsertListing(ctx context.Context, l *domain.Listing) (*domain.L
 	)
 	out, err := scanListing(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert listing failed", "err", err)
 		return nil, apperr.Internal("upsert listing", err)
 	}
 	return out, nil
@@ -60,6 +62,7 @@ func (s *Store) GetListing(ctx context.Context, id string) (*domain.Listing, err
 		if noRows(err) {
 			return nil, apperr.NotFound("listing not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get listing failed", "err", err, "id", id)
 		return nil, apperr.Internal("get listing", err)
 	}
 	return out, nil
@@ -74,6 +77,7 @@ func (s *Store) GetListingBySecurityID(ctx context.Context, securityID string) (
 		if noRows(err) {
 			return nil, apperr.NotFound("listing not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get listing by security failed", "err", err, "security_id", securityID)
 		return nil, apperr.Internal("get listing by security", err)
 	}
 	return out, nil
@@ -139,6 +143,7 @@ func (s *Store) ListListings(ctx context.Context, f ListingFilter, page, pageSiz
 		`select count(*) from "trading".listings l join "trading".securities s on s.id = l.security_id`+where,
 		args...,
 	).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count listings failed", "err", err)
 		return nil, 0, apperr.Internal("count listings", err)
 	}
 
@@ -167,6 +172,7 @@ func (s *Store) ListListings(ctx context.Context, f ListingFilter, page, pageSiz
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list listings failed", "err", err)
 		return nil, 0, apperr.Internal("list listings", err)
 	}
 	defer rows.Close()
@@ -175,11 +181,16 @@ func (s *Store) ListListings(ctx context.Context, f ListingFilter, page, pageSiz
 	for rows.Next() {
 		sec, list, err := scanSecurityWithListing(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan listing row failed", "err", err)
 			return nil, 0, apperr.Internal("scan listing row", err)
 		}
 		out = append(out, &ListListingsRow{Security: sec, Listing: list})
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list listings rows failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // GetListingDailyHistory returns daily history rows in date asc order
@@ -200,6 +211,7 @@ func (s *Store) GetListingDailyHistory(ctx context.Context, listingID string, fr
 	q += " order by date asc"
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "listing daily failed", "err", err, "listing_id", listingID)
 		return nil, apperr.Internal("listing daily", err)
 	}
 	defer rows.Close()
@@ -207,12 +219,17 @@ func (s *Store) GetListingDailyHistory(ctx context.Context, listingID string, fr
 	for rows.Next() {
 		var r domain.ListingDailyPrice
 		if err := rows.Scan(&r.Date, &r.Price, &r.Ask, &r.Bid, &r.ChangeAmt, &r.Volume); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan daily failed", "err", err, "listing_id", listingID)
 			return nil, apperr.Internal("scan daily", err)
 		}
 		r.ListingID = listingID
 		out = append(out, &r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "get listing daily history rows failed", "err", err, "listing_id", listingID)
+		return out, err
+	}
+	return out, nil
 }
 
 // UpsertListingDaily writes one historical row per (listing, date).
@@ -225,6 +242,7 @@ func (s *Store) UpsertListingDaily(ctx context.Context, r *domain.ListingDailyPr
             price = excluded.price, ask = excluded.ask, bid = excluded.bid,
             change_amt = excluded.change_amt, volume = excluded.volume`
 	if _, err := s.DB.Exec(ctx, q, r.ListingID, r.Date, r.Price, r.Ask, r.Bid, r.ChangeAmt, r.Volume); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "upsert listing daily failed", "err", err)
 		return apperr.Internal("upsert listing daily", err)
 	}
 	return nil

--- a/services/trading/internal/store/option_exercises.go
+++ b/services/trading/internal/store/option_exercises.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
 )
@@ -37,6 +38,7 @@ func (s *Store) InsertPendingOptionExercise(ctx context.Context, tx pgx.Tx, e *d
 	)
 	out, err := scanOptionExercise(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert pending option exercise failed", "err", err)
 		return nil, apperr.Internal("insert pending option exercise", err)
 	}
 	return out, nil
@@ -54,6 +56,7 @@ func (s *Store) MarkOptionExerciseSettled(ctx context.Context, tx pgx.Tx, exerci
             updated_at       = now()
         where id = $1`
 	if _, err := tx.Exec(ctx, q, exerciseID, bankOpID, realizedGainID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark option exercise settled failed", "err", err, "exercise_id", exerciseID, "bank_op_id", bankOpID)
 		return apperr.Internal("mark option exercise settled", err)
 	}
 	return nil
@@ -81,6 +84,7 @@ func (s *Store) AdjustHoldingQuantity(ctx context.Context, tx pgx.Tx, holdingID 
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nedovoljno količine za promenu")
 		}
+		logger.From(ctx).ErrorContext(ctx, "adjust holding quantity failed", "err", err, "holding_id", holdingID)
 		return nil, apperr.Internal("adjust holding quantity", err)
 	}
 	return out, nil

--- a/services/trading/internal/store/orders.go
+++ b/services/trading/internal/store/orders.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -111,6 +112,7 @@ func (s *Store) CreateOrder(ctx context.Context, o *domain.Order) (*domain.Order
 	)
 	out, err := scanOrder(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create order failed", "err", err)
 		return nil, apperr.Internal("create order", err)
 	}
 	return out, nil
@@ -124,6 +126,7 @@ func (s *Store) GetOrder(ctx context.Context, id string) (*domain.Order, error) 
 		if noRows(err) {
 			return nil, apperr.NotFound("nalog ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get order failed", "err", err, "id", id)
 		return nil, apperr.Internal("get order", err)
 	}
 	return out, nil
@@ -210,6 +213,7 @@ func (s *Store) ListOrders(ctx context.Context, f OrderFilter, page, pageSize in
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "trading".orders`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count orders failed", "err", err)
 		return nil, 0, apperr.Internal("count orders", err)
 	}
 
@@ -222,6 +226,7 @@ func (s *Store) ListOrders(ctx context.Context, f OrderFilter, page, pageSize in
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list orders failed", "err", err)
 		return nil, 0, apperr.Internal("list orders", err)
 	}
 	defer rows.Close()
@@ -229,11 +234,16 @@ func (s *Store) ListOrders(ctx context.Context, f OrderFilter, page, pageSize in
 	for rows.Next() {
 		o, err := scanOrder(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan order failed", "err", err)
 			return nil, 0, apperr.Internal("scan order", err)
 		}
 		out = append(out, o)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list orders rows failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // ApproveOrder marks the order approved and stamps approver/timestamp.
@@ -251,6 +261,7 @@ func (s *Store) ApproveOrder(ctx context.Context, orderID, approverID string) (*
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nalog nije u stanju 'pending'")
 		}
+		logger.From(ctx).ErrorContext(ctx, "approve order failed", "err", err, "order_id", orderID, "approver_id", approverID)
 		return nil, apperr.Internal("approve order", err)
 	}
 	return out, nil
@@ -269,6 +280,7 @@ func (s *Store) DeclineOrder(ctx context.Context, orderID, approverID string) (*
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nalog nije u stanju 'pending'")
 		}
+		logger.From(ctx).ErrorContext(ctx, "decline order failed", "err", err, "order_id", orderID, "approver_id", approverID)
 		return nil, apperr.Internal("decline order", err)
 	}
 	return out, nil
@@ -288,6 +300,7 @@ func (s *Store) CancelOrder(ctx context.Context, orderID string) (*domain.Order,
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nalog se ne može otkazati")
 		}
+		logger.From(ctx).ErrorContext(ctx, "cancel order failed", "err", err, "order_id", orderID)
 		return nil, apperr.Internal("cancel order", err)
 	}
 	return out, nil
@@ -315,6 +328,7 @@ func (s *Store) PartialCancelOrder(ctx context.Context, orderID string, qty int3
 		if noRows(err) {
 			return nil, apperr.FailedPrecondition("nalog se ne može delimično otkazati")
 		}
+		logger.From(ctx).ErrorContext(ctx, "partial cancel order failed", "err", err, "order_id", orderID)
 		return nil, apperr.Internal("partial cancel order", err)
 	}
 	return out, nil
@@ -331,6 +345,7 @@ func (s *Store) CancelOrderTx(ctx context.Context, tx pgx.Tx, orderID string) er
         set cancelled = true, last_modification = now()
         where id = $1 and cancelled = false`
 	if _, err := tx.Exec(ctx, q, orderID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "cancel order (tx) failed", "err", err, "order_id", orderID)
 		return apperr.Internal("cancel order (tx)", err)
 	}
 	return nil
@@ -349,6 +364,7 @@ func (s *Store) GetActiveOrdersForExecution(ctx context.Context, limit int) ([]*
 	      limit $1`
 	rows, err := s.DB.Query(ctx, q, limit)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "active orders failed", "err", err)
 		return nil, apperr.Internal("active orders", err)
 	}
 	defer rows.Close()
@@ -356,11 +372,16 @@ func (s *Store) GetActiveOrdersForExecution(ctx context.Context, limit int) ([]*
 	for rows.Next() {
 		o, err := scanOrder(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan active order failed", "err", err)
 			return nil, apperr.Internal("scan active order", err)
 		}
 		out = append(out, o)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "get active orders for execution rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanOrder(row pgx.Row) (*domain.Order, error) {

--- a/services/trading/internal/store/otc.go
+++ b/services/trading/internal/store/otc.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -77,6 +78,7 @@ func (s *Store) InsertOTCOffer(ctx context.Context, tx pgx.Tx, o *domain.OTCOffe
 	)
 	out, err := scanOTCOffer(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert otc offer failed", "err", err)
 		return nil, apperr.Internal("insert otc offer", err)
 	}
 	// First-iteration convention: thread_id == id when caller left it
@@ -86,6 +88,7 @@ func (s *Store) InsertOTCOffer(ctx context.Context, tx pgx.Tx, o *domain.OTCOffe
 		row := execer.QueryRow(ctx, u, out.ID)
 		out, err = scanOTCOffer(row)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "update thread_id failed", "err", err)
 			return nil, apperr.Internal("update thread_id", err)
 		}
 	}
@@ -100,6 +103,7 @@ func (s *Store) GetOTCOffer(ctx context.Context, id string) (*domain.OTCOffer, e
 		if noRows(err) {
 			return nil, apperr.NotFound("ponuda ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get otc offer failed", "err", err, "id", id)
 		return nil, apperr.Internal("get otc offer", err)
 	}
 	return out, nil
@@ -128,6 +132,7 @@ func (s *Store) GetOpenOTCOfferByThread(ctx context.Context, tx pgx.Tx, threadID
 		if noRows(err) {
 			return nil, apperr.NotFound("nema aktivne iteracije")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get open otc offer failed", "err", err, "thread_id", threadID)
 		return nil, apperr.Internal("get open otc offer", err)
 	}
 	return out, nil
@@ -139,6 +144,7 @@ func (s *Store) ListOTCThread(ctx context.Context, threadID string) ([]*domain.O
 	           where thread_id = $1 order by created_at`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, threadID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc thread failed", "err", err, "thread_id", threadID)
 		return nil, apperr.Internal("list otc thread", err)
 	}
 	defer rows.Close()
@@ -146,11 +152,16 @@ func (s *Store) ListOTCThread(ctx context.Context, threadID string) ([]*domain.O
 	for rows.Next() {
 		o, err := scanOTCOffer(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc offer failed", "err", err, "thread_id", threadID)
 			return nil, apperr.Internal("scan otc offer", err)
 		}
 		out = append(out, o)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc thread rows failed", "err", err, "thread_id", threadID)
+		return out, err
+	}
+	return out, nil
 }
 
 // OTCThreadFilter narrows ListLatestOTCOffers — the "Aktivne ponude" view.
@@ -199,6 +210,7 @@ func (s *Store) ListLatestOTCOffers(ctx context.Context, f OTCThreadFilter) ([]*
         order by o.updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc threads failed", "err", err)
 		return nil, apperr.Internal("list otc threads", err)
 	}
 	defer rows.Close()
@@ -206,11 +218,16 @@ func (s *Store) ListLatestOTCOffers(ctx context.Context, f OTCThreadFilter) ([]*
 	for rows.Next() {
 		o, err := scanOTCOffer(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc offer failed", "err", err)
 			return nil, apperr.Internal("scan otc offer", err)
 		}
 		out = append(out, o)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list latest otc offers rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // MarkOTCOfferStatus flips the status of a single iteration. Inside the
@@ -225,6 +242,7 @@ func (s *Store) MarkOTCOfferStatus(ctx context.Context, tx pgx.Tx, offerID strin
 		if noRows(err) {
 			return nil, apperr.NotFound("ponuda ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update otc offer status failed", "err", err, "offer_id", offerID)
 		return nil, apperr.Internal("update otc offer status", err)
 	}
 	return out, nil
@@ -240,6 +258,7 @@ func (s *Store) ListStaleOpenOTCOffers(ctx context.Context, cutoff time.Time) ([
 	           order by updated_at`
 	rows, err := s.DB.Query(ctx, q, cutoff)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list stale open otc offers failed", "err", err)
 		return nil, apperr.Internal("list stale open otc offers", err)
 	}
 	defer rows.Close()
@@ -247,11 +266,16 @@ func (s *Store) ListStaleOpenOTCOffers(ctx context.Context, cutoff time.Time) ([
 	for rows.Next() {
 		o, err := scanOTCOffer(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc offer failed", "err", err)
 			return nil, apperr.Internal("scan otc offer", err)
 		}
 		out = append(out, o)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list stale open otc offers rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListOpenOTCOffersExpiringSoon returns open offer iterations whose last
@@ -268,6 +292,7 @@ func (s *Store) ListOpenOTCOffersExpiringSoon(ctx context.Context, warnFrom, war
 	           order by updated_at`
 	rows, err := s.DB.Query(ctx, q, warnFrom, warnTo)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list open otc offers expiring soon failed", "err", err)
 		return nil, apperr.Internal("list open otc offers expiring soon", err)
 	}
 	defer rows.Close()
@@ -275,11 +300,16 @@ func (s *Store) ListOpenOTCOffersExpiringSoon(ctx context.Context, warnFrom, war
 	for rows.Next() {
 		o, err := scanOTCOffer(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc offer failed", "err", err)
 			return nil, apperr.Internal("scan otc offer", err)
 		}
 		out = append(out, o)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list open otc offers expiring soon rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // SupersedePriorOTCOffers flips every `open` iteration in a thread to
@@ -290,6 +320,7 @@ func (s *Store) SupersedePriorOTCOffers(ctx context.Context, tx pgx.Tx, threadID
 	           set status = 'superseded', updated_at = now()
 	           where thread_id = $1 and status = 'open'`
 	if _, err := tx.Exec(ctx, q, threadID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "supersede prior otc offers failed", "err", err, "thread_id", threadID)
 		return apperr.Internal("supersede prior otc offers", err)
 	}
 	return nil
@@ -304,12 +335,14 @@ func (s *Store) MarkAllOTCOffersAcceptedInThread(ctx context.Context, tx pgx.Tx,
 	            set status = 'accepted', updated_at = now()
 	            where id = $1`
 	if _, err := tx.Exec(ctx, q1, acceptedOfferID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark otc offer accepted failed", "err", err, "thread_id", threadID, "accepted_offer_id", acceptedOfferID)
 		return apperr.Internal("mark otc offer accepted", err)
 	}
 	const q2 = `update "trading".otc_offers
 	            set status = 'superseded', updated_at = now()
 	            where thread_id = $1 and id <> $2 and status = 'open'`
 	if _, err := tx.Exec(ctx, q2, threadID, acceptedOfferID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark prior accepted thread offers failed", "err", err, "thread_id", threadID, "accepted_offer_id", acceptedOfferID)
 		return apperr.Internal("mark prior accepted thread offers", err)
 	}
 	return nil
@@ -383,6 +416,7 @@ func (s *Store) InsertOTCContract(ctx context.Context, tx pgx.Tx, c *domain.OTCC
 	)
 	out, err := scanOTCContract(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert otc contract failed", "err", err)
 		return nil, apperr.Internal("insert otc contract", err)
 	}
 	return out, nil
@@ -394,6 +428,7 @@ func (s *Store) InsertOTCContract(ctx context.Context, tx pgx.Tx, c *domain.OTCC
 func (s *Store) DeleteOTCContractByThread(ctx context.Context, tx pgx.Tx, threadID string) error {
 	const q = `delete from "trading".otc_contracts where thread_id = $1`
 	if _, err := tx.Exec(ctx, q, threadID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "delete otc contract by thread failed", "err", err, "thread_id", threadID)
 		return apperr.Internal("delete otc contract by thread", err)
 	}
 	return nil
@@ -407,6 +442,7 @@ func (s *Store) GetOTCContract(ctx context.Context, id string) (*domain.OTCContr
 		if noRows(err) {
 			return nil, apperr.NotFound("ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get otc contract failed", "err", err, "id", id)
 		return nil, apperr.Internal("get otc contract", err)
 	}
 	return out, nil
@@ -420,6 +456,7 @@ func (s *Store) GetOTCContractByThread(ctx context.Context, threadID string) (*d
 		if noRows(err) {
 			return nil, apperr.NotFound("ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get otc contract by thread failed", "err", err, "thread_id", threadID)
 		return nil, apperr.Internal("get otc contract by thread", err)
 	}
 	return out, nil
@@ -446,6 +483,7 @@ func (s *Store) MarkOTCContractStatus(
 		if noRows(err) {
 			return nil, apperr.NotFound("ugovor ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update otc contract status failed", "err", err, "exercised_op_id", exercisedOpID, "exercise_saga_id", exerciseSagaID)
 		return nil, apperr.Internal("update otc contract status", err)
 	}
 	return out, nil
@@ -481,6 +519,7 @@ func (s *Store) ListOTCContracts(ctx context.Context, f OTCContractFilter) ([]*d
 	q := `select ` + otcContractCols + ` from "trading".otc_contracts where ` + strings.Join(conds, " and ") + ` order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc contracts failed", "err", err)
 		return nil, apperr.Internal("list otc contracts", err)
 	}
 	defer rows.Close()
@@ -488,11 +527,16 @@ func (s *Store) ListOTCContracts(ctx context.Context, f OTCContractFilter) ([]*d
 	for rows.Next() {
 		c, err := scanOTCContract(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc contract failed", "err", err)
 			return nil, apperr.Internal("scan otc contract", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc contracts rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListExpiredOTCContracts returns active contracts whose settlement_date
@@ -503,6 +547,7 @@ func (s *Store) ListExpiredOTCContracts(ctx context.Context, today time.Time) ([
 	           order by settlement_date`
 	rows, err := s.DB.Query(ctx, q, today)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list expired otc contracts failed", "err", err)
 		return nil, apperr.Internal("list expired otc contracts", err)
 	}
 	defer rows.Close()
@@ -510,11 +555,16 @@ func (s *Store) ListExpiredOTCContracts(ctx context.Context, today time.Time) ([
 	for rows.Next() {
 		c, err := scanOTCContract(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc contract failed", "err", err)
 			return nil, apperr.Internal("scan otc contract", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list expired otc contracts rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListOTCContractsExpiringSoon returns active contracts whose
@@ -536,6 +586,7 @@ func (s *Store) ListOTCContractsExpiringSoon(ctx context.Context, now time.Time,
 	           order by settlement_date`
 	rows, err := s.DB.Query(ctx, q, dayStart, dayEnd)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc contracts expiring soon failed", "err", err)
 		return nil, apperr.Internal("list otc contracts expiring soon", err)
 	}
 	defer rows.Close()
@@ -543,11 +594,16 @@ func (s *Store) ListOTCContractsExpiringSoon(ctx context.Context, now time.Time,
 	for rows.Next() {
 		c, err := scanOTCContract(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan otc contract expiring soon failed", "err", err)
 			return nil, apperr.Internal("scan otc contract expiring soon", err)
 		}
 		out = append(out, c)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list otc contracts expiring soon rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListPublicHoldings returns holding rows with public_count > reserved_count
@@ -560,6 +616,7 @@ func (s *Store) ListPublicHoldings(ctx context.Context, excludeUserID string) ([
 	           order by updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, excludeUserID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list public holdings failed", "err", err, "exclude_user_id", excludeUserID)
 		return nil, apperr.Internal("list public holdings", err)
 	}
 	defer rows.Close()
@@ -567,9 +624,14 @@ func (s *Store) ListPublicHoldings(ctx context.Context, excludeUserID string) ([
 	for rows.Next() {
 		h, err := scanHolding(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan holding failed", "err", err, "exclude_user_id", excludeUserID)
 			return nil, apperr.Internal("scan holding", err)
 		}
 		out = append(out, h)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list public holdings rows failed", "err", err, "exclude_user_id", excludeUserID)
+		return out, err
+	}
+	return out, nil
 }

--- a/services/trading/internal/store/portfolio.go
+++ b/services/trading/internal/store/portfolio.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -28,6 +29,7 @@ func (s *Store) GetHolding(ctx context.Context, tx pgx.Tx, userID, userKind, sec
 		if noRows(err) {
 			return nil, apperr.NotFound("holding not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get holding failed", "err", err, "user_id", userID, "security_id", securityID)
 		return nil, apperr.Internal("get holding", err)
 	}
 	return out, nil
@@ -56,6 +58,7 @@ func (s *Store) ApplyBuyFill(
 	row := tx.QueryRow(ctx, q, userID, userKind, securityID, accountID, qty, pricePerUnit)
 	out, err := scanHolding(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "apply buy fill failed", "err", err, "user_id", userID, "security_id", securityID)
 		return nil, apperr.Internal("apply buy fill", err)
 	}
 	return out, nil
@@ -98,6 +101,7 @@ func (s *Store) ApplySellFill(
 		if noRows(err) {
 			return "", nil, apperr.FailedPrecondition("nedovoljna količina za prodaju")
 		}
+		logger.From(ctx).ErrorContext(ctx, "apply sell fill failed", "err", err, "user_id", userID, "security_id", securityID)
 		return "", nil, apperr.Internal("apply sell fill", err)
 	}
 	h.UserKind = domain.UserKind(t)
@@ -134,6 +138,7 @@ func (s *Store) ListHoldings(ctx context.Context, f HoldingFilter) ([]*domain.Ho
 	q := `select ` + holdingCols + ` from "trading".portfolio_holdings` + where + ` order by updated_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list holdings failed", "err", err)
 		return nil, apperr.Internal("list holdings", err)
 	}
 	defer rows.Close()
@@ -141,11 +146,16 @@ func (s *Store) ListHoldings(ctx context.Context, f HoldingFilter) ([]*domain.Ho
 	for rows.Next() {
 		h, err := scanHolding(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan holding failed", "err", err)
 			return nil, apperr.Internal("scan holding", err)
 		}
 		out = append(out, h)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list holdings rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // SetPublicCount updates the spec p.61 OTC public-share count for c4.
@@ -162,6 +172,7 @@ func (s *Store) SetPublicCount(ctx context.Context, holdingID string, count int3
 		if noRows(err) {
 			return nil, apperr.NotFound("holding ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set public count failed", "err", err, "holding_id", holdingID)
 		return nil, apperr.Internal("set public count", err)
 	}
 	return out, nil
@@ -175,6 +186,7 @@ func (s *Store) GetHoldingByID(ctx context.Context, id string) (*domain.Holding,
 		if noRows(err) {
 			return nil, apperr.NotFound("holding ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get holding failed", "err", err, "id", id)
 		return nil, apperr.Internal("get holding", err)
 	}
 	return out, nil
@@ -195,6 +207,7 @@ func (s *Store) GetHoldingForUpdate(ctx context.Context, tx pgx.Tx, id string) (
 		if noRows(err) {
 			return nil, apperr.NotFound("holding ne postoji")
 		}
+		logger.From(ctx).ErrorContext(ctx, "lock holding failed", "err", err, "id", id)
 		return nil, apperr.Internal("lock holding", err)
 	}
 	return out, nil
@@ -239,6 +252,7 @@ func (s *Store) IncrementReservedHolding(ctx context.Context, tx pgx.Tx, holding
 		if isCheckViolation(err) {
 			return nil, apperr.FailedPrecondition("nedovoljno raspoloživih akcija za rezervaciju")
 		}
+		logger.From(ctx).ErrorContext(ctx, "increment reserved failed", "err", err, "holding_id", holdingID)
 		return nil, apperr.Internal("increment reserved", err)
 	}
 	return out, nil
@@ -265,8 +279,10 @@ func (s *Store) DecrementReservedHolding(ctx context.Context, tx pgx.Tx, holding
 			return nil, apperr.NotFound("holding ne postoji")
 		}
 		if isCheckViolation(err) {
+			logger.From(ctx).ErrorContext(ctx, "rezervacija je negativna failed", "err", err, "holding_id", holdingID)
 			return nil, apperr.Internal("rezervacija je negativna", err)
 		}
+		logger.From(ctx).ErrorContext(ctx, "decrement reserved failed", "err", err, "holding_id", holdingID)
 		return nil, apperr.Internal("decrement reserved", err)
 	}
 	return out, nil

--- a/services/trading/internal/store/postgres.go
+++ b/services/trading/internal/store/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/jackc/pgx/v5"
 )
@@ -93,13 +94,17 @@ func intArg(n int) string {
 func (s *Store) ExecuteAtomic(ctx context.Context, fn func(pgx.Tx) error) error {
 	tx, err := s.DB.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "begin tx failed", "err", err)
 		return apperr.Internal("begin tx", err)
 	}
 	if err := fn(tx); err != nil {
-		_ = tx.Rollback(ctx)
+		if rerr := tx.Rollback(ctx); rerr != nil && !errors.Is(rerr, pgx.ErrTxClosed) {
+			logger.From(ctx).WarnContext(ctx, "rollback tx failed", "err", rerr)
+		}
 		return err
 	}
 	if err := tx.Commit(ctx); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "commit tx failed", "err", err)
 		return apperr.Internal("commit tx", err)
 	}
 	return nil

--- a/services/trading/internal/store/price_alerts.go
+++ b/services/trading/internal/store/price_alerts.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -24,6 +25,7 @@ func (s *Store) InsertPriceAlert(ctx context.Context, a *domain.PriceAlert) (*do
 		a.UserID, string(a.UserKind), a.SecurityID, a.Threshold, string(a.Condition))
 	out, err := scanPriceAlert(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert price alert failed", "err", err)
 		return nil, apperr.Internal("insert price alert", err)
 	}
 	return out, nil
@@ -36,10 +38,15 @@ func (s *Store) ListPriceAlertsByUser(ctx context.Context, userID string) ([]*do
 	      where user_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list price alerts failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list price alerts", err)
 	}
 	defer rows.Close()
-	return scanPriceAlerts(rows)
+	out, err := scanPriceAlerts(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list price alerts by user failed", "err", err, "user_id", userID)
+	}
+	return out, err
 }
 
 // ListActivePriceAlerts returns every active alert across all users —
@@ -49,10 +56,15 @@ func (s *Store) ListActivePriceAlerts(ctx context.Context) ([]*domain.PriceAlert
 	      where is_active = true order by created_at asc`
 	rows, err := s.DB.Query(ctx, q)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list active price alerts failed", "err", err)
 		return nil, apperr.Internal("list active price alerts", err)
 	}
 	defer rows.Close()
-	return scanPriceAlerts(rows)
+	out, err := scanPriceAlerts(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list active price alerts failed", "err", err)
+	}
+	return out, err
 }
 
 // GetPriceAlert returns one alert by id. NotFound on miss.
@@ -63,6 +75,7 @@ func (s *Store) GetPriceAlert(ctx context.Context, id string) (*domain.PriceAler
 		if noRows(err) {
 			return nil, apperr.NotFound("price alert not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get price alert failed", "err", err, "id", id)
 		return nil, apperr.Internal("get price alert", err)
 	}
 	return out, nil
@@ -76,6 +89,7 @@ func (s *Store) DeactivatePriceAlert(ctx context.Context, id string, triggeredAt
 	           set is_active = false, triggered_at = $2
 	           where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, triggeredAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "deactivate price alert failed", "err", err, "id", id)
 		return apperr.Internal("deactivate price alert", err)
 	}
 	return nil

--- a/services/trading/internal/store/realized_gains.go
+++ b/services/trading/internal/store/realized_gains.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -42,6 +43,7 @@ func (s *Store) InsertRealizedGain(ctx context.Context, tx pgx.Tx, g *domain.Rea
 	)
 	out, err := scanRealizedGain(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert realized gain failed", "err", err)
 		return nil, apperr.Internal("insert realized gain", err)
 	}
 	return out, nil
@@ -87,6 +89,7 @@ func (s *Store) ListRealizedGains(ctx context.Context, f RealizedGainFilter) ([]
 	q := `select ` + realizedGainCols + ` from "trading".realized_gains` + where + ` order by realized_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list realized gains failed", "err", err)
 		return nil, apperr.Internal("list realized gains", err)
 	}
 	defer rows.Close()
@@ -94,11 +97,16 @@ func (s *Store) ListRealizedGains(ctx context.Context, f RealizedGainFilter) ([]
 	for rows.Next() {
 		g, err := scanRealizedGain(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan realized gain failed", "err", err)
 			return nil, apperr.Internal("scan realized gain", err)
 		}
 		out = append(out, g)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list realized gains rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // MarkRealizedGainsTaxed flips taxed=true and stamps tax_op_id +
@@ -113,6 +121,7 @@ func (s *Store) MarkRealizedGainsTaxed(ctx context.Context, tx pgx.Tx, ids []str
         set taxed = true, taxed_at = now(), tax_op_id = $2::uuid
         where id = any($1::uuid[]) and taxed = false`
 	if _, err := tx.Exec(ctx, q, ids, taxOpID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark gains taxed failed", "err", err, "tax_op_id", taxOpID)
 		return apperr.Internal("mark gains taxed", err)
 	}
 	return nil
@@ -147,6 +156,7 @@ func (s *Store) ListTaxAggregates(ctx context.Context, kind domain.UserKind) ([]
         order by user_id`
 	rows, err := s.DB.Query(ctx, q, string(kind))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list tax aggregates failed", "err", err)
 		return nil, apperr.Internal("list tax aggregates", err)
 	}
 	defer rows.Close()
@@ -157,12 +167,17 @@ func (s *Store) ListTaxAggregates(ctx context.Context, kind domain.UserKind) ([]
 			k string
 		)
 		if err := rows.Scan(&a.UserID, &k, &a.UnpaidGainRSD, &a.PaidGainYTDRSD); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan tax aggregate failed", "err", err)
 			return nil, apperr.Internal("scan tax aggregate", err)
 		}
 		a.UserKind = domain.UserKind(k)
 		out = append(out, &a)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list tax aggregates rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // ListUnpaidGainsForUser returns the not-yet-taxed positive-gain rows
@@ -177,6 +192,7 @@ func (s *Store) ListUnpaidGainsForUser(ctx context.Context, userID string, kind 
         order by realized_at asc`
 	rows, err := s.DB.Query(ctx, q, userID, string(kind))
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list unpaid gains failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list unpaid gains", err)
 	}
 	defer rows.Close()
@@ -184,11 +200,16 @@ func (s *Store) ListUnpaidGainsForUser(ctx context.Context, userID string, kind 
 	for rows.Next() {
 		g, err := scanRealizedGain(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan unpaid gain failed", "err", err, "user_id", userID)
 			return nil, apperr.Internal("scan unpaid gain", err)
 		}
 		out = append(out, g)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list unpaid gains for user rows failed", "err", err, "user_id", userID)
+		return out, err
+	}
+	return out, nil
 }
 
 // ActuaryPerformance is one row of ListActuaryPerformances — one per
@@ -229,6 +250,7 @@ func (s *Store) ListActuaryPerformances(ctx context.Context, typeFilter string) 
                  ai.employee_id`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, typeFilter)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list actuary performances failed", "err", err)
 		return nil, apperr.Internal("list actuary performances", err)
 	}
 	defer rows.Close()
@@ -239,12 +261,17 @@ func (s *Store) ListActuaryPerformances(ctx context.Context, typeFilter string) 
 			t string
 		)
 		if err := rows.Scan(&p.UserID, &t, &p.ProfitRSD, &p.RealizedCount); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan actuary performance failed", "err", err)
 			return nil, apperr.Internal("scan actuary performance", err)
 		}
 		p.ActuaryType = domain.ActuaryType(t)
 		out = append(out, &p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list actuary performances rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 // BankProfitBucket is one calendar period of realized bank profit.
@@ -271,6 +298,7 @@ func (s *Store) LatestEmployeeRealizedAt(ctx context.Context) (time.Time, bool, 
 	const q = `select max(realized_at) from "trading".realized_gains where user_kind = 'employee'`
 	var t *time.Time
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), q).Scan(&t); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "latest employee realized_at failed", "err", err)
 		return time.Time{}, false, apperr.Internal("latest employee realized_at", err)
 	}
 	if t == nil {
@@ -309,6 +337,7 @@ func (s *Store) BankProfitTimeseries(ctx context.Context, bucket string, from, t
         order by period_start asc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, bucket, from, to)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank profit timeseries failed", "err", err)
 		return nil, apperr.Internal("bank profit timeseries", err)
 	}
 	defer rows.Close()
@@ -317,11 +346,16 @@ func (s *Store) BankProfitTimeseries(ctx context.Context, bucket string, from, t
 		var b BankProfitBucket
 		if err := rows.Scan(&b.PeriodStart, &b.ProfitRSD, &b.TradingRSD,
 			&b.FundRSD, &b.CumulativeRSD, &b.RealizedCount); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan bank profit bucket failed", "err", err)
 			return nil, apperr.Internal("scan bank profit bucket", err)
 		}
 		out = append(out, &b)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "bank profit timeseries rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanRealizedGain(row pgx.Row) (*domain.RealizedGain, error) {

--- a/services/trading/internal/store/recurring_order.go
+++ b/services/trading/internal/store/recurring_order.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -38,6 +39,7 @@ func (s *Store) InsertRecurringOrder(ctx context.Context, r *domain.RecurringOrd
 		amount, qty, r.AccountID, r.Cadence, r.NextRun)
 	out, err := scanRecurringOrder(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert recurring order failed", "err", err)
 		return nil, apperr.Internal("insert recurring order", err)
 	}
 	return out, nil
@@ -50,10 +52,15 @@ func (s *Store) ListRecurringOrdersByUser(ctx context.Context, userID string) ([
 	      where user_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list recurring orders failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list recurring orders", err)
 	}
 	defer rows.Close()
-	return scanRecurringOrders(rows)
+	out, err := scanRecurringOrders(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list recurring orders by user failed", "err", err, "user_id", userID)
+	}
+	return out, err
 }
 
 // ListDueRecurringOrders returns every active recurring order whose
@@ -64,10 +71,15 @@ func (s *Store) ListDueRecurringOrders(ctx context.Context, now time.Time) ([]*d
 	      where active = true and next_run <= $1 order by next_run asc`
 	rows, err := s.DB.Query(ctx, q, now)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due recurring orders failed", "err", err)
 		return nil, apperr.Internal("list due recurring orders", err)
 	}
 	defer rows.Close()
-	return scanRecurringOrders(rows)
+	out, err := scanRecurringOrders(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due recurring orders failed", "err", err)
+	}
+	return out, err
 }
 
 // GetRecurringOrder returns one recurring order by id. NotFound on miss.
@@ -78,6 +90,7 @@ func (s *Store) GetRecurringOrder(ctx context.Context, id string) (*domain.Recur
 		if noRows(err) {
 			return nil, apperr.NotFound("trajni nalog nije pronađen")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get recurring order failed", "err", err, "id", id)
 		return nil, apperr.Internal("get recurring order", err)
 	}
 	return out, nil
@@ -89,6 +102,7 @@ func (s *Store) SetRecurringOrderActive(ctx context.Context, id string, active b
 	const q = `update "trading".recurring_orders
 	           set active = $2, updated_at = now() where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, active); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set recurring order active failed", "err", err, "id", id)
 		return apperr.Internal("set recurring order active", err)
 	}
 	return nil
@@ -100,6 +114,7 @@ func (s *Store) UpdateRecurringOrderNextRun(ctx context.Context, id string, next
 	const q = `update "trading".recurring_orders
 	           set next_run = $2, updated_at = now() where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, next); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "update recurring order next_run failed", "err", err, "id", id)
 		return apperr.Internal("update recurring order next_run", err)
 	}
 	return nil
@@ -109,6 +124,7 @@ func (s *Store) UpdateRecurringOrderNextRun(ctx context.Context, id string, next
 func (s *Store) DeleteRecurringOrder(ctx context.Context, id string) error {
 	const q = `delete from "trading".recurring_orders where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "delete recurring order failed", "err", err, "id", id)
 		return apperr.Internal("delete recurring order", err)
 	}
 	return nil

--- a/services/trading/internal/store/saga.go
+++ b/services/trading/internal/store/saga.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/saga"
 )
 
@@ -88,6 +89,7 @@ func (s *SagaStore) Insert(ctx context.Context, row *saga.Row) error {
 	}
 	logRaw, err := marshalLog(row.Log)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "encode saga log failed", "err", err, "transaction_id", row.TransactionID)
 		return apperr.Internal("encode saga log", err)
 	}
 	_, err = s.Pool.Exec(ctx, q,
@@ -98,6 +100,7 @@ func (s *SagaStore) Insert(ctx context.Context, row *saga.Row) error {
 		if isUniqueViolation(err) {
 			return saga.ErrAlreadyExists
 		}
+		logger.From(ctx).ErrorContext(ctx, "insert saga failed", "err", err, "transaction_id", row.TransactionID)
 		return apperr.Internal("insert saga", err)
 	}
 	return nil
@@ -111,6 +114,7 @@ func (s *SagaStore) Get(ctx context.Context, transactionID string) (*saga.Row, e
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
+		logger.From(ctx).ErrorContext(ctx, "get saga failed", "err", err, "transaction_id", transactionID)
 		return nil, apperr.Internal("get saga", err)
 	}
 	return out, nil
@@ -137,6 +141,7 @@ func (s *SagaStore) Update(ctx context.Context, row *saga.Row) error {
 	}
 	logRaw, err := marshalLog(row.Log)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "encode saga log failed", "err", err, "transaction_id", row.TransactionID)
 		return apperr.Internal("encode saga log", err)
 	}
 	tag, err := s.Pool.Exec(ctx, q,
@@ -145,6 +150,7 @@ func (s *SagaStore) Update(ctx context.Context, row *saga.Row) error {
 		row.NextAttemptAt,
 	)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "update saga failed", "err", err, "transaction_id", row.TransactionID)
 		return apperr.Internal("update saga", err)
 	}
 	if tag.RowsAffected() == 0 {
@@ -167,9 +173,14 @@ func (s *SagaStore) Update(ctx context.Context, row *saga.Row) error {
 func (s *SagaStore) TryLock(ctx context.Context, transactionID string, fn func(ctx context.Context) error) (bool, error) {
 	tx, err := s.Pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "begin saga lock tx failed", "err", err, "transaction_id", transactionID)
 		return false, apperr.Internal("begin saga lock tx", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() {
+		if rerr := tx.Rollback(ctx); rerr != nil && !errors.Is(rerr, pgx.ErrTxClosed) {
+			logger.From(ctx).WarnContext(ctx, "rollback saga lock tx failed", "err", rerr, "transaction_id", transactionID)
+		}
+	}()
 
 	// Use bigint hash of the transaction_id so we don't depend on
 	// hashtext (search_path-sensitive). FNV-1a is stable across runs
@@ -178,6 +189,7 @@ func (s *SagaStore) TryLock(ctx context.Context, transactionID string, fn func(c
 	key := lockKey(transactionID)
 	var acquired bool
 	if err := tx.QueryRow(ctx, `select pg_try_advisory_xact_lock($1)`, key).Scan(&acquired); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "advisory lock failed", "err", err, "transaction_id", transactionID)
 		return false, apperr.Internal("advisory lock", err)
 	}
 	if !acquired {
@@ -187,6 +199,7 @@ func (s *SagaStore) TryLock(ctx context.Context, transactionID string, fn func(c
 		return true, err
 	}
 	if err := tx.Commit(ctx); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "commit saga lock tx failed", "err", err, "transaction_id", transactionID)
 		return true, apperr.Internal("commit saga lock tx", err)
 	}
 	return true, nil
@@ -214,6 +227,7 @@ func (s *SagaStore) DueForRecovery(ctx context.Context, limit int) ([]*saga.Row,
 	      limit $2`
 	rows, err := s.Pool.Query(ctx, q, time.Now(), limit)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due sagas failed", "err", err)
 		return nil, apperr.Internal("list due sagas", err)
 	}
 	defer rows.Close()
@@ -221,9 +235,14 @@ func (s *SagaStore) DueForRecovery(ctx context.Context, limit int) ([]*saga.Row,
 	for rows.Next() {
 		r, err := scanSaga(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan saga failed", "err", err)
 			return nil, apperr.Internal("scan saga", err)
 		}
 		out = append(out, r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "due for recovery rows failed", "err", err)
+		return out, err
+	}
+	return out, nil
 }

--- a/services/trading/internal/store/scheduled_interbank.go
+++ b/services/trading/internal/store/scheduled_interbank.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -30,6 +31,7 @@ func (s *Store) InsertScheduledInterbankPayment(ctx context.Context, p *domain.S
 		p.Cadence, p.NextRun)
 	out, err := scanScheduledInterbank(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert scheduled interbank payment failed", "err", err)
 		return nil, apperr.Internal("insert scheduled interbank payment", err)
 	}
 	return out, nil
@@ -42,10 +44,15 @@ func (s *Store) ListScheduledInterbankPaymentsByUser(ctx context.Context, userID
 	      where user_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list scheduled interbank payments failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list scheduled interbank payments", err)
 	}
 	defer rows.Close()
-	return scanScheduledInterbanks(rows)
+	out, err := scanScheduledInterbanks(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list scheduled interbank payments by user failed", "err", err, "user_id", userID)
+	}
+	return out, err
 }
 
 // ListDueScheduledInterbankPayments returns every active row whose
@@ -56,10 +63,15 @@ func (s *Store) ListDueScheduledInterbankPayments(ctx context.Context, now time.
 	      where active = true and next_run <= $1 order by next_run asc`
 	rows, err := s.DB.Query(ctx, q, now)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due scheduled interbank payments failed", "err", err)
 		return nil, apperr.Internal("list due scheduled interbank payments", err)
 	}
 	defer rows.Close()
-	return scanScheduledInterbanks(rows)
+	out, err := scanScheduledInterbanks(rows)
+	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list due scheduled interbank payments failed", "err", err)
+	}
+	return out, err
 }
 
 // GetScheduledInterbankPayment returns one row by id. NotFound on miss.
@@ -70,6 +82,7 @@ func (s *Store) GetScheduledInterbankPayment(ctx context.Context, id string) (*d
 		if noRows(err) {
 			return nil, apperr.NotFound("zakazana inostrana uplata nije pronađena")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get scheduled interbank payment failed", "err", err, "id", id)
 		return nil, apperr.Internal("get scheduled interbank payment", err)
 	}
 	return out, nil
@@ -81,6 +94,7 @@ func (s *Store) SetScheduledInterbankPaymentActive(ctx context.Context, id strin
 	const q = `update "trading".scheduled_interbank_payments
 	           set active = $2, updated_at = now() where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, active); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set scheduled interbank payment active failed", "err", err, "id", id)
 		return apperr.Internal("set scheduled interbank payment active", err)
 	}
 	return nil
@@ -99,6 +113,7 @@ func (s *Store) AdvanceScheduledInterbankPayment(ctx context.Context, id string,
 	               updated_at = now()
 	           where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id, next, deactivate, lastStatus, lastErr, ranAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "advance scheduled interbank payment failed", "err", err, "id", id)
 		return apperr.Internal("advance scheduled interbank payment", err)
 	}
 	return nil
@@ -109,6 +124,7 @@ func (s *Store) AdvanceScheduledInterbankPayment(ctx context.Context, id string,
 func (s *Store) DeleteScheduledInterbankPayment(ctx context.Context, id string) error {
 	const q = `delete from "trading".scheduled_interbank_payments where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "delete scheduled interbank payment failed", "err", err, "id", id)
 		return apperr.Internal("delete scheduled interbank payment", err)
 	}
 	return nil

--- a/services/trading/internal/store/securities.go
+++ b/services/trading/internal/store/securities.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -63,6 +64,7 @@ func (s *Store) UpsertSecurity(ctx context.Context, in *domain.Security) (*domai
 		)
 		out, err := scanSecurity(row)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "insert security failed", "err", err)
 			return nil, apperr.Internal("insert security", err)
 		}
 		return out, nil
@@ -92,6 +94,7 @@ func (s *Store) UpsertSecurity(ctx context.Context, in *domain.Security) (*domai
 		if noRows(err) {
 			return nil, apperr.NotFound("security not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update security failed", "err", err)
 		return nil, apperr.Internal("update security", err)
 	}
 	return out, nil
@@ -105,6 +108,7 @@ func (s *Store) GetSecurity(ctx context.Context, id string) (*domain.Security, e
 		if noRows(err) {
 			return nil, apperr.NotFound("security not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get security failed", "err", err, "id", id)
 		return nil, apperr.Internal("get security", err)
 	}
 	return out, nil
@@ -119,6 +123,7 @@ func (s *Store) GetSecurityByTicker(ctx context.Context, ticker string, t domain
 		if noRows(err) {
 			return nil, apperr.NotFound("security not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get security by ticker failed", "err", err)
 		return nil, apperr.Internal("get security by ticker", err)
 	}
 	return out, nil
@@ -222,6 +227,7 @@ func (s *Store) ListSecurities(ctx context.Context, f SecurityFilter, page, page
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), "select count(*)"+fromJoin+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count securities failed", "err", err)
 		return nil, 0, apperr.Internal("count securities", err)
 	}
 
@@ -243,6 +249,7 @@ func (s *Store) ListSecurities(ctx context.Context, f SecurityFilter, page, page
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list securities failed", "err", err)
 		return nil, 0, apperr.Internal("list securities", err)
 	}
 	defer rows.Close()
@@ -251,11 +258,16 @@ func (s *Store) ListSecurities(ctx context.Context, f SecurityFilter, page, page
 	for rows.Next() {
 		sec, err := scanSecurity(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan security failed", "err", err)
 			return nil, 0, apperr.Internal("scan security", err)
 		}
 		out = append(out, sec)
 	}
-	return out, total, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list securities rows failed", "err", err)
+		return out, total, err
+	}
+	return out, total, nil
 }
 
 // ListOptionsForUnderlying returns every option whose underlying is
@@ -271,6 +283,7 @@ func (s *Store) ListOptionsForUnderlying(ctx context.Context, stockID string, se
 	q += ` order by settlement_date asc, strike_price asc, option_type asc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list options failed", "err", err, "stock_id", stockID)
 		return nil, apperr.Internal("list options", err)
 	}
 	defer rows.Close()
@@ -278,11 +291,16 @@ func (s *Store) ListOptionsForUnderlying(ctx context.Context, stockID string, se
 	for rows.Next() {
 		sec, err := scanSecurity(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan option failed", "err", err, "stock_id", stockID)
 			return nil, apperr.Internal("scan option", err)
 		}
 		out = append(out, sec)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list options for underlying rows failed", "err", err, "stock_id", stockID)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanSecurity(row pgx.Row) (*domain.Security, error) {

--- a/services/trading/internal/store/watchlist.go
+++ b/services/trading/internal/store/watchlist.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/trading/internal/domain"
 	"github.com/jackc/pgx/v5"
@@ -20,6 +21,7 @@ func (s *Store) CreateWatchlist(ctx context.Context, w *domain.Watchlist) (*doma
 	row := s.DB.QueryRow(ctx, q, w.UserID, string(w.UserKind), w.Name)
 	out, err := scanWatchlist(row)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert watchlist failed", "err", err)
 		return nil, apperr.Internal("insert watchlist", err)
 	}
 	return out, nil
@@ -33,6 +35,7 @@ func (s *Store) ListWatchlists(ctx context.Context, userID string) ([]*domain.Wa
 	      where user_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list watchlists failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list watchlists", err)
 	}
 	defer rows.Close()
@@ -40,11 +43,16 @@ func (s *Store) ListWatchlists(ctx context.Context, userID string) ([]*domain.Wa
 	for rows.Next() {
 		w, err := scanWatchlist(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan watchlist failed", "err", err, "user_id", userID)
 			return nil, apperr.Internal("scan watchlist", err)
 		}
 		out = append(out, w)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list watchlists rows failed", "err", err, "user_id", userID)
+		return out, err
+	}
+	return out, nil
 }
 
 // GetWatchlist returns one watchlist by id (without items). NotFound on
@@ -56,6 +64,7 @@ func (s *Store) GetWatchlist(ctx context.Context, id string) (*domain.Watchlist,
 		if noRows(err) {
 			return nil, apperr.NotFound("lista za praćenje nije pronađena")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get watchlist failed", "err", err, "id", id)
 		return nil, apperr.Internal("get watchlist", err)
 	}
 	return out, nil
@@ -65,6 +74,7 @@ func (s *Store) GetWatchlist(ctx context.Context, id string) (*domain.Watchlist,
 func (s *Store) DeleteWatchlist(ctx context.Context, id string) error {
 	const q = `delete from "trading".watchlists where id = $1`
 	if _, err := s.DB.Exec(ctx, q, id); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "delete watchlist failed", "err", err, "id", id)
 		return apperr.Internal("delete watchlist", err)
 	}
 	return nil
@@ -83,6 +93,7 @@ func (s *Store) AddItem(ctx context.Context, watchlistID, securityID string) (*d
 	var it domain.WatchlistItem
 	if err := s.DB.QueryRow(ctx, q, watchlistID, securityID).
 		Scan(&it.ID, &it.SecurityID, &it.CreatedAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "add watchlist item failed", "err", err, "watchlist_id", watchlistID, "security_id", securityID)
 		return nil, apperr.Internal("add watchlist item", err)
 	}
 	return &it, nil
@@ -93,6 +104,7 @@ func (s *Store) RemoveItem(ctx context.Context, watchlistID, securityID string) 
 	const q = `delete from "trading".watchlist_items
 	           where watchlist_id = $1 and security_id = $2`
 	if _, err := s.DB.Exec(ctx, q, watchlistID, securityID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "remove watchlist item failed", "err", err, "watchlist_id", watchlistID, "security_id", securityID)
 		return apperr.Internal("remove watchlist item", err)
 	}
 	return nil
@@ -106,6 +118,7 @@ func (s *Store) ListItems(ctx context.Context, watchlistID string) ([]*domain.Wa
 	           where watchlist_id = $1 order by created_at desc`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, watchlistID)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list watchlist items failed", "err", err, "watchlist_id", watchlistID)
 		return nil, apperr.Internal("list watchlist items", err)
 	}
 	defer rows.Close()
@@ -113,11 +126,16 @@ func (s *Store) ListItems(ctx context.Context, watchlistID string) ([]*domain.Wa
 	for rows.Next() {
 		var it domain.WatchlistItem
 		if err := rows.Scan(&it.ID, &it.SecurityID, &it.CreatedAt); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan watchlist item failed", "err", err, "watchlist_id", watchlistID)
 			return nil, apperr.Internal("scan watchlist item", err)
 		}
 		out = append(out, &it)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list items rows failed", "err", err, "watchlist_id", watchlistID)
+		return out, err
+	}
+	return out, nil
 }
 
 func scanWatchlist(row pgx.Row) (*domain.Watchlist, error) {

--- a/services/user/internal/app/app.go
+++ b/services/user/internal/app/app.go
@@ -32,15 +32,23 @@ import (
 // Run blocks until the process is signalled to terminate.
 func Run() error {
 	log := logger.New("user")
+	// Make logger.From(ctx) fall back to the JSON logger in frames that
+	// don't carry an injected logger (store, server helpers).
+	slog.SetDefault(log)
 
 	ctx, cancel := shutdown.Context()
 	defer cancel()
 
 	prov, err := otelinit.Init(ctx, "user")
 	if err != nil {
+		log.ErrorContext(ctx, "otel init failed", "err", err)
 		return fmt.Errorf("otelinit: %w", err)
 	}
-	defer func() { _ = prov.Shutdown(context.Background()) }()
+	defer func() {
+		if err := prov.Shutdown(context.Background()); err != nil {
+			log.Warn("otel shutdown failed", "err", err)
+		}
+	}()
 
 	// OpenPair dials the primary (DATABASE_URL → banka-pg-pooler-rw) and,
 	// when set, a hot-standby read pool (DATABASE_READ_URL →
@@ -48,6 +56,7 @@ func Run() error {
 	// the standby; writes and transactions stay on the primary.
 	db, err := postgres.OpenPair(ctx, config.MustString("DATABASE_URL"), config.String("DATABASE_READ_URL", ""))
 	if err != nil {
+		log.ErrorContext(ctx, "postgres connect failed", "err", err)
 		return fmt.Errorf("postgres: %w", err)
 	}
 	defer db.Close()
@@ -57,6 +66,7 @@ func Run() error {
 
 	rdb, err := pkgredis.Open(ctx, config.MustString("REDIS_ADDR"), config.String("REDIS_PASSWORD", ""))
 	if err != nil {
+		log.ErrorContext(ctx, "redis connect failed", "err", err)
 		return fmt.Errorf("redis: %w", err)
 	}
 	defer rdb.Close()
@@ -88,6 +98,7 @@ func Run() error {
 			grpc.WithStatsHandler(prov.GRPCClientHandler()),
 		)
 		if err != nil {
+			log.ErrorContext(ctx, "dial trading failed", "err", err, "addr", tradingAddr)
 			return fmt.Errorf("dial trading: %w", err)
 		}
 		defer conn.Close()
@@ -120,6 +131,7 @@ func Run() error {
 	log.Info("user service ready", "grpc", grpcAddr)
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		log.Error("user service exited", "err", err)
 		return err
 	}
 	return nil
@@ -133,6 +145,7 @@ func buildNotifier(ctx context.Context, log *slog.Logger) (service.Notifier, fun
 	if addr := config.String("NOTIFICATION_GRPC_ADDR", ""); addr != "" {
 		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
+			log.ErrorContext(ctx, "dial notification failed", "err", err, "addr", addr)
 			return nil, func() {}, fmt.Errorf("dial notification: %w", err)
 		}
 		return &notifClientAdapter{c: notifpb.NewNotificationServiceClient(conn), origin: "user"},

--- a/services/user/internal/service/activation.go
+++ b/services/user/internal/service/activation.go
@@ -25,11 +25,17 @@ func (s *Service) ActivateAccount(ctx context.Context, token, newPassword string
 	hash := tokens.Hash(token)
 	employeeID, err := s.Store.LookupActivationToken(ctx, hash)
 	if err != nil {
+		// Used/expired tokens and query errors are logged by the store;
+		// an unknown token value is only classified here.
+		if isNotFound(err) {
+			s.Log.WarnContext(ctx, "activation rejected: unknown token")
+		}
 		return err
 	}
 
 	pwHash, err := passwords.Hash(newPassword)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "password hash failed", "err", err, "employee_id", employeeID)
 		return apperr.Internal("hash password", err)
 	}
 	if err := s.Store.SetEmployeePasswordHash(ctx, employeeID, pwHash); err != nil {
@@ -38,16 +44,17 @@ func (s *Service) ActivateAccount(ctx context.Context, token, newPassword string
 	if err := s.Store.MarkActivationTokenUsed(ctx, hash); err != nil {
 		return err
 	}
+	s.Log.InfoContext(ctx, "account activated", "employee_id", employeeID)
 
 	emp, err := s.Store.GetEmployeeByID(ctx, employeeID)
 	if err != nil {
 		// Activation already succeeded; failing the confirmation email
 		// shouldn't roll it back. Log and move on.
-		s.Log.Warn("activation confirmation: load employee", "employee_id", employeeID, "error", err)
+		s.Log.WarnContext(ctx, "activation confirmation: load employee failed", "err", err, "employee_id", employeeID)
 		return nil
 	}
 	if err := s.sendActivationConfirmation(ctx, emp); err != nil {
-		s.Log.Warn("activation confirmation email failed", "employee_id", employeeID, "error", err)
+		s.Log.WarnContext(ctx, "activation confirmation email failed", "err", err, "employee_id", employeeID)
 	}
 	return nil
 }
@@ -74,12 +81,17 @@ func (s *Service) ResendActivation(ctx context.Context, employeeID string) error
 		return err
 	}
 	if emp.Activated() {
+		s.Log.WarnContext(ctx, "resend activation rejected: already activated", "employee_id", employeeID)
 		return apperr.FailedPrecondition("nalog je već aktiviran")
 	}
 	if err := s.Store.InvalidateActivationTokens(ctx, employeeID); err != nil {
 		return err
 	}
-	return s.sendActivationEmail(ctx, emp)
+	if err := s.sendActivationEmail(ctx, emp); err != nil {
+		s.Log.ErrorContext(ctx, "activation email send failed", "err", err, "employee_id", employeeID)
+		return err
+	}
+	return nil
 }
 
 // RequestPasswordReset emails a reset link if the email belongs to a
@@ -100,7 +112,7 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) error 
 
 	if emp, err := s.Store.GetEmployeeByEmail(ctx, email); err == nil {
 		if serr := s.sendResetEmail(ctx, domain.KindEmployee, emp.ID, emp.Email, emp.FirstName); serr != nil {
-			s.Log.Warn("password reset email failed", "user_kind", "employee", "user_id", emp.ID, "error", serr)
+			s.Log.WarnContext(ctx, "password reset email failed", "err", serr, "user_kind", "employee", "user_id", emp.ID)
 		}
 		return nil
 	} else if !isNotFound(err) {
@@ -108,13 +120,15 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) error 
 	}
 	if cl, err := s.Store.GetClientByEmail(ctx, email); err == nil {
 		if serr := s.sendResetEmail(ctx, domain.KindClient, cl.ID, cl.Email, cl.FirstName); serr != nil {
-			s.Log.Warn("password reset email failed", "user_kind", "client", "user_id", cl.ID, "error", serr)
+			s.Log.WarnContext(ctx, "password reset email failed", "err", serr, "user_kind", "client", "user_id", cl.ID)
 		}
 		return nil
 	} else if !isNotFound(err) {
 		return err
 	}
-	// Unknown email — silently succeed.
+	// Unknown email — silently succeed toward the caller; logged as a
+	// probe signal.
+	s.Log.WarnContext(ctx, "password reset requested for unknown email", "email", email)
 	return nil
 }
 
@@ -130,11 +144,17 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 	hash := tokens.Hash(token)
 	kind, userID, err := s.Store.LookupPasswordResetToken(ctx, hash)
 	if err != nil {
+		// Used/expired tokens and query errors are logged by the store;
+		// an unknown token value is only classified here.
+		if isNotFound(err) {
+			s.Log.WarnContext(ctx, "password reset rejected: unknown token")
+		}
 		return err
 	}
 
 	pwHash, err := passwords.Hash(newPassword)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "password hash failed", "err", err, "user_id", userID, "kind", kind)
 		return apperr.Internal("hash password", err)
 	}
 
@@ -148,6 +168,7 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 			return err
 		}
 	default:
+		s.Log.ErrorContext(ctx, "password reset failed: unknown user kind", "user_id", userID, "kind", kind)
 		return apperr.Internal("unknown user kind", nil)
 	}
 
@@ -159,8 +180,9 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 	}
 	// Resetting the password clears any brute-force lockout (S10).
 	if err := s.Store.ResetFailedLogin(ctx, kind, userID); err != nil {
-		s.Log.Warn("reset failed login on password reset failed", "user_kind", string(kind), "user_id", userID, "error", err)
+		s.Log.WarnContext(ctx, "reset failed login on password reset failed", "err", err, "user_kind", string(kind), "user_id", userID)
 	}
+	s.Log.InfoContext(ctx, "password reset completed", "user_id", userID, "kind", kind)
 	return nil
 }
 
@@ -173,6 +195,7 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 func (s *Service) sendInitialPasswordEmail(ctx context.Context, kind domain.UserKind, userID, email, firstName string) error {
 	plaintext, hash, err := tokens.Generate(32)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "initial-password token generate failed", "err", err, "user_id", userID, "kind", kind)
 		return err
 	}
 	if err := s.Store.CreatePasswordResetToken(ctx, kind, userID, hash, s.Clock.Now().Add(s.Cfg.ResetTTL)); err != nil {
@@ -192,6 +215,7 @@ func (s *Service) sendInitialPasswordEmail(ctx context.Context, kind domain.User
 func (s *Service) sendResetEmail(ctx context.Context, kind domain.UserKind, userID, email, firstName string) error {
 	plaintext, hash, err := tokens.Generate(32)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "reset token generate failed", "err", err, "user_id", userID, "kind", kind)
 		return err
 	}
 	if err := s.Store.CreatePasswordResetToken(ctx, kind, userID, hash, s.Clock.Now().Add(s.Cfg.ResetTTL)); err != nil {

--- a/services/user/internal/service/audit.go
+++ b/services/user/internal/service/audit.go
@@ -16,7 +16,7 @@ import (
 func (s *Service) recordAudit(ctx context.Context, action, targetID, targetLabel, oldVal, newVal, note string) {
 	p, ok := auth.PrincipalFrom(ctx)
 	if !ok {
-		s.Log.Warn("audit skipped: no principal", "action", action)
+		s.Log.WarnContext(ctx, "audit skipped: no principal", "action", action, "target_id", targetID)
 		return
 	}
 	if err := s.Store.InsertAudit(ctx, &domain.AuditEntry{
@@ -30,7 +30,9 @@ func (s *Service) recordAudit(ctx context.Context, action, targetID, targetLabel
 		NewValue:    newVal,
 		Note:        note,
 	}); err != nil {
-		s.Log.Warn("audit insert failed", "action", action, "error", err)
+		// Swallowed by design: a failed audit write must not fail the
+		// business operation that triggered it.
+		s.Log.WarnContext(ctx, "audit insert failed", "err", err, "action", action, "target_id", targetID)
 	}
 }
 
@@ -44,6 +46,11 @@ func (s *Service) resolveActorName(ctx context.Context, userID, kind string) str
 	}
 	e, err := s.Store.GetEmployeeByID(ctx, userID)
 	if err != nil || e == nil {
+		if err != nil && !isNotFound(err) {
+			// Swallowed by design: the audit row still lands without a
+			// display name. The store already logged the query error.
+			s.Log.WarnContext(ctx, "resolve actor name failed", "err", err, "user_id", userID)
+		}
 		return ""
 	}
 	return strings.TrimSpace(e.FirstName + " " + e.LastName)
@@ -93,5 +100,6 @@ func (s *Service) requireAuditReader(ctx context.Context) error {
 		permissions.Has(p.Permissions, permissions.ActuarySupervisor) {
 		return nil
 	}
+	s.Log.WarnContext(ctx, "audit read denied", "user_id", p.UserID, "kind", p.UserKind)
 	return apperr.PermissionDenied("nedovoljne permisije")
 }

--- a/services/user/internal/service/auth.go
+++ b/services/user/internal/service/auth.go
@@ -94,6 +94,7 @@ func (s *Service) Login(ctx context.Context, email, password string, opts ...Log
 	// Email not in the system: return the same "Neispravni kredencijali"
 	// the wrong-password path uses. See the doc comment above for why we
 	// don't surface "Korisnik ne postoji" anymore.
+	s.Log.WarnContext(ctx, "login rejected: unknown email", "email", email)
 	return nil, apperr.Unauthenticated("Neispravni kredencijali")
 }
 
@@ -122,18 +123,30 @@ func (s *Service) completeLogin(
 	// Brute-force lockout (S7–S8): refuse a still-locked account before
 	// even checking the password.
 	if lockedUntil != nil && lockedUntil.After(s.Clock.Now()) {
+		s.Log.WarnContext(ctx, "login rejected: account locked", "user_id", userID, "kind", kind)
 		return nil, apperr.PermissionDenied("Nalog je privremeno zaključan zbog previše neuspešnih pokušaja. Pokušajte ponovo kasnije.")
 	}
 	ok, err := passwords.Verify(password, passwordHash)
 	if err != nil || !ok {
+		if err != nil {
+			// A verify error (malformed stored hash) is conflated with
+			// "wrong password" toward the caller; surface it for ops.
+			s.Log.ErrorContext(ctx, "password verify failed", "err", err, "user_id", userID, "kind", kind)
+		}
 		s.Log.WarnContext(ctx, "login rejected: bad password", "user_id", userID, "kind", kind)
 		// Wrong password: bump the counter and lock once the threshold
 		// is reached (S7–S8).
-		newCount, _ := s.Store.IncrementFailedLogin(ctx, kind, userID)
+		newCount, cerr := s.Store.IncrementFailedLogin(ctx, kind, userID)
+		if cerr != nil {
+			// Swallowed by design: a broken counter must not mask the
+			// auth failure. The store already logged the query error.
+			s.Log.WarnContext(ctx, "failed-login counter not bumped", "err", cerr, "user_id", userID, "kind", kind)
+		}
 		if newCount >= maxFailedLogins {
 			if lerr := s.Store.LockUser(ctx, kind, userID, s.Clock.Now().Add(lockoutDuration)); lerr != nil {
-				s.Log.Warn("lock user failed", "user_kind", string(kind), "user_id", userID, "error", lerr)
+				s.Log.WarnContext(ctx, "lock user failed", "err", lerr, "user_kind", string(kind), "user_id", userID)
 			}
+			s.Log.WarnContext(ctx, "account locked after repeated failed logins", "user_id", userID, "kind", kind)
 			s.sendLockoutEmail(ctx, email, firstName)
 			return nil, apperr.PermissionDenied("Nalog je zaključan zbog previše neuspešnih pokušaja prijave. Proverite email za uputstvo o resetovanju lozinke.")
 		}
@@ -142,7 +155,7 @@ func (s *Service) completeLogin(
 	// Successful login clears any accumulated failures / lock (S9, S11).
 	if failedAttempts > 0 || lockedUntil != nil {
 		if rerr := s.Store.ResetFailedLogin(ctx, kind, userID); rerr != nil {
-			s.Log.Warn("reset failed login failed", "user_kind", string(kind), "user_id", userID, "error", rerr)
+			s.Log.WarnContext(ctx, "reset failed login failed", "err", rerr, "user_kind", string(kind), "user_id", userID)
 		}
 	}
 	r, err := s.issueTokens(ctx, kind, userID, perms, sessionVersion, longLived)
@@ -151,6 +164,7 @@ func (s *Service) completeLogin(
 	}
 	r.FirstName = firstName
 	r.LastName = lastName
+	s.Log.InfoContext(ctx, "login ok", "user_id", userID, "kind", kind, "long_lived", longLived)
 	return r, nil
 }
 
@@ -163,11 +177,13 @@ func (s *Service) issueTokens(ctx context.Context, kind domain.UserKind, userID 
 		SessionVersion: sv,
 	}, s.Cfg.JWTSigningKey, s.Cfg.AccessTTL)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "access token sign failed", "err", err, "user_id", userID, "kind", kind)
 		return nil, apperr.Internal("sign access", err)
 	}
 
 	refreshPlain, refreshHash, err := tokens.Generate(32)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "refresh token generate failed", "err", err, "user_id", userID, "kind", kind)
 		return nil, apperr.Internal("generate refresh", err)
 	}
 	// Mobile (spec p.84 "no session interval") gets the long-lived
@@ -209,7 +225,7 @@ func (s *Service) sendLockoutEmail(ctx context.Context, to, firstName string) {
 		"lozinku i kontaktirate podršku.\n\n" +
 		"– Banka 3"
 	if err := s.Notifier.Send(ctx, to, subject, body, false); err != nil {
-		s.Log.Warn("lockout email failed", "to", to, "error", err)
+		s.Log.WarnContext(ctx, "lockout email failed", "err", err, "to", to)
 	}
 }
 
@@ -217,11 +233,15 @@ func (s *Service) sendLockoutEmail(ctx context.Context, to, firstName string) {
 // immediately on use; if it's already revoked or expired we reject.
 func (s *Service) Refresh(ctx context.Context, refreshPlain string, opts ...LoginOption) (*LoginResult, error) {
 	if refreshPlain == "" {
+		s.Log.WarnContext(ctx, "refresh rejected: missing token")
 		return nil, apperr.Unauthenticated("missing refresh token")
 	}
 	hash := tokens.Hash(refreshPlain)
 	kind, userID, err := s.Store.LookupRefreshToken(ctx, hash)
 	if err != nil {
+		if isUnauthenticated(err) {
+			s.Log.WarnContext(ctx, "refresh rejected: invalid or expired token")
+		}
 		return nil, err
 	}
 	// Look up current permissions and session_version (they may have
@@ -231,13 +251,19 @@ func (s *Service) Refresh(ctx context.Context, refreshPlain string, opts ...Logi
 		return nil, err
 	}
 	if !active {
+		s.Log.WarnContext(ctx, "refresh rejected: account disabled", "user_id", userID, "kind", kind)
 		return nil, apperr.PermissionDenied("nalog je deaktiviran")
 	}
 	// Rotate: revoke old, issue new.
 	if err := s.Store.RevokeRefreshToken(ctx, hash); err != nil {
 		return nil, err
 	}
-	return s.issueTokens(ctx, kind, userID, perms, sv, resolveOpts(opts).longLived)
+	r, err := s.issueTokens(ctx, kind, userID, perms, sv, resolveOpts(opts).longLived)
+	if err != nil {
+		return nil, err
+	}
+	s.Log.InfoContext(ctx, "refresh ok", "user_id", userID, "kind", kind)
+	return r, nil
 }
 
 // Logout revokes one refresh token. Idempotent.
@@ -245,7 +271,15 @@ func (s *Service) Logout(ctx context.Context, refreshPlain string) error {
 	if refreshPlain == "" {
 		return nil
 	}
-	return s.Store.RevokeRefreshToken(ctx, tokens.Hash(refreshPlain))
+	if err := s.Store.RevokeRefreshToken(ctx, tokens.Hash(refreshPlain)); err != nil {
+		return err
+	}
+	if p, ok := auth.PrincipalFrom(ctx); ok {
+		s.Log.InfoContext(ctx, "logout ok", "user_id", p.UserID, "kind", p.UserKind)
+	} else {
+		s.Log.InfoContext(ctx, "logout ok")
+	}
+	return nil
 }
 
 // MeResult is the authenticated user's view of itself. Exactly one of
@@ -276,6 +310,7 @@ func (s *Service) Me(ctx context.Context) (*MeResult, error) {
 		}
 		return &MeResult{Client: c}, nil
 	default:
+		s.Log.ErrorContext(ctx, "me failed: unknown user kind", "user_id", p.UserID, "kind", p.UserKind)
 		return nil, apperr.Internal("unknown user kind", nil)
 	}
 }
@@ -295,6 +330,7 @@ func (s *Service) lookupAuthState(ctx context.Context, kind domain.UserKind, use
 		}
 		return c.Permissions, c.SessionVersion, c.Active, nil
 	}
+	s.Log.ErrorContext(ctx, "auth state lookup failed: unknown user kind", "user_id", userID, "kind", kind)
 	return nil, 0, false, apperr.Internal("unknown user kind", nil)
 }
 
@@ -329,4 +365,12 @@ func isNotFound(err error) bool {
 		return false
 	}
 	return ae.Kind == apperr.KindNotFound
+}
+
+func isUnauthenticated(err error) bool {
+	var ae *apperr.Error
+	if !errors.As(err, &ae) {
+		return false
+	}
+	return ae.Kind == apperr.KindUnauthenticated
 }

--- a/services/user/internal/service/client.go
+++ b/services/user/internal/service/client.go
@@ -58,10 +58,12 @@ func (s *Service) CreateClient(ctx context.Context, in CreateClientInput) (*doma
 		return nil, err
 	}
 
+	s.Log.InfoContext(ctx, "client created", "client_id", c.ID, "email", c.Email)
+
 	if err := s.sendInitialPasswordEmail(ctx, domain.KindClient, c.ID, c.Email, c.FirstName); err != nil {
 		// Don't roll back — the employee portal can resend by triggering
 		// the regular reset flow. Logged for ops visibility.
-		s.Log.Error("send initial-password email failed", "client_id", c.ID, "error", err)
+		s.Log.ErrorContext(ctx, "send initial-password email failed", "err", err, "client_id", c.ID)
 	}
 
 	return c, nil

--- a/services/user/internal/service/employee.go
+++ b/services/user/internal/service/employee.go
@@ -76,9 +76,11 @@ func (s *Service) CreateEmployee(ctx context.Context, in CreateEmployeeInput) (*
 		return nil, err
 	}
 
+	s.Log.InfoContext(ctx, "employee created", "employee_id", emp.ID, "email", emp.Email)
+
 	if err := s.sendActivationEmail(ctx, emp); err != nil {
 		// Don't roll back the employee — admin can resend manually.
-		s.Log.Error("send activation email failed", "employee_id", emp.ID, "error", err)
+		s.Log.ErrorContext(ctx, "send activation email failed", "err", err, "employee_id", emp.ID)
 	}
 
 	s.recordAudit(ctx, "employee.create", emp.ID,
@@ -148,11 +150,11 @@ func (s *Service) UpdateEmployee(ctx context.Context, in UpdateEmployeeInput) (*
 		// goes — and the old one too so the previous account holder sees
 		// the swap.
 		if err := s.sendProfileChangeEmail(ctx, updated, changes); err != nil {
-			s.Log.Warn("profile change email failed", "employee_id", updated.ID, "error", err)
+			s.Log.WarnContext(ctx, "profile change email failed", "err", err, "employee_id", updated.ID)
 		}
 		if before.Email != updated.Email {
 			if err := s.sendProfileChangeEmailTo(ctx, before.Email, updated.FirstName, changes); err != nil {
-				s.Log.Warn("profile change email (old address) failed", "employee_id", updated.ID, "error", err)
+				s.Log.WarnContext(ctx, "profile change email (old address) failed", "err", err, "employee_id", updated.ID)
 			}
 		}
 	}
@@ -187,13 +189,14 @@ func (s *Service) SetEmployeeActive(ctx context.Context, id string, active bool)
 	}
 	if !active {
 		if _, err := s.Store.IncrementEmployeeSessionVersion(ctx, id); err != nil {
-			s.Log.Error("bump session version failed", "employee_id", id, "error", err)
+			s.Log.ErrorContext(ctx, "bump session version failed", "err", err, "employee_id", id)
 		}
 		if err := s.Store.RevokeAllRefreshTokens(ctx, domain.KindEmployee, id); err != nil {
-			s.Log.Error("revoke refresh tokens failed", "employee_id", id, "error", err)
+			s.Log.ErrorContext(ctx, "revoke refresh tokens failed", "err", err, "employee_id", id)
 		}
 		s.invalidateSessionCache(ctx, domain.KindEmployee, id)
 	}
+	s.Log.InfoContext(ctx, "employee active set", "employee_id", id, "active", active)
 	return updated, nil
 }
 
@@ -236,6 +239,7 @@ func (s *Service) SetEmployeePermissions(ctx context.Context, id string, perms [
 		}
 		n, err := s.FundReassigner.Reassign(ctx, id, caller.UserID)
 		if err != nil {
+			s.Log.ErrorContext(ctx, "supervisor fund reassign failed", "err", err, "from_user_id", id, "to_user_id", caller.UserID)
 			return nil, apperr.Internal("reassign supervisor assets", err)
 		}
 		if n > 0 && s.Notifier != nil && target.Email != "" {
@@ -245,11 +249,11 @@ func (s *Service) SetEmployeePermissions(ctx context.Context, id string, perms [
 				"upravljanje Vašim postojećim fondovima je preneto na drugog supervizora.\n\n" +
 				"Banka 3"
 			if err := s.Notifier.Send(ctx, target.Email, subject, body, false); err != nil {
-				s.Log.Warn("send handover email failed", "to", target.Email, "err", err.Error())
+				s.Log.WarnContext(ctx, "send handover email failed", "err", err, "to", target.Email)
 			}
 		}
 	} else if losingFundsManager && s.FundReassigner == nil {
-		s.Log.Warn("funds.manage.supervisor revoked but FundReassigner not wired — funds may be orphaned",
+		s.Log.WarnContext(ctx, "funds.manage.supervisor revoked but FundReassigner not wired — funds may be orphaned",
 			"user_id", id)
 	}
 	updated, err := s.Store.SetEmployeePermissions(ctx, id, perms)
@@ -261,6 +265,7 @@ func (s *Service) SetEmployeePermissions(ctx context.Context, id string, perms [
 		strings.Join(target.Permissions, ", "), strings.Join(perms, ", "),
 		"Izmena permisija")
 	s.invalidateSessionCache(ctx, domain.KindEmployee, id)
+	s.Log.InfoContext(ctx, "employee permissions updated", "employee_id", id)
 	return updated, nil
 }
 
@@ -273,7 +278,7 @@ func (s *Service) invalidateSessionCache(ctx context.Context, kind domain.UserKi
 		return
 	}
 	if err := s.Redis.Del(ctx, "usv:"+string(kind)+":"+id).Err(); err != nil {
-		s.Log.Warn("invalidate session cache", "user_id", id, "error", err)
+		s.Log.ErrorContext(ctx, "invalidate session cache failed", "err", err, "user_id", id, "kind", kind)
 	}
 }
 
@@ -287,6 +292,7 @@ func (s *Service) guardSelf(ctx context.Context, targetID, action string) error 
 		return apperr.Unauthenticated("not authenticated")
 	}
 	if p.UserID == targetID {
+		s.Log.WarnContext(ctx, "self-edit rejected", "user_id", p.UserID, "action", action)
 		return apperr.PermissionDenied("ne možete promeniti " + action + " sopstvenog naloga")
 	}
 	return nil
@@ -305,6 +311,7 @@ func (s *Service) guardAdminOnAdmin(ctx context.Context, target *domain.Employee
 	if p.UserID == target.ID {
 		return nil
 	}
+	s.Log.WarnContext(ctx, "admin-on-admin edit rejected", "user_id", p.UserID, "target_id", target.ID)
 	return apperr.PermissionDenied("admin nije ovlašćen da menja drugog admina")
 }
 
@@ -316,6 +323,7 @@ func (s *Service) requirePermission(ctx context.Context, perm string) error {
 	if permissions.Has(p.Permissions, perm) || permissions.Has(p.Permissions, permissions.Admin) {
 		return nil
 	}
+	s.Log.WarnContext(ctx, "permission denied", "user_id", p.UserID, "kind", p.UserKind, "required", perm)
 	return apperr.PermissionDenied("nedovoljne permisije")
 }
 
@@ -440,6 +448,7 @@ func (s *Service) sendProfileChangeEmailTo(ctx context.Context, to, firstName st
 func (s *Service) sendActivationEmail(ctx context.Context, e *domain.Employee) error {
 	plaintext, hash, err := tokens.Generate(32)
 	if err != nil {
+		s.Log.ErrorContext(ctx, "activation token generate failed", "err", err, "employee_id", e.ID)
 		return err
 	}
 	if err := s.Store.CreateActivationToken(ctx, e.ID, hash, s.Clock.Now().Add(s.Cfg.ActivationTTL)); err != nil {

--- a/services/user/internal/service/session_version.go
+++ b/services/user/internal/service/session_version.go
@@ -24,5 +24,6 @@ func (s *Service) GetSessionVersion(ctx context.Context, kind domain.UserKind, u
 		}
 		return c.SessionVersion, nil
 	}
+	s.Log.ErrorContext(ctx, "session version lookup failed: unknown user kind", "user_id", userID, "kind", kind)
 	return 0, apperr.Internal("unknown user kind", nil)
 }

--- a/services/user/internal/store/audit.go
+++ b/services/user/internal/store/audit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
@@ -33,6 +34,7 @@ func (s *Store) InsertAudit(ctx context.Context, e *domain.AuditEntry) error {
 		e.Action, e.ActorID, e.ActorKind, e.ActorName,
 		e.TargetID, e.TargetLabel, e.OldValue, e.NewValue, e.Note,
 	); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "insert audit failed", "err", err, "action", e.Action, "actor_id", e.ActorID)
 		return apperr.Internal("insert audit", err)
 	}
 	return nil
@@ -70,6 +72,7 @@ func (s *Store) ListAudit(ctx context.Context, f domain.AuditFilter, limit, offs
 	if err := s.DB.QueryRow(postgres.WithRead(ctx),
 		`select count(*) from "user".audit_log`+where, args...,
 	).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count audit failed", "err", err)
 		return nil, 0, apperr.Internal("count audit", err)
 	}
 
@@ -78,6 +81,7 @@ func (s *Store) ListAudit(ctx context.Context, f domain.AuditFilter, limit, offs
 		fmt.Sprintf(" order by created_at desc limit $%d offset $%d", len(args)-1, len(args))
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, args...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list audit failed", "err", err)
 		return nil, 0, apperr.Internal("list audit", err)
 	}
 	defer rows.Close()
@@ -85,9 +89,13 @@ func (s *Store) ListAudit(ctx context.Context, f domain.AuditFilter, limit, offs
 	for rows.Next() {
 		e, err := scanAudit(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan audit failed", "err", err)
 			return nil, 0, apperr.Internal("scan audit", err)
 		}
 		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "rows audit failed", "err", err)
 	}
 	return out, total, rows.Err()
 }

--- a/services/user/internal/store/clients.go
+++ b/services/user/internal/store/clients.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
@@ -53,6 +54,7 @@ func (s *Store) CreateClient(ctx context.Context, c *domain.Client) (*domain.Cli
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("an account with this email already exists")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create client failed", "err", err, "email", c.Email)
 		return nil, apperr.Internal("create client", err)
 	}
 	return out, nil
@@ -66,6 +68,7 @@ func (s *Store) GetClientByID(ctx context.Context, id string) (*domain.Client, e
 		if noRows(err) {
 			return nil, apperr.NotFound("client not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get client failed", "err", err, "client_id", id)
 		return nil, apperr.Internal("get client", err)
 	}
 	return out, nil
@@ -79,6 +82,7 @@ func (s *Store) GetClientByEmail(ctx context.Context, email string) (*domain.Cli
 		if noRows(err) {
 			return nil, apperr.NotFound("client not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get client by email failed", "err", err, "email", email)
 		return nil, apperr.Internal("get client by email", err)
 	}
 	return out, nil
@@ -105,6 +109,7 @@ func (s *Store) UpdateClientProfile(ctx context.Context, c *domain.Client) (*dom
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("email already in use")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update client failed", "err", err, "client_id", c.ID)
 		return nil, apperr.Internal("update client", err)
 	}
 	return out, nil
@@ -117,6 +122,7 @@ func (s *Store) SetClientPasswordHash(ctx context.Context, id, hash string) erro
         where id = $1`
 	tag, err := s.DB.Exec(ctx, q, id, hash)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set client password failed", "err", err, "client_id", id)
 		return apperr.Internal("set client password", err)
 	}
 	if tag.RowsAffected() == 0 {
@@ -136,6 +142,7 @@ func (s *Store) IncrementClientSessionVersion(ctx context.Context, id string) (i
 		if noRows(err) {
 			return 0, apperr.NotFound("client not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "bump client session version failed", "err", err, "client_id", id)
 		return 0, apperr.Internal("bump client session version", err)
 	}
 	return v, nil
@@ -172,6 +179,7 @@ func (s *Store) ListClients(ctx context.Context, f domain.ClientFilter, page, pa
 
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), `select count(*) from "user".clients`+where, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count clients failed", "err", err)
 		return nil, 0, apperr.Internal("count clients", err)
 	}
 
@@ -182,6 +190,7 @@ func (s *Store) ListClients(ctx context.Context, f domain.ClientFilter, page, pa
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list clients failed", "err", err)
 		return nil, 0, apperr.Internal("list clients", err)
 	}
 	defer rows.Close()
@@ -190,11 +199,13 @@ func (s *Store) ListClients(ctx context.Context, f domain.ClientFilter, page, pa
 	for rows.Next() {
 		c, err := scanClient(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan client failed", "err", err)
 			return nil, 0, apperr.Internal("scan client", err)
 		}
 		out = append(out, c)
 	}
 	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "rows clients failed", "err", err)
 		return nil, 0, apperr.Internal("rows clients", err)
 	}
 	return out, total, nil

--- a/services/user/internal/store/employees.go
+++ b/services/user/internal/store/employees.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
@@ -52,6 +53,7 @@ func (s *Store) CreateEmployee(ctx context.Context, e *domain.Employee) (*domain
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("an account with this email or username already exists")
 		}
+		logger.From(ctx).ErrorContext(ctx, "create employee failed", "err", err, "email", e.Email)
 		return nil, apperr.Internal("create employee", err)
 	}
 	return out, nil
@@ -65,6 +67,7 @@ func (s *Store) GetEmployeeByID(ctx context.Context, id string) (*domain.Employe
 		if noRows(err) {
 			return nil, apperr.NotFound("employee not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get employee failed", "err", err, "employee_id", id)
 		return nil, apperr.Internal("get employee", err)
 	}
 	return out, nil
@@ -78,6 +81,7 @@ func (s *Store) GetEmployeeByEmail(ctx context.Context, email string) (*domain.E
 		if noRows(err) {
 			return nil, apperr.NotFound("employee not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "get employee by email failed", "err", err, "email", email)
 		return nil, apperr.Internal("get employee by email", err)
 	}
 	return out, nil
@@ -107,6 +111,7 @@ func (s *Store) UpdateEmployeeProfile(ctx context.Context, e *domain.Employee) (
 		if isUniqueViolation(err) {
 			return nil, apperr.Conflict("email or username already in use")
 		}
+		logger.From(ctx).ErrorContext(ctx, "update employee failed", "err", err, "employee_id", e.ID)
 		return nil, apperr.Internal("update employee", err)
 	}
 	return out, nil
@@ -120,6 +125,7 @@ func (s *Store) SetEmployeePasswordHash(ctx context.Context, id, hash string) er
         where id = $1`
 	tag, err := s.DB.Exec(ctx, q, id, hash)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "set employee password failed", "err", err, "employee_id", id)
 		return apperr.Internal("set password", err)
 	}
 	if tag.RowsAffected() == 0 {
@@ -141,6 +147,7 @@ func (s *Store) SetEmployeeActive(ctx context.Context, id string, active bool) (
 		if noRows(err) {
 			return nil, apperr.NotFound("employee not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set employee active failed", "err", err, "employee_id", id, "active", active)
 		return nil, apperr.Internal("set active", err)
 	}
 	return out, nil
@@ -161,6 +168,7 @@ func (s *Store) SetEmployeePermissions(ctx context.Context, id string, perms []s
 		if noRows(err) {
 			return nil, apperr.NotFound("employee not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "set employee permissions failed", "err", err, "employee_id", id)
 		return nil, apperr.Internal("set permissions", err)
 	}
 	return out, nil
@@ -178,6 +186,7 @@ func (s *Store) IncrementEmployeeSessionVersion(ctx context.Context, id string) 
 		if noRows(err) {
 			return 0, apperr.NotFound("employee not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "bump employee session version failed", "err", err, "employee_id", id)
 		return 0, apperr.Internal("bump session version", err)
 	}
 	return v, nil
@@ -219,6 +228,7 @@ func (s *Store) ListEmployees(ctx context.Context, f domain.EmployeeFilter, page
 	countQ := `select count(*) from "user".employees` + where
 	var total int64
 	if err := s.DB.QueryRow(postgres.WithRead(ctx), countQ, args...).Scan(&total); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "count employees failed", "err", err)
 		return nil, 0, apperr.Internal("count employees", err)
 	}
 
@@ -229,6 +239,7 @@ func (s *Store) ListEmployees(ctx context.Context, f domain.EmployeeFilter, page
 
 	rows, err := s.DB.Query(postgres.WithRead(ctx), listQ, listArgs...)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list employees failed", "err", err)
 		return nil, 0, apperr.Internal("list employees", err)
 	}
 	defer rows.Close()
@@ -237,11 +248,13 @@ func (s *Store) ListEmployees(ctx context.Context, f domain.EmployeeFilter, page
 	for rows.Next() {
 		e, err := scanEmployee(rows)
 		if err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan employee failed", "err", err)
 			return nil, 0, apperr.Internal("scan employee", err)
 		}
 		out = append(out, e)
 	}
 	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "rows employees failed", "err", err)
 		return nil, 0, apperr.Internal("rows employees", err)
 	}
 	return out, total, nil

--- a/services/user/internal/store/login_security.go
+++ b/services/user/internal/store/login_security.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
 
@@ -28,6 +29,7 @@ func tableForKind(kind domain.UserKind) (string, error) {
 func (s *Store) IncrementFailedLogin(ctx context.Context, kind domain.UserKind, userID string) (int, error) {
 	tbl, err := tableForKind(kind)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "increment failed login: unknown user kind", "err", err, "user_id", userID, "kind", string(kind))
 		return 0, err
 	}
 	q := `update "user".` + tbl + `
@@ -36,6 +38,7 @@ func (s *Store) IncrementFailedLogin(ctx context.Context, kind domain.UserKind, 
         returning failed_login_attempts`
 	var n int
 	if err := s.DB.QueryRow(ctx, q, userID).Scan(&n); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "increment failed login failed", "err", err, "user_id", userID, "kind", string(kind))
 		return 0, apperr.Internal("increment failed login", err)
 	}
 	return n, nil
@@ -46,12 +49,14 @@ func (s *Store) IncrementFailedLogin(ctx context.Context, kind domain.UserKind, 
 func (s *Store) ResetFailedLogin(ctx context.Context, kind domain.UserKind, userID string) error {
 	tbl, err := tableForKind(kind)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset failed login: unknown user kind", "err", err, "user_id", userID, "kind", string(kind))
 		return err
 	}
 	q := `update "user".` + tbl + `
         set failed_login_attempts = 0, locked_until = null, updated_at = now()
         where id = $1`
 	if _, err := s.DB.Exec(ctx, q, userID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "reset failed login failed", "err", err, "user_id", userID, "kind", string(kind))
 		return apperr.Internal("reset failed login", err)
 	}
 	return nil
@@ -61,12 +66,14 @@ func (s *Store) ResetFailedLogin(ctx context.Context, kind domain.UserKind, user
 func (s *Store) LockUser(ctx context.Context, kind domain.UserKind, userID string, until time.Time) error {
 	tbl, err := tableForKind(kind)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "lock user: unknown user kind", "err", err, "user_id", userID, "kind", string(kind))
 		return err
 	}
 	q := `update "user".` + tbl + `
         set locked_until = $2, updated_at = now()
         where id = $1`
 	if _, err := s.DB.Exec(ctx, q, userID, until); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "lock user failed", "err", err, "user_id", userID, "kind", string(kind))
 		return apperr.Internal("lock user", err)
 	}
 	return nil

--- a/services/user/internal/store/tokens.go
+++ b/services/user/internal/store/tokens.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
 
@@ -18,6 +19,7 @@ func (s *Store) CreateRefreshToken(ctx context.Context, kind domain.UserKind, us
         insert into "user".refresh_tokens (user_id, user_kind, token_hash, expires_at)
         values ($1, $2, $3, $4)`
 	if _, err := s.DB.Exec(ctx, q, userID, string(kind), hash, expiresAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create refresh token failed", "err", err, "user_id", userID, "kind", string(kind))
 		return apperr.Internal("create refresh token", err)
 	}
 	return nil
@@ -34,6 +36,7 @@ func (s *Store) LookupRefreshToken(ctx context.Context, hash string) (domain.Use
 		if noRows(err) {
 			return "", "", apperr.Unauthenticated("invalid or expired refresh token")
 		}
+		logger.From(ctx).ErrorContext(ctx, "lookup refresh token failed", "err", err)
 		return "", "", apperr.Internal("lookup refresh", err)
 	}
 	return domain.UserKind(kind), userID, nil
@@ -43,6 +46,7 @@ func (s *Store) LookupRefreshToken(ctx context.Context, hash string) (domain.Use
 func (s *Store) RevokeRefreshToken(ctx context.Context, hash string) error {
 	const q = `update "user".refresh_tokens set revoked_at = now() where token_hash = $1`
 	if _, err := s.DB.Exec(ctx, q, hash); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "revoke refresh token failed", "err", err)
 		return apperr.Internal("revoke refresh", err)
 	}
 	return nil
@@ -55,6 +59,7 @@ func (s *Store) RevokeAllRefreshTokens(ctx context.Context, kind domain.UserKind
         update "user".refresh_tokens set revoked_at = now()
         where user_kind = $1 and user_id = $2 and revoked_at is null`
 	if _, err := s.DB.Exec(ctx, q, string(kind), userID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "revoke all refresh tokens failed", "err", err, "user_id", userID, "kind", string(kind))
 		return apperr.Internal("revoke all refresh", err)
 	}
 	return nil
@@ -69,6 +74,7 @@ func (s *Store) CreateActivationToken(ctx context.Context, employeeID, hash stri
         insert into "user".activation_tokens (employee_id, token_hash, expires_at)
         values ($1, $2, $3)`
 	if _, err := s.DB.Exec(ctx, q, employeeID, hash, expiresAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create activation token failed", "err", err, "employee_id", employeeID)
 		return apperr.Internal("create activation", err)
 	}
 	return nil
@@ -91,6 +97,7 @@ func (s *Store) LookupActivationToken(ctx context.Context, hash string) (string,
 		if noRows(err) {
 			return "", apperr.NotFound("activation token not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "lookup activation token failed", "err", err)
 		return "", apperr.Internal("lookup activation", err)
 	}
 	usedAtV = usedAt
@@ -98,9 +105,11 @@ func (s *Store) LookupActivationToken(ctx context.Context, hash string) (string,
 		expiresAtV = *expiresAt
 	}
 	if usedAtV != nil {
+		logger.From(ctx).WarnContext(ctx, "activation token already used", "employee_id", employeeID)
 		return "", apperr.FailedPrecondition("activation link already used")
 	}
 	if time.Now().After(expiresAtV) {
+		logger.From(ctx).WarnContext(ctx, "activation token expired", "employee_id", employeeID)
 		return "", apperr.FailedPrecondition("activation link has expired")
 	}
 	return employeeID, nil
@@ -110,6 +119,7 @@ func (s *Store) LookupActivationToken(ctx context.Context, hash string) (string,
 func (s *Store) MarkActivationTokenUsed(ctx context.Context, hash string) error {
 	const q = `update "user".activation_tokens set used_at = now() where token_hash = $1`
 	if _, err := s.DB.Exec(ctx, q, hash); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark activation token used failed", "err", err)
 		return apperr.Internal("mark activation used", err)
 	}
 	return nil
@@ -122,6 +132,7 @@ func (s *Store) InvalidateActivationTokens(ctx context.Context, employeeID strin
         update "user".activation_tokens set used_at = now()
         where employee_id = $1 and used_at is null`
 	if _, err := s.DB.Exec(ctx, q, employeeID); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "invalidate activation tokens failed", "err", err, "employee_id", employeeID)
 		return apperr.Internal("invalidate activation", err)
 	}
 	return nil
@@ -136,6 +147,7 @@ func (s *Store) CreatePasswordResetToken(ctx context.Context, kind domain.UserKi
         insert into "user".password_reset_tokens (user_id, user_kind, token_hash, expires_at)
         values ($1, $2, $3, $4)`
 	if _, err := s.DB.Exec(ctx, q, userID, string(kind), hash, expiresAt); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "create reset token failed", "err", err, "user_id", userID, "kind", string(kind))
 		return apperr.Internal("create reset", err)
 	}
 	return nil
@@ -154,12 +166,15 @@ func (s *Store) LookupPasswordResetToken(ctx context.Context, hash string) (doma
 		if noRows(err) {
 			return "", "", apperr.NotFound("reset token not found")
 		}
+		logger.From(ctx).ErrorContext(ctx, "lookup reset token failed", "err", err)
 		return "", "", apperr.Internal("lookup reset", err)
 	}
 	if usedAt != nil {
+		logger.From(ctx).WarnContext(ctx, "reset token already used", "user_id", userID, "kind", kind)
 		return "", "", apperr.FailedPrecondition("reset link already used")
 	}
 	if time.Now().After(expiresAt) {
+		logger.From(ctx).WarnContext(ctx, "reset token expired", "user_id", userID, "kind", kind)
 		return "", "", apperr.FailedPrecondition("reset link has expired")
 	}
 	return domain.UserKind(kind), userID, nil
@@ -168,6 +183,7 @@ func (s *Store) LookupPasswordResetToken(ctx context.Context, hash string) (doma
 func (s *Store) MarkPasswordResetTokenUsed(ctx context.Context, hash string) error {
 	const q = `update "user".password_reset_tokens set used_at = now() where token_hash = $1`
 	if _, err := s.DB.Exec(ctx, q, hash); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "mark reset token used failed", "err", err)
 		return apperr.Internal("mark reset used", err)
 	}
 	return nil

--- a/services/user/internal/store/verification.go
+++ b/services/user/internal/store/verification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/apperr"
+	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/logger"
 	"github.com/RAF-SI-2025/Banka-3-Backend/pkg/postgres"
 	"github.com/RAF-SI-2025/Banka-3-Backend/services/user/internal/domain"
 )
@@ -22,6 +23,7 @@ func (s *Store) RecordVerificationEvent(ctx context.Context, id, userID, actionK
         values ($1, $2, $3)
         on conflict (id) do nothing`
 	if _, err := s.DB.Exec(ctx, q, id, userID, actionKind); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "record verification event failed", "err", err, "event_id", id, "user_id", userID)
 		return apperr.Internal("record verification event", err)
 	}
 	return nil
@@ -42,6 +44,7 @@ func (s *Store) ResolveVerificationEvent(ctx context.Context, id string, success
            set status = $2, resolved_at = now()
          where id = $1 and status = 'pending'`
 	if _, err := s.DB.Exec(ctx, q, id, status); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "resolve verification event failed", "err", err, "event_id", id)
 		return apperr.Internal("resolve verification event", err)
 	}
 	return nil
@@ -58,6 +61,7 @@ func (s *Store) ListVerificationEvents(ctx context.Context, userID string, limit
          limit $2`
 	rows, err := s.DB.Query(postgres.WithRead(ctx), q, userID, limit)
 	if err != nil {
+		logger.From(ctx).ErrorContext(ctx, "list verification events failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("list verification events", err)
 	}
 	defer rows.Close()
@@ -68,11 +72,13 @@ func (s *Store) ListVerificationEvents(ctx context.Context, userID string, limit
 		if err := rows.Scan(
 			&e.ID, &e.UserID, &e.ActionKind, &e.Status, &e.CreatedAt, &e.ResolvedAt,
 		); err != nil {
+			logger.From(ctx).ErrorContext(ctx, "scan verification event failed", "err", err, "user_id", userID)
 			return nil, apperr.Internal("scan verification event", err)
 		}
 		out = append(out, e)
 	}
 	if err := rows.Err(); err != nil {
+		logger.From(ctx).ErrorContext(ctx, "rows verification events failed", "err", err, "user_id", userID)
 		return nil, apperr.Internal("rows verification events", err)
 	}
 	return out, nil

--- a/tools/mock-partner/.gitignore
+++ b/tools/mock-partner/.gitignore
@@ -1,0 +1,1 @@
+mock-partner

--- a/tools/mock-partner/main.go
+++ b/tools/mock-partner/main.go
@@ -148,24 +148,39 @@ func main() {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	log.Printf("mock-partner listening on :%s as bank_code=%s", port, bankCode)
-	srv := &http.Server{Addr: ":" + port, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	srv := &http.Server{Addr: ":" + port, Handler: logRequests(mux), ReadHeaderTimeout: 5 * time.Second}
 	if err := srv.ListenAndServe(); err != nil {
-		log.Fatal(err)
+		log.Fatalf("mock-partner listen failed on :%s: %v", port, err)
 	}
 }
 
-func (s *state) handlePublic(w http.ResponseWriter, _ *http.Request) {
+// logRequests logs every inbound request's method + path (healthz
+// probes excluded) so interop sessions are debuggable from the mock's
+// stdout alone; handlers add the per-route decision lines.
+func logRequests(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			log.Printf("inbound request: method=%s path=%s remote=%s", r.Method, r.URL.Path, r.RemoteAddr)
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+func (s *state) handlePublic(w http.ResponseWriter, r *http.Request) {
+	log.Printf("public feed served: items=%d remote=%s", len(s.holdings), r.RemoteAddr)
 	writeJSON(w, http.StatusOK, map[string]any{"items": s.holdings})
 }
 
 func (s *state) handleOffer(w http.ResponseWriter, r *http.Request) {
 	var in offerRequest
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		log.Printf("offer rejected: invalid JSON: %v (remote=%s)", err, r.RemoteAddr)
 		writeJSON(w, http.StatusBadRequest, map[string]any{"code": 400, "message": "invalid JSON"})
 		return
 	}
 	// Validate seller_holding_id matches our seed.
 	if in.SellerHoldingID != "mock-holding-aapl-50" {
+		log.Printf("offer rejected: unknown holding=%s sender=%s thread=%s", in.SellerHoldingID, in.SenderBankCode, in.SenderThreadID)
 		writeJSON(w, http.StatusNotFound, map[string]any{"code": 404, "message": "unknown holding"})
 		return
 	}
@@ -195,6 +210,7 @@ func (s *state) handleOffer(w http.ResponseWriter, r *http.Request) {
 func (s *state) handleCounter(w http.ResponseWriter, r *http.Request) {
 	var in counterRequest
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		log.Printf("counter rejected: invalid JSON: %v (remote=%s)", err, r.RemoteAddr)
 		writeJSON(w, http.StatusBadRequest, map[string]any{"code": 400, "message": "invalid JSON"})
 		return
 	}
@@ -203,10 +219,12 @@ func (s *state) handleCounter(w http.ResponseWriter, r *http.Request) {
 	defer s.mu.Unlock()
 	t, ok := s.threads[threadID]
 	if !ok {
+		log.Printf("counter rejected: thread not found thread=%s sender=%s", threadID, in.SenderBankCode)
 		writeJSON(w, http.StatusNotFound, map[string]any{"code": 404, "message": "thread not found"})
 		return
 	}
 	if t.Status != "open" {
+		log.Printf("counter rejected: thread not open thread=%s status=%s sender=%s", threadID, t.Status, in.SenderBankCode)
 		writeJSON(w, http.StatusConflict, map[string]any{"code": 409, "message": "thread not open"})
 		return
 	}
@@ -222,16 +240,20 @@ func (s *state) handleCounter(w http.ResponseWriter, r *http.Request) {
 func (s *state) handleAction(target string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var in actionRequest
-		_ = json.NewDecoder(r.Body).Decode(&in)
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			log.Printf("%s body ignored: invalid JSON: %v (remote=%s)", target, err, r.RemoteAddr)
+		}
 		threadID := r.PathValue("thread_id")
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		t, ok := s.threads[threadID]
 		if !ok {
+			log.Printf("%s rejected: thread not found thread=%s sender=%s", target, threadID, in.SenderBankCode)
 			writeJSON(w, http.StatusNotFound, map[string]any{"code": 404, "message": "thread not found"})
 			return
 		}
 		if t.Status != "open" {
+			log.Printf("%s rejected: thread not open thread=%s status=%s sender=%s", target, threadID, t.Status, in.SenderBankCode)
 			writeJSON(w, http.StatusConflict, map[string]any{"code": 409, "message": "thread not open"})
 			return
 		}
@@ -251,6 +273,7 @@ func guard(apiKey string, h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		got := []byte(r.Header.Get("X-Api-Key"))
 		if subtle.ConstantTimeCompare(got, expected) != 1 {
+			log.Printf("request rejected: invalid X-Api-Key method=%s path=%s remote=%s", r.Method, r.URL.Path, r.RemoteAddr)
 			writeJSON(w, http.StatusUnauthorized, map[string]any{"code": 401, "message": "invalid X-Api-Key"})
 			return
 		}


### PR DESCRIPTION
## What

Exhaustive structured-log sweep so production failures are diagnosable from Loki alone: every error path now logs the error detail plus business identifiers, significant state changes log at Info, and expected client-class failures log at Warn. ~1,400 new log statements across all six services, the gateway, and `pkg/`. Logging additions only — no behavior, signature, or error-value changes.

## Why

Production incidents currently dead-end at lines like `msg=grpc code=Internal` / `msg=http status=500` with zero cause (see the recurring `/api/v1/otc/external-discovery` 500s). The central gRPC interceptor wasn't logging the error message at all.

## Highlights

- **Central gRPC interceptor** (`pkg/grpcserver`): failed RPCs now carry the `err` message; client-class codes (NotFound, InvalidArgument, …) log at Warn instead of Info. This alone explains the external-discovery 500s going forward.
- **OTC/interbank (heaviest coverage)**: outbound access log for every partner HTTP call (method/url/status/dur + 512B response-body snippet on rejection), protocol-probe failure reasons, a loud warning when a partner gets stuck cached as `ProtocolUnknown` until restart, discovery sweep summaries, 2PC prepare/commit/rollback at Info/Error with transaction ids, Banka-2 NO votes logged with the partner's reasons, every saga step/compensation failure.
- **Gateway**: HTTP access log attaches the upstream error envelope on 4xx/5xx (auth routes excluded as defense-in-depth); partner route rejections log which check failed (api key present, signature, timestamp skew) without ever logging key/signature values.
- **Stores**: every non-`ErrNoRows` query error logs the operation + ids. **Services**: errors log where they originate/classify, with op-specific context; successful state changes (payment executed, contract minted, order filled, login ok) log at Info.
- **Silent-default fixes**: a dozen sites converted errors into default values with no error surviving to any boundary — fund valuation counting FX amounts *unconverted* on a failed quote, withdraw liquidation skipping holdings on a DB blip, stop/limit orders never triggering on unparseable stored prices, OTC settlement quantity silently parsing to 0. All now log.
- **Leak prevention**: AlphaVantage transport errors are stripped of the URL before logging/returning (the query string embeds the API key); `INTERBANK_ROUTES` parse warnings no longer echo raw values.

## Notes for review

- One internal failure can now emit a log line per layer (store → service → interceptor → gateway). Intentional per the "cover everything" brief — each layer adds ids the others lack. If it proves noisy, the store layer (~487 sites) is the candidate to drop.
- Scheduler per-tick "job triggered/completed" went to Debug (5s-tick jobs were ~50k Info lines/day).
- An accidentally committed `mock-partner` binary was removed and gitignored.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` pass for all 8 modules (pkg + 7 services) via the nix dev shell. Three independent adversarial review passes (coverage gaps, log quality, secret leakage) ran over the diff; all findings fixed in the second commit.